### PR TITLE
fix: eliminate dual rendering and fix mobile layout in system hierarchy

### DIFF
--- a/src/hooks/use-mobile.ts
+++ b/src/hooks/use-mobile.ts
@@ -3,7 +3,9 @@ import * as React from 'react'
 const MOBILE_BREAKPOINT = 768
 
 export function useIsMobile() {
-    const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+    const [isMobile, setIsMobile] = React.useState(
+        typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false,
+    )
 
     React.useEffect(() => {
         const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)

--- a/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
+++ b/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
@@ -1,6 +1,18 @@
+import { ChevronDown, Info } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
+import { useState } from 'react'
+import { useIntl } from 'react-intl'
 
+import { Button } from '@/components/ui/button'
+import {
+    Collapsible,
+    CollapsibleContent,
+    CollapsibleTrigger,
+} from '@/components/ui/collapsible'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+import { useIsMobile } from '@/hooks/use-mobile'
+import { message } from '@/i18n/src/messages'
 
 interface HierarchyLayoutProps {
     tree: ReactNode
@@ -9,17 +21,57 @@ interface HierarchyLayoutProps {
 }
 
 export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middle, sidebar }) => {
-    return (
-        <div className="h-[calc(100vh)] flex overflow-hidden">
-            {/* Mobile: stacked layout */}
-            <div className="md:hidden flex flex-col h-full w-full">
-                {tree}
-                {middle}
-            </div>
+    const isMobile = useIsMobile()
+    const [treeOpen, setTreeOpen] = useState(false)
+    const { formatMessage: fm } = useIntl()
 
-            {/* Desktop: resizable tree + content */}
-            <ResizablePanelGroup orientation="horizontal" className="hidden md:flex">
-                {/* Left panel - System Tree (resizable) */}
+    if (isMobile) {
+        return (
+            <div className="h-dvh flex flex-col overflow-hidden">
+                <Collapsible open={treeOpen} onOpenChange={setTreeOpen}>
+                    <CollapsibleTrigger asChild>
+                        <button className="flex w-full items-center justify-between border-b border-border px-3 py-2 text-sm font-semibold hover:bg-muted/50">
+                            {fm({ id: message.systemHierarchy.tree.title })}
+                            <ChevronDown
+                                className={`size-4 transition-transform ${treeOpen ? 'rotate-180' : ''}`}
+                            />
+                        </button>
+                    </CollapsibleTrigger>
+                    <CollapsibleContent className="max-h-[50vh] overflow-y-auto border-b border-border">
+                        {tree}
+                    </CollapsibleContent>
+                </Collapsible>
+
+                <div className="flex-1 flex flex-col min-h-0 overflow-hidden">{middle}</div>
+
+                {sidebar && (
+                    <Sheet>
+                        <SheetTrigger asChild>
+                            <Button
+                                variant="outline"
+                                size="icon"
+                                className="fixed bottom-4 right-4 z-40 rounded-full shadow-lg"
+                            >
+                                <Info className="size-4" />
+                            </Button>
+                        </SheetTrigger>
+                        <SheetContent side="right" size="m">
+                            <SheetHeader>
+                                <SheetTitle>
+                                    {fm({ id: message.systemHierarchy.sidebar.title })}
+                                </SheetTitle>
+                            </SheetHeader>
+                            {sidebar}
+                        </SheetContent>
+                    </Sheet>
+                )}
+            </div>
+        )
+    }
+
+    return (
+        <div className="h-dvh flex overflow-hidden">
+            <ResizablePanelGroup orientation="horizontal">
                 <ResizablePanel
                     defaultSize="25%"
                     minSize="15%"
@@ -31,7 +83,6 @@ export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middl
 
                 <ResizableHandle withHandle />
 
-                {/* Middle panel - Content + Sidebar */}
                 <ResizablePanel
                     defaultSize="75%"
                     minSize="50%"

--- a/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
+++ b/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, Info } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Button } from '@/components/ui/button'
@@ -10,7 +10,7 @@ import {
     CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
+import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { message } from '@/i18n/src/messages'
 
@@ -22,20 +22,31 @@ interface HierarchyLayoutProps {
 
 export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middle, sidebar }) => {
     const isMobile = useIsMobile()
+    const [hasMounted, setHasMounted] = useState(false)
     const [treeOpen, setTreeOpen] = useState(false)
     const { formatMessage: fm } = useIntl()
+
+    useEffect(() => {
+        setHasMounted(true)
+    }, [])
+
+    if (!hasMounted) return null
 
     if (isMobile) {
         return (
             <div className="h-dvh flex flex-col overflow-hidden">
                 <Collapsible open={treeOpen} onOpenChange={setTreeOpen}>
                     <CollapsibleTrigger asChild>
-                        <button className="flex w-full items-center justify-between border-b border-border px-3 py-2 text-sm font-semibold hover:bg-muted/50">
+                        <Button
+                            type="button"
+                            variant="ghost"
+                            className="flex w-full justify-between rounded-none border-b border-border px-3 py-2 text-sm font-semibold"
+                        >
                             {fm({ id: message.systemHierarchy.tree.title })}
                             <ChevronDown
                                 className={`size-4 transition-transform ${treeOpen ? 'rotate-180' : ''}`}
                             />
-                        </button>
+                        </Button>
                     </CollapsibleTrigger>
                     <CollapsibleContent className="max-h-[50vh] overflow-y-auto border-b border-border">
                         {tree}
@@ -51,16 +62,12 @@ export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middl
                                 variant="outline"
                                 size="icon"
                                 className="fixed bottom-4 right-4 z-40 rounded-full shadow-lg"
+                                aria-label={fm({ id: message.systemHierarchy.sidebar.title })}
                             >
                                 <Info className="size-4" />
                             </Button>
                         </SheetTrigger>
                         <SheetContent side="right" size="m">
-                            <SheetHeader>
-                                <SheetTitle>
-                                    {fm({ id: message.systemHierarchy.sidebar.title })}
-                                </SheetTitle>
-                            </SheetHeader>
                             {sidebar}
                         </SheetContent>
                     </Sheet>

--- a/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
+++ b/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/collapsible'
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable'
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
+import { SidebarTrigger } from '@/components/ui/sidebar'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { message } from '@/i18n/src/messages'
 import { cn } from '@/lib/utils'
@@ -55,18 +56,25 @@ export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middl
         return (
             <div className="h-dvh flex flex-col overflow-hidden">
                 <Collapsible open={treeOpen} onOpenChange={setTreeOpen}>
-                    <CollapsibleTrigger asChild>
-                        <Button
-                            type="button"
-                            variant="ghost"
-                            className="flex w-full justify-between rounded-none border-b border-border px-3 py-2 text-sm font-semibold"
-                        >
-                            {fm({ id: message.systemHierarchy.tree.title })}
-                            <ChevronDown
-                                className={cn('size-4 transition-transform', treeOpen && 'rotate-180')}
-                            />
-                        </Button>
-                    </CollapsibleTrigger>
+                    <div className="flex items-center gap-1 border-b border-border px-2 py-1.5">
+                        <SidebarTrigger />
+                        <CollapsibleTrigger asChild>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="flex-1 justify-between text-sm font-semibold"
+                            >
+                                {fm({ id: message.systemHierarchy.tree.title })}
+                                <ChevronDown
+                                    className={cn(
+                                        'size-4 transition-transform',
+                                        treeOpen && 'rotate-180',
+                                    )}
+                                />
+                            </Button>
+                        </CollapsibleTrigger>
+                    </div>
                     <CollapsibleContent className="max-h-[50vh] overflow-y-auto border-b border-border">
                         {tree}
                     </CollapsibleContent>

--- a/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
+++ b/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
@@ -75,7 +75,13 @@ export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middl
                             </Button>
                         </CollapsibleTrigger>
                     </div>
-                    <CollapsibleContent className="max-h-[50vh] overflow-y-auto border-b border-border">
+                    <CollapsibleContent
+                        forceMount
+                        className={cn(
+                            'max-h-[50vh] overflow-y-auto border-b border-border',
+                            !treeOpen && 'hidden',
+                        )}
+                    >
                         {tree}
                     </CollapsibleContent>
                 </Collapsible>

--- a/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
+++ b/src/modules/systemHierarchy/components/layout/HierarchyLayout.comp.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown, Info } from 'lucide-react'
 import type { FC, ReactNode } from 'react'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Button } from '@/components/ui/button'
@@ -13,6 +13,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/componen
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet'
 import { useIsMobile } from '@/hooks/use-mobile'
 import { message } from '@/i18n/src/messages'
+import { cn } from '@/lib/utils'
 
 interface HierarchyLayoutProps {
     tree: ReactNode
@@ -20,17 +21,35 @@ interface HierarchyLayoutProps {
     sidebar?: ReactNode
 }
 
+const SidebarSheet: FC<{ sidebar: ReactNode; className?: string; label: string }> = ({
+    sidebar,
+    className,
+    label,
+}) => (
+    <Sheet>
+        <SheetTrigger asChild>
+            <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className={cn('fixed bottom-4 right-4 z-40 rounded-full shadow-lg', className)}
+                aria-label={label}
+            >
+                <Info className="size-4" />
+            </Button>
+        </SheetTrigger>
+        <SheetContent side="right" size="m">
+            {sidebar}
+        </SheetContent>
+    </Sheet>
+)
+
 export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middle, sidebar }) => {
     const isMobile = useIsMobile()
-    const [hasMounted, setHasMounted] = useState(false)
     const [treeOpen, setTreeOpen] = useState(false)
     const { formatMessage: fm } = useIntl()
 
-    useEffect(() => {
-        setHasMounted(true)
-    }, [])
-
-    if (!hasMounted) return null
+    const sidebarLabel = fm({ id: message.systemHierarchy.sidebar.title })
 
     if (isMobile) {
         return (
@@ -44,7 +63,7 @@ export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middl
                         >
                             {fm({ id: message.systemHierarchy.tree.title })}
                             <ChevronDown
-                                className={`size-4 transition-transform ${treeOpen ? 'rotate-180' : ''}`}
+                                className={cn('size-4 transition-transform', treeOpen && 'rotate-180')}
                             />
                         </Button>
                     </CollapsibleTrigger>
@@ -55,23 +74,7 @@ export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middl
 
                 <div className="flex-1 flex flex-col min-h-0 overflow-hidden">{middle}</div>
 
-                {sidebar && (
-                    <Sheet>
-                        <SheetTrigger asChild>
-                            <Button
-                                variant="outline"
-                                size="icon"
-                                className="fixed bottom-4 right-4 z-40 rounded-full shadow-lg"
-                                aria-label={fm({ id: message.systemHierarchy.sidebar.title })}
-                            >
-                                <Info className="size-4" />
-                            </Button>
-                        </SheetTrigger>
-                        <SheetContent side="right" size="m">
-                            {sidebar}
-                        </SheetContent>
-                    </Sheet>
-                )}
+                {sidebar && <SidebarSheet sidebar={sidebar} label={sidebarLabel} />}
             </div>
         )
     }
@@ -97,9 +100,16 @@ export const HierarchyLayoutComponent: FC<HierarchyLayoutProps> = ({ tree, middl
                 >
                     <div className="flex-1 flex flex-col overflow-hidden">{middle}</div>
                     {sidebar && (
-                        <aside className="hidden lg:flex flex-col w-80 border-l border-border bg-background overflow-hidden shrink-0">
-                            {sidebar}
-                        </aside>
+                        <>
+                            <aside className="hidden lg:flex flex-col w-80 border-l border-border bg-background overflow-hidden shrink-0">
+                                {sidebar}
+                            </aside>
+                            <SidebarSheet
+                                sidebar={sidebar}
+                                className="lg:hidden"
+                                label={sidebarLabel}
+                            />
+                        </>
                     )}
                 </ResizablePanel>
             </ResizablePanelGroup>

--- a/src/modules/systemHierarchy/components/tree/SystemTree.cont.tsx
+++ b/src/modules/systemHierarchy/components/tree/SystemTree.cont.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl'
 
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { SidebarTrigger } from '@/components/ui/sidebar'
 import { message } from '@/i18n/src/messages'
 
 import { useSystemHierarchy } from '../../hooks/queries/useSystemHierarchy'
@@ -54,9 +55,12 @@ export const SystemTreeContainer: FC = () => {
         <div className="flex flex-col h-full" data-testid="system-hierarchy-tree-panel">
             <div className="flex flex-col gap-2 border-b border-border px-3 py-2">
                 <div className="flex items-center justify-between">
-                    <h2 className="text-sm font-semibold">
-                        {fm({ id: message.systemHierarchy.tree.title })}
-                    </h2>
+                    <div className="flex items-center gap-2">
+                        <SidebarTrigger className="hidden md:flex" />
+                        <h2 className="text-sm font-semibold">
+                            {fm({ id: message.systemHierarchy.tree.title })}
+                        </h2>
+                    </div>
                     <Button
                         variant="ghost"
                         size="sm"


### PR DESCRIPTION
## Summary
- Replace CSS-hidden dual layout (`md:hidden` + `hidden md:flex`) with conditional rendering via `useIsMobile()` — components mount only once instead of twice
- Mobile tree: collapsible accordion (collapsed by default, max 50vh when open)
- Mobile sidebar: accessible via floating button → right-side Sheet
- Fix `h-[calc(100vh)]` → `h-dvh` for proper mobile browser chrome handling

## Test plan
- [x] Desktop (≥768px): resizable panels + sidebar at lg+ unchanged
- [x] Mobile (<768px): tree collapses/expands, middle fills space, info FAB opens sidebar sheet
- [x] Network tab: verify API calls fire once (not doubled)
- [x] Tree search, copy/paste, leaf selection work on both layouts