### PR TITLE
feat: hierarchy leaves filtering, search & column visibility

### DIFF
--- a/src/hooks/useQueryManager.ts
+++ b/src/hooks/useQueryManager.ts
@@ -27,6 +27,7 @@ export default function useQueryManager(
     )
 
     const [searchQuery] = useQueryState('search')
+    const [filterQuery] = useQueryState('filter')
     const [pageQuery] = useQueryState('page')
     const [pageSizeQuery] = useQueryState('pageSize')
 
@@ -60,11 +61,13 @@ export default function useQueryManager(
 
     const search = instances[tableId]?.search || searchQuery || ''
 
-    //columnFilter merge with categoryFilter
-    const columnFilter = useMemo(
-        () => JSON.stringify((instances[tableId]?.columnFilter || []).concat(categoryFilter || [])),
-        [instances, tableId, categoryFilter],
-    )
+    //columnFilter merge with categoryFilter, fallback to URL params
+    const columnFilter = useMemo(() => {
+        const storeFilters = instances[tableId]?.columnFilter || []
+        const urlFilters = storeFilters.length === 0 && filterQuery ? JSON.parse(filterQuery) : []
+        const filters = storeFilters.length > 0 ? storeFilters : urlFilters
+        return JSON.stringify(filters.concat(categoryFilter || []))
+    }, [instances, tableId, categoryFilter, filterQuery])
     const custom = useMemo(() => instances[tableId]?.custom || {}, [instances, tableId])
 
     const query = useMemo(

--- a/src/hooks/useQueryManager.ts
+++ b/src/hooks/useQueryManager.ts
@@ -64,7 +64,15 @@ export default function useQueryManager(
     //columnFilter merge with categoryFilter, fallback to URL params
     const columnFilter = useMemo(() => {
         const storeFilters = instances[tableId]?.columnFilter || []
-        const urlFilters = storeFilters.length === 0 && filterQuery ? JSON.parse(filterQuery) : []
+        let urlFilters: any[] = []
+        if (storeFilters.length === 0 && filterQuery) {
+            try {
+                const parsed = JSON.parse(filterQuery)
+                urlFilters = Array.isArray(parsed) ? parsed : []
+            } catch {
+                urlFilters = []
+            }
+        }
         const filters = storeFilters.length > 0 ? storeFilters : urlFilters
         return JSON.stringify(filters.concat(categoryFilter || []))
     }, [instances, tableId, categoryFilter, filterQuery])

--- a/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
+++ b/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
@@ -1,0 +1,63 @@
+import type { Table } from '@tanstack/react-table'
+import { SlidersHorizontal } from 'lucide-react'
+import type { FC } from 'react'
+
+import { Button } from '@/components/ui/button'
+import {
+    DropdownMenu,
+    DropdownMenuCheckboxItem,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+
+interface ColumnVisibilityDropdownProps {
+    table: Table<any>
+    excludeColumns?: string[]
+}
+
+export const ColumnVisibilityDropdown: FC<ColumnVisibilityDropdownProps> = ({
+    table,
+    excludeColumns = [],
+}) => {
+    const columns = table
+        .getAllLeafColumns()
+        .filter(column => !excludeColumns.includes(column.id))
+
+    return (
+        <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    data-testid="column-visibility-trigger"
+                >
+                    <SlidersHorizontal className="h-4 w-4" />
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuLabel>Columns</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuCheckboxItem
+                    checked={table.getIsAllColumnsVisible()}
+                    onCheckedChange={table.getToggleAllColumnsVisibilityHandler()}
+                >
+                    Toggle All
+                </DropdownMenuCheckboxItem>
+                <DropdownMenuSeparator />
+                {columns.map(column => (
+                    <DropdownMenuCheckboxItem
+                        key={column.id}
+                        checked={column.getIsVisible()}
+                        onCheckedChange={value => column.toggleVisibility(!!value)}
+                    >
+                        {typeof column.columnDef.header === 'string'
+                            ? column.columnDef.header || column.id
+                            : column.id}
+                    </DropdownMenuCheckboxItem>
+                ))}
+            </DropdownMenuContent>
+        </DropdownMenu>
+    )
+}

--- a/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
+++ b/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
@@ -41,7 +41,9 @@ export const ColumnVisibilityDropdown: FC<ColumnVisibilityDropdownProps> = ({
                 <DropdownMenuSeparator />
                 <DropdownMenuCheckboxItem
                     checked={table.getIsAllColumnsVisible()}
-                    onCheckedChange={table.getToggleAllColumnsVisibilityHandler()}
+                    onCheckedChange={checked =>
+                        table.getToggleAllColumnsVisibilityHandler()({ target: { checked } })
+                    }
                 >
                     Toggle All
                 </DropdownMenuCheckboxItem>

--- a/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.test.tsx
+++ b/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import React from 'react'
+
+import { ColumnVisibilityDropdown } from '../ColumnVisibilityDropdown.comp'
+
+const createMockColumn = (id: string, header: string, isVisible = true) => ({
+    id,
+    columnDef: { header },
+    getIsVisible: jest.fn(() => isVisible),
+    toggleVisibility: jest.fn(),
+})
+
+const createMockTable = (columns: ReturnType<typeof createMockColumn>[]) => ({
+    getAllLeafColumns: jest.fn(() => columns),
+    getIsAllColumnsVisible: jest.fn(() => true),
+    getToggleAllColumnsVisibilityHandler: jest.fn(() => jest.fn()),
+})
+
+// Radix DropdownMenu renders content in a portal, need to query the whole document
+const getDropdownContent = () => document.querySelector('[role="menu"]')
+
+describe('ColumnVisibilityDropdown', () => {
+    it('renders trigger button', () => {
+        const table = createMockTable([])
+        render(<ColumnVisibilityDropdown table={table as any} />)
+        expect(screen.getByTestId('column-visibility-trigger')).toBeInTheDocument()
+    })
+
+    it('shows column items when opened', async () => {
+        const columns = [
+            createMockColumn('name', 'Name'),
+            createMockColumn('code', 'System Code'),
+        ]
+        const table = createMockTable(columns)
+
+        render(<ColumnVisibilityDropdown table={table as any} />)
+        fireEvent.click(screen.getByTestId('column-visibility-trigger'))
+
+        const menu = getDropdownContent()
+        if (menu) {
+            const container = within(menu as HTMLElement)
+            expect(container.getByText('Columns')).toBeInTheDocument()
+            expect(container.getByText('Toggle All')).toBeInTheDocument()
+            expect(container.getByText('Name')).toBeInTheDocument()
+            expect(container.getByText('System Code')).toBeInTheDocument()
+        }
+    })
+
+    it('excludes columns specified in excludeColumns', () => {
+        const columns = [
+            createMockColumn('icon', 'Icon'),
+            createMockColumn('name', 'Name'),
+        ]
+        const table = createMockTable(columns)
+
+        render(<ColumnVisibilityDropdown table={table as any} excludeColumns={['icon']} />)
+        fireEvent.click(screen.getByTestId('column-visibility-trigger'))
+
+        const menu = getDropdownContent()
+        if (menu) {
+            const container = within(menu as HTMLElement)
+            expect(container.getByText('Name')).toBeInTheDocument()
+            expect(container.queryByText('Icon')).not.toBeInTheDocument()
+        }
+    })
+
+    it('calls toggleVisibility when checkbox clicked', () => {
+        const columns = [createMockColumn('name', 'Name', true)]
+        const table = createMockTable(columns)
+
+        render(<ColumnVisibilityDropdown table={table as any} />)
+        fireEvent.click(screen.getByTestId('column-visibility-trigger'))
+
+        const menu = getDropdownContent()
+        if (menu) {
+            const container = within(menu as HTMLElement)
+            fireEvent.click(container.getByText('Name'))
+            expect(columns[0].toggleVisibility).toHaveBeenCalled()
+        }
+    })
+})

--- a/src/modules/shared/table/pandaTableV2/PandaTableV2.tsx
+++ b/src/modules/shared/table/pandaTableV2/PandaTableV2.tsx
@@ -28,6 +28,8 @@ interface Props<T> {
     skeletonRowCount?: number
     tableId: string
     table: Table<T>
+    toolbar?: React.ReactNode
+    emptyState?: React.ReactNode
 }
 
 /**
@@ -54,6 +56,8 @@ function PandaTableV2Inner<T>(
         tableId,
         getRowProps = defaultPropGetter,
         skeletonRowCount = 5,
+        toolbar,
+        emptyState,
     }: Props<T>,
     ref: React.ForwardedRef<PandaTableV2Handle>,
 ) {
@@ -123,6 +127,8 @@ function PandaTableV2Inner<T>(
             isLoading={isInitialLoad}
             isRefetching={isRefetching}
             isEmpty={data && isEmptyArray(data)}
+            toolbar={toolbar}
+            emptyState={emptyState}
         >
             <thead className="sticky top-0 z-10 bg-background/95 backdrop-blur backdrop-filter">
                 {table.getHeaderGroups().map(headerGroup => {

--- a/src/modules/shared/table/pandaTableV2/components/Table.cont.tsx
+++ b/src/modules/shared/table/pandaTableV2/components/Table.cont.tsx
@@ -5,7 +5,7 @@ import EmptyResults from '@/components/empty-section/EmptyResults'
 import { PaginationV2 } from '@/components/table/PaginationV2.comp'
 import { cn } from '@/lib/utils'
 
-import { TableSettings } from '../../pandaTable/components/TableSettings'
+import { ColumnVisibilityDropdown } from '../../ColumnVisibilityDropdown.comp'
 
 interface Props {
     table: Table<any>
@@ -18,6 +18,8 @@ interface Props {
     tableContainerRef?: any
     enablePagination?: boolean
     itemsTotalCount?: number
+    toolbar?: React.ReactNode
+    emptyState?: React.ReactNode
 }
 
 export const TableContainer: FC<PropsWithChildren<Props>> = ({
@@ -32,6 +34,8 @@ export const TableContainer: FC<PropsWithChildren<Props>> = ({
     isLoading,
     isRefetching,
     isEmpty,
+    toolbar,
+    emptyState,
 }) => {
     return (
         <Fragment>
@@ -43,14 +47,11 @@ export const TableContainer: FC<PropsWithChildren<Props>> = ({
                     <span>{tableHeading}</span>
                 </div>
             )}
-            {enableColumnHiding && (
-                <TableSettings
-                    getAllLeafColumns={table.getAllLeafColumns}
-                    getIsAllColumnsVisible={table.getIsAllColumnsVisible}
-                    getToggleAllColumnsVisibilityHandler={
-                        table.getToggleAllColumnsVisibilityHandler
-                    }
-                />
+            {toolbar}
+            {enableColumnHiding && !toolbar && (
+                <div id="column-hiding" className="flex justify-end px-4 py-1.5 border-b border-border">
+                    <ColumnVisibilityDropdown table={table} />
+                </div>
             )}
             <div
                 ref={tableContainerRef}
@@ -62,7 +63,7 @@ export const TableContainer: FC<PropsWithChildren<Props>> = ({
                 <table className={cn('min-w-full', isRefetching && 'opacity-60 animate-pulse')}>
                     {children}
                 </table>
-                {isEmpty && !isLoading && <EmptyResults />}
+                {isEmpty && !isLoading && (emptyState ?? <EmptyResults />)}
             </div>
             {enablePagination && (
                 <PaginationV2

--- a/src/modules/systemHierarchy/components/filters/LeavesFilterFooter.comp.tsx
+++ b/src/modules/systemHierarchy/components/filters/LeavesFilterFooter.comp.tsx
@@ -1,0 +1,46 @@
+import type { UseFormReset } from 'react-hook-form'
+import { useIntl } from 'react-intl'
+
+import { Button } from '@/components/Buttons'
+import { useFormFilterState } from '@/hooks/form/useFormFilters'
+import { message } from '@/i18n/src/messages'
+import { FilterSaveSettings } from '@/modules/shared/filters/FilterSaveSettings'
+
+interface LeavesFilterFooterProps {
+    tableId: string
+    enableQueryURL: boolean
+    resetForm: UseFormReset<any>
+    defaultFormValues: any
+}
+
+export const LeavesFilterFooter = ({
+    tableId,
+    enableQueryURL,
+    resetForm,
+    defaultFormValues,
+}: LeavesFilterFooterProps) => {
+    const { formatMessage: fm } = useIntl()
+    const { setColumnFilters } = useFormFilterState({
+        tableId,
+        enableQueryUrl: enableQueryURL,
+    })
+
+    const handleClearFilters = () => {
+        resetForm(defaultFormValues, { keepValues: false })
+        setColumnFilters([])
+    }
+
+    return (
+        <div className="flex flex-col gap-4 pt-4 border-t">
+            <FilterSaveSettings
+                tableId={tableId}
+                enableQueryURL={enableQueryURL}
+                resetForm={resetForm}
+                defaultFormValues={defaultFormValues}
+            />
+            <Button type="button" className="w-full justify-center" onClick={handleClearFilters}>
+                {fm({ id: message.common.ui.clearFilters })}
+            </Button>
+        </div>
+    )
+}

--- a/src/modules/systemHierarchy/components/filters/LeavesFilterSheet.cont.tsx
+++ b/src/modules/systemHierarchy/components/filters/LeavesFilterSheet.cont.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useMemo } from 'react'
+
+import { Form } from '@/components/form/Form'
+import { useFormFilter } from '@/hooks/form/useFormFilters'
+import { useFormControlStore } from '@/store/useFormControlStore'
+import type { CodebookType } from '@/types/responses/codebook'
+
+import { useMinMaxPrice } from '../../../systems/hooks/useMinMaxPrice'
+import { LeavesFilterForm } from './form/LeavesFilter.form'
+import { LeavesFilterFooter } from './LeavesFilterFooter.comp'
+
+type LeavesFilterType = {
+    name: string
+    systemLevel: string[]
+    systemCode: string
+    systemType: CodebookType | null
+    zone: CodebookType | null
+    location: CodebookType | null
+    responsible: CodebookType | null
+    description: string
+    importance: CodebookType | null
+    itemUsage: string[]
+    eun: string
+    serialNumber: string
+    catalogueName: string
+    catalogueNumber: string
+    category: CodebookType | null
+    catalogueDescription: string
+    supplier: CodebookType | null
+    price: [number | undefined, number | undefined]
+}
+
+interface LeavesFilterSheetProps {
+    tableId: string
+    enableQueryURL: boolean
+}
+
+export const LeavesFilterSheet = ({
+    tableId,
+    enableQueryURL,
+}: LeavesFilterSheetProps) => {
+    const { minMaxPrice } = useMinMaxPrice()
+
+    const defaultValues = useMemo<LeavesFilterType>(
+        () => ({
+            name: '',
+            systemLevel: [],
+            systemCode: '',
+            systemType: null,
+            zone: null,
+            location: null,
+            responsible: null,
+            description: '',
+            importance: null,
+            itemUsage: [],
+            eun: '',
+            serialNumber: '',
+            catalogueName: '',
+            catalogueNumber: '',
+            category: null,
+            catalogueDescription: '',
+            supplier: null,
+            price: [minMaxPrice?.min, minMaxPrice?.max],
+        }),
+        [minMaxPrice],
+    )
+
+    const formMethods = useFormFilter<LeavesFilterType>({
+        tableId,
+        defValues: defaultValues,
+        enableQueryURL,
+    })
+
+    const { toggleDeleteCustom } = useFormControlStore()
+    const { watch } = formMethods
+
+    const category = watch('category')
+
+    useEffect(() => {
+        if (!category) {
+            toggleDeleteCustom()
+        }
+    }, [category, toggleDeleteCustom])
+
+    return (
+        <Form className="flex flex-col h-full justify-between" formMethods={formMethods}>
+            <LeavesFilterForm
+                tableId={tableId}
+                enableQueryUrl={enableQueryURL}
+            />
+            <LeavesFilterFooter
+                tableId={tableId}
+                enableQueryURL={enableQueryURL}
+                resetForm={formMethods.reset}
+                defaultFormValues={defaultValues}
+            />
+        </Form>
+    )
+}

--- a/src/modules/systemHierarchy/components/filters/__tests__/LeavesFilterSheet.test.tsx
+++ b/src/modules/systemHierarchy/components/filters/__tests__/LeavesFilterSheet.test.tsx
@@ -1,0 +1,66 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+
+import { LeavesFilterSheet } from '../LeavesFilterSheet.cont'
+
+jest.mock('@/hooks/form/useFormFilters', () => ({
+    useFormFilter: () => ({
+        register: jest.fn(),
+        watch: jest.fn(() => null),
+        reset: jest.fn(),
+        handleSubmit: jest.fn(),
+        formState: { errors: {} },
+        control: {},
+        setValue: jest.fn(),
+        getValues: jest.fn(),
+    }),
+    useFormFilterState: () => ({
+        setFilter: jest.fn(() => jest.fn()),
+        setColumnFilters: jest.fn(),
+        storeFilters: [],
+    }),
+}))
+
+jest.mock('@/store/useFormControlStore', () => ({
+    useFormControlStore: () => ({
+        toggleDeleteCustom: jest.fn(),
+        addFieldIdToSync: jest.fn(),
+    }),
+}))
+
+jest.mock('@/modules/systems/hooks/useMinMaxPrice', () => ({
+    useMinMaxPrice: () => ({ minMaxPrice: { min: 0, max: 10000 } }),
+}))
+
+jest.mock('../form/LeavesFilter.form', () => ({
+    LeavesFilterForm: () => <div data-testid="leaves-filter-form" />,
+}))
+
+jest.mock('../LeavesFilterFooter.comp', () => ({
+    LeavesFilterFooter: () => <div data-testid="leaves-filter-footer" />,
+}))
+
+jest.mock('@/components/form/Form', () => ({
+    Form: ({ children, ...props }: any) => (
+        <form data-testid="filter-form" {...props}>
+            {children}
+        </form>
+    ),
+}))
+
+const msgs: Record<string, string> = {}
+
+describe('LeavesFilterSheet', () => {
+    it('renders form with filter form and footer', () => {
+        render(
+            <IntlProvider locale="en" messages={msgs}>
+                <LeavesFilterSheet tableId="systemLeaves" enableQueryURL={true} />
+            </IntlProvider>,
+        )
+
+        expect(screen.getByTestId('filter-form')).toBeInTheDocument()
+        expect(screen.getByTestId('leaves-filter-form')).toBeInTheDocument()
+        expect(screen.getByTestId('leaves-filter-footer')).toBeInTheDocument()
+    })
+})

--- a/src/modules/systemHierarchy/components/filters/form/LeavesFilter.fields.ts
+++ b/src/modules/systemHierarchy/components/filters/form/LeavesFilter.fields.ts
@@ -1,0 +1,162 @@
+import { useMakeFormFields } from '@/hooks/form/useMakeFormFields'
+import { message } from '@/i18n/src/messages'
+import { CODEBOOK } from '@/types/constants/codebook'
+
+const { form } = message.systemsPage.systemDetail
+const { form: catalogueForm } = message.cataloguePage.itemDetail
+
+export const useLeavesFilterFields = () => {
+    const disabledEdit = false
+    return useMakeFormFields({
+        name: {
+            name: 'name',
+            label: form.name.label,
+            placeholder: form.name.placeholder,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        responsible: {
+            name: 'responsible',
+            label: form.responsiblePerson.label,
+            codebook: CODEBOOK.EMPLOYEE,
+            disabled: disabledEdit,
+        },
+        importance: {
+            name: 'importance',
+            label: form.importance.label,
+            codebook: CODEBOOK.SYSTEM_IMPORTANCE,
+            disabled: disabledEdit,
+        },
+        location: {
+            name: 'location',
+            label: form.location.label,
+            codebook: CODEBOOK.LOCATION,
+            disabled: disabledEdit,
+        },
+        zone: {
+            name: 'zone',
+            label: form.zone.label,
+            codebook: CODEBOOK.ZONE,
+            disabled: disabledEdit,
+        },
+        systemType: {
+            name: 'systemType',
+            label: form.systemType.label,
+            disabled: disabledEdit,
+        },
+        description: {
+            name: 'description',
+            label: form.description.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        systemCode: {
+            name: 'systemCode',
+            label: form.systemCode.label,
+            placeholder: form.systemCode.placeholder,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        systemLevel: {
+            name: 'systemLevel',
+            label: form.systemLevel.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        itemUsage: {
+            name: 'itemUsage',
+            label: form.physicalItem.itemUsage.label,
+            codebook: CODEBOOK.ITEM_USAGE,
+            disabled: disabledEdit,
+        },
+        itemConditionStatus: {
+            name: 'conditionStatus',
+            label: form.physicalItem.conditionStatus.label,
+            codebook: CODEBOOK.ITEM_CONDITION_STATUS,
+            disabled: disabledEdit,
+        },
+        sparePartsCoverage: {
+            name: 'sparePartsCoverage',
+            label: form.sparePartsCoverage.label,
+            disabled: disabledEdit,
+        },
+        criticalSpCoverage: {
+            name: 'criticalSpCoverage',
+            label: form.criticalSpCoverage.label,
+            disabled: disabledEdit,
+        },
+        price: {
+            name: 'price',
+            label: form.physicalItem.price.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        orderName: {
+            name: 'orderName',
+            label: form.physicalItem.orderName.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        orderNumber: {
+            name: 'orderNumber',
+            label: form.physicalItem.orderNumber.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        orderRequestNumber: {
+            name: 'orderRequestNumber',
+            label: form.physicalItem.orderRequestNumber.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        orderContractNumber: {
+            name: 'orderContractNumber',
+            label: form.physicalItem.orderContractNumber.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        eun: {
+            name: 'eun',
+            label: form.physicalItem.eun.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        serialNumber: {
+            name: 'serialNumber',
+            label: form.physicalItem.serialNumber.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        partNumber: {
+            name: 'catalogueNumber',
+            label: catalogueForm.catalogueNumber.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        catalogueName: {
+            name: 'catalogueName',
+            label: catalogueForm.name.label,
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+        },
+        catalogueDescription: {
+            name: 'catalogueDescription',
+            rounded: 'rounded-md',
+            label: catalogueForm.description.label,
+            disabled: disabledEdit,
+        },
+        category: {
+            name: 'category',
+            rounded: 'rounded-md',
+            disabled: disabledEdit,
+            label: catalogueForm.catalogueCategory.label,
+            codebook: CODEBOOK.CATALOGUE_CATEGORY,
+        },
+        catalogueSupplier: {
+            name: 'supplier',
+            label: catalogueForm.manufacturer.label,
+            disabled: disabledEdit,
+            codebook: CODEBOOK.SUPPLIER,
+        },
+    })
+}

--- a/src/modules/systemHierarchy/components/filters/form/LeavesFilter.form.tsx
+++ b/src/modules/systemHierarchy/components/filters/form/LeavesFilter.form.tsx
@@ -1,0 +1,179 @@
+import { useMemo } from 'react'
+import { useFormContext } from 'react-hook-form'
+
+import CheckBox from '@/components/form/CheckBox'
+import Combobox from '@/components/form/Combobox'
+import { ComboboxTree } from '@/components/form/ComboboxTree'
+import { FilterCheckboxes } from '@/components/form/FIlterCheckboxes'
+import { Input } from '@/components/form/inputs'
+import { RangeInput } from '@/components/form/RangeInput'
+import { RangeSliderComponent } from '@/components/form/RangeSlider'
+import { useFormFilterState } from '@/hooks/form/useFormFilters'
+import { cn } from '@/lib/utils'
+import { CategoryPropFilters } from '@/modules/shared/form/CategoryPropFilters'
+import { SelectLocationCombo } from '@/modules/shared/form/location/SelectLocation.combo'
+import { SystemTypeComboBox } from '@/modules/shared/form/systemType/SelectSystemType.combo'
+import { useCategoryItemProperties } from '@/modules/systems/hooks/useCategoryItemProperties'
+import { useCategoryProperties } from '@/modules/systems/hooks/useCategoryProperties'
+import { useMinMaxPrice } from '@/modules/systems/hooks/useMinMaxPrice'
+import { SystemLevel } from '@/types/gql/graphql'
+
+import { useLeavesFilterFields } from './LeavesFilter.fields'
+
+export const LeavesFilterForm = ({
+    tableId,
+    enableQueryUrl,
+}: {
+    tableId: string
+    enableQueryUrl: boolean
+}) => {
+    const fields = useLeavesFilterFields()
+    const systemLevels = Object.values(SystemLevel).map(level => level)
+    const { minMaxPrice } = useMinMaxPrice()
+
+    const { setFilter } = useFormFilterState({ tableId, enableQueryUrl })
+    const { watch } = useFormContext()
+
+    const category = watch('category')
+    const uid = useMemo(() => category?.uid, [category])
+
+    const { catalogueCategoryProperties } = useCategoryProperties(uid)
+    const { data: itemProperties } = useCategoryItemProperties(uid)
+
+    return (
+        <div className={cn('md:grid md:grid-cols-2 md:gap-4 md:min-w-[500px]')}>
+            <div className="flex flex-col gap-2">
+                <Input {...fields.name} onChange={setFilter(fields.name.name)} isFilter={true} />
+                <Combobox
+                    {...fields.responsible}
+                    onSelect={setFilter(fields.responsible.name)}
+                    isFilter={true}
+                />
+                <Input
+                    {...fields.systemCode}
+                    onChange={setFilter(fields.systemCode.name)}
+                    isFilter={true}
+                />
+                <Combobox {...fields.zone} onSelect={setFilter(fields.zone.name)} isFilter={true} />
+                <SelectLocationCombo
+                    locationField={fields.location}
+                    onSelect={setFilter(fields.location.name)}
+                    isFilter={true}
+                />
+                <FilterCheckboxes
+                    name={fields.itemUsage.name}
+                    codebook={fields.itemUsage.codebook}
+                    label="Item Usage"
+                    onChange={setFilter(fields.itemUsage.name)}
+                    isFilter={true}
+                />
+                <FilterCheckboxes
+                    name={fields.systemLevel.name}
+                    label="System Level"
+                    options={systemLevels}
+                    onChange={setFilter(fields.systemLevel.name)}
+                    isFilter={true}
+                />
+                <Input
+                    {...fields.description}
+                    onChange={setFilter(fields.description.name)}
+                    isFilter={true}
+                />
+                <RangeInput
+                    {...fields.sparePartsCoverage}
+                    placeholder={{ min: 'Min', max: 'Max' }}
+                    isFilter={true}
+                    onChange={value => {
+                        setFilter(fields.sparePartsCoverage.name)(value)
+                    }}
+                />
+                <CheckBox
+                    {...fields.criticalSpCoverage}
+                    label="Critical SP Coverage"
+                    onChange={e => {
+                        setFilter(fields.criticalSpCoverage.name)(e.target.checked)
+                    }}
+                    isFilter={true}
+                />
+            </div>
+            <div className="flex flex-col gap-2">
+                <SystemTypeComboBox
+                    systemTypeField={fields.systemType}
+                    clickIcon={true}
+                    onChange={setFilter(fields.systemType.name)}
+                    isFilter={true}
+                />
+                <Combobox
+                    {...fields.importance}
+                    onSelect={setFilter(fields.importance.name)}
+                    isFilter={true}
+                />
+                <Input {...fields.eun} onChange={setFilter(fields.eun.name)} isFilter={true} />
+                <Input
+                    {...fields.partNumber}
+                    onChange={setFilter(fields.partNumber.name)}
+                    isFilter={true}
+                />
+                <Input
+                    {...fields.serialNumber}
+                    onChange={setFilter(fields.serialNumber.name)}
+                    isFilter={true}
+                />
+                <Input
+                    {...fields.catalogueName}
+                    onChange={setFilter(fields.catalogueName.name)}
+                    isFilter={true}
+                />
+                <ComboboxTree
+                    {...fields.category}
+                    onSelect={setFilter(fields.category.name)}
+                    isFilter={true}
+                />
+                <Combobox
+                    {...fields.catalogueSupplier}
+                    onSelect={setFilter(fields.catalogueSupplier.name)}
+                    isFilter={true}
+                />
+                <RangeSliderComponent
+                    min={minMaxPrice?.min}
+                    max={minMaxPrice?.max}
+                    name={'price'}
+                    label={'Price'}
+                    onChange={setFilter('price')}
+                />
+                <Input
+                    {...fields.orderName}
+                    onChange={setFilter(fields.orderName.name)}
+                    isFilter={true}
+                />
+                <Input
+                    {...fields.orderNumber}
+                    onChange={setFilter(fields.orderNumber.name)}
+                    isFilter={true}
+                />
+                <Input
+                    {...fields.orderRequestNumber}
+                    onChange={setFilter(fields.orderRequestNumber.name)}
+                    isFilter={true}
+                />
+                <Input
+                    {...fields.orderContractNumber}
+                    onChange={setFilter(fields.orderContractNumber.name)}
+                    isFilter={true}
+                />
+            </div>
+            <CategoryPropFilters
+                tableId={tableId}
+                catalogueCategoryProperties={itemProperties}
+                enableQueryUrl={enableQueryUrl}
+                isItemProperties={true}
+            />
+            <CategoryPropFilters
+                tableId={tableId}
+                catalogueCategoryProperties={catalogueCategoryProperties}
+                enableQueryUrl={enableQueryUrl}
+                isItemProperties={false}
+            />
+        </div>
+    )
+}

--- a/src/modules/systemHierarchy/components/filters/form/__tests__/LeavesFilter.fields.test.ts
+++ b/src/modules/systemHierarchy/components/filters/form/__tests__/LeavesFilter.fields.test.ts
@@ -1,0 +1,109 @@
+import { renderHook } from '@testing-library/react'
+
+import { useLeavesFilterFields } from '../LeavesFilter.fields'
+
+jest.mock('@/hooks/form/useMakeFormFields', () => ({
+    useMakeFormFields: (fields: Record<string, any>) => {
+        const result: Record<string, any> = {}
+        for (const [key, value] of Object.entries(fields)) {
+            result[key] = { ...value, id: key }
+        }
+        return result
+    },
+}))
+
+jest.mock('@/i18n/src/messages', () => ({
+    message: {
+        systemsPage: {
+            systemDetail: {
+                form: {
+                    name: { label: 'Name', placeholder: 'Name' },
+                    responsiblePerson: { label: 'Responsible' },
+                    importance: { label: 'Importance' },
+                    location: { label: 'Location' },
+                    zone: { label: 'Zone' },
+                    systemType: { label: 'System Type' },
+                    description: { label: 'Description' },
+                    systemCode: { label: 'System Code', placeholder: 'Code' },
+                    systemLevel: { label: 'System Level' },
+                    sparePartsCoverage: { label: 'Spare Parts Coverage' },
+                    criticalSpCoverage: { label: 'Critical SP Coverage' },
+                    physicalItem: {
+                        itemUsage: { label: 'Item Usage' },
+                        conditionStatus: { label: 'Condition Status' },
+                        price: { label: 'Price' },
+                        orderName: { label: 'Order Name' },
+                        orderNumber: { label: 'Order Number' },
+                        orderRequestNumber: { label: 'Request Number' },
+                        orderContractNumber: { label: 'Contract Number' },
+                        eun: { label: 'EUN' },
+                        serialNumber: { label: 'Serial Number' },
+                        notes: { label: 'Notes' },
+                    },
+                },
+            },
+        },
+        cataloguePage: {
+            itemDetail: {
+                form: {
+                    catalogueNumber: { label: 'Catalogue Number' },
+                    name: { label: 'Catalogue Name' },
+                    description: { label: 'Catalogue Description' },
+                    catalogueCategory: { label: 'Category' },
+                    manufacturer: { label: 'Supplier' },
+                },
+            },
+        },
+    },
+}))
+
+describe('useLeavesFilterFields', () => {
+    it('returns all expected filter fields', () => {
+        const { result } = renderHook(() => useLeavesFilterFields())
+        const fields = result.current
+
+        const expectedKeys = [
+            'name',
+            'responsible',
+            'importance',
+            'location',
+            'zone',
+            'systemType',
+            'description',
+            'systemCode',
+            'systemLevel',
+            'itemUsage',
+            'itemConditionStatus',
+            'sparePartsCoverage',
+            'criticalSpCoverage',
+            'price',
+            'orderName',
+            'orderNumber',
+            'orderRequestNumber',
+            'orderContractNumber',
+            'eun',
+            'serialNumber',
+            'partNumber',
+            'catalogueName',
+            'catalogueDescription',
+            'category',
+            'catalogueSupplier',
+        ]
+
+        for (const key of expectedKeys) {
+            expect(fields).toHaveProperty(key)
+        }
+    })
+
+    it('does not include parentSystem field', () => {
+        const { result } = renderHook(() => useLeavesFilterFields())
+        expect(result.current).not.toHaveProperty('parentSystem')
+    })
+
+    it('all fields have a name property', () => {
+        const { result } = renderHook(() => useLeavesFilterFields())
+        for (const field of Object.values(result.current)) {
+            expect((field as any).name).toBeDefined()
+        }
+    })
+})

--- a/src/modules/systemHierarchy/components/filters/hooks/__tests__/useLeavesFilterSheet.test.ts
+++ b/src/modules/systemHierarchy/components/filters/hooks/__tests__/useLeavesFilterSheet.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react'
+
+import { useDynamicModalStore } from '@/store/useDynamicModalStore'
+
+import { LEAVES_TABLE_ID } from '../../../../types/constants'
+import { useLeavesFilterSheet } from '../useLeavesFilterSheet'
+
+jest.mock('@/store/useDynamicModalStore')
+
+jest.mock('../../LeavesFilterSheet.cont', () => ({
+    LeavesFilterSheet: () => null,
+}))
+
+const mockOpenModal = jest.fn(() => 'mock-modal-id')
+
+;(useDynamicModalStore as unknown as jest.Mock).mockReturnValue({
+    openModal: mockOpenModal,
+})
+
+describe('useLeavesFilterSheet', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        ;(useDynamicModalStore as unknown as jest.Mock).mockReturnValue({
+            openModal: mockOpenModal,
+        })
+    })
+
+    it('returns a function', () => {
+        const { result } = renderHook(() => useLeavesFilterSheet())
+        expect(typeof result.current).toBe('function')
+    })
+
+    it('calls openModal with sheet type and correct props', () => {
+        const { result } = renderHook(() => useLeavesFilterSheet())
+        result.current()
+
+        expect(mockOpenModal).toHaveBeenCalledWith('sheet', expect.objectContaining({
+            id: `leaves-filters-${LEAVES_TABLE_ID}`,
+            props: expect.objectContaining({
+                title: 'Leaves Filters',
+                size: 'l',
+                side: 'left',
+                tableId: LEAVES_TABLE_ID,
+                enableQueryURL: true,
+            }),
+        }))
+    })
+
+    it('supports custom side prop', () => {
+        const { result } = renderHook(() => useLeavesFilterSheet())
+        result.current({ side: 'right' })
+
+        expect(mockOpenModal).toHaveBeenCalledWith('sheet', expect.objectContaining({
+            props: expect.objectContaining({
+                side: 'right',
+            }),
+        }))
+    })
+
+    it('returns modal id', () => {
+        const { result } = renderHook(() => useLeavesFilterSheet())
+        const modalId = result.current()
+        expect(modalId).toBe('mock-modal-id')
+    })
+})

--- a/src/modules/systemHierarchy/components/filters/hooks/useLeavesFilterSheet.ts
+++ b/src/modules/systemHierarchy/components/filters/hooks/useLeavesFilterSheet.ts
@@ -1,0 +1,35 @@
+import { useCallback } from 'react'
+
+import { useDynamicModalStore } from '@/store/useDynamicModalStore'
+
+import { LEAVES_TABLE_ID } from '../../../types/constants'
+import { LeavesFilterSheet } from '../LeavesFilterSheet.cont'
+
+interface UseLeavesFilterSheetProps {
+    side?: 'top' | 'right' | 'bottom' | 'left'
+}
+
+export const useLeavesFilterSheet = () => {
+    const { openModal } = useDynamicModalStore()
+
+    const openFilterSheet = useCallback(
+        ({ side = 'left' }: UseLeavesFilterSheetProps = {}) => {
+            const modalId = openModal('sheet', {
+                id: `leaves-filters-${LEAVES_TABLE_ID}`,
+                component: LeavesFilterSheet,
+                props: {
+                    title: 'Leaves Filters',
+                    size: 'l',
+                    side,
+                    tableId: LEAVES_TABLE_ID,
+                    enableQueryURL: true,
+                },
+            })
+
+            return modalId
+        },
+        [openModal],
+    )
+
+    return openFilterSheet
+}

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -48,9 +48,14 @@ export const LeavesPanelContainer: FC = () => {
 
     useEffect(() => {
         if (filterQuery) {
-            const urlFilters = JSON.parse(filterQuery)
-            if (urlFilters.length > 0) {
-                setColumnFilter(LEAVES_TABLE_ID, urlFilters)
+            try {
+                const parsed = JSON.parse(filterQuery)
+                const urlFilters = Array.isArray(parsed) ? parsed : []
+                if (urlFilters.length > 0) {
+                    setColumnFilter(LEAVES_TABLE_ID, urlFilters)
+                }
+            } catch {
+                // ignore malformed filter query
             }
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -1,17 +1,24 @@
+import { useQueryState } from 'next-usequerystate'
 import type { FC } from 'react'
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 
+import { Button } from '@/components/ui/button'
+import { useFormFilterState } from '@/hooks/form/useFormFilters'
 import { message } from '@/i18n/src/messages'
+import { usePandaTable } from '@/modules/shared/table/pandaTable/hooks/usePandaTable'
+import useTableStateStore from '@/store/useTableStateStore'
 
 import { useSystemDetail } from '../../hooks/queries/useSystemDetail'
 import { useSystemLeaves } from '../../hooks/queries/useSystemLeaves'
 import { useHierarchyNavigation } from '../../hooks/useHierarchyNavigation'
-import { HIERARCHY_VIEWS } from '../../types/constants'
+import { HIERARCHY_VIEWS, LEAVES_TABLE_ID } from '../../types/constants'
 import { SystemDetailViewContainer } from '../detail/SystemDetailView.cont'
 import { RelationshipGraphContainer } from '../graph/RelationshipGraph.cont'
 import { LeavesPanelHeader } from './LeavesPanelHeader.comp'
 import { LeavesTableComponent } from './LeavesTable.comp'
+import { LeavesToolbar } from './LeavesToolbar.comp'
+import { useLeavesColumns } from './useLeavesColumns'
 
 export const LeavesPanelContainer: FC = () => {
     const { formatMessage: fm } = useIntl()
@@ -19,6 +26,41 @@ export const LeavesPanelContainer: FC = () => {
         useHierarchyNavigation()
     const { system: parentSystem, isLoading: isParentLoading } = useSystemDetail(selectedParentUid)
     const { leaves, totalCount, isLoading } = useSystemLeaves(selectedParentUid)
+
+    const { columns } = useLeavesColumns()
+
+    const table = usePandaTable({
+        tableId: LEAVES_TABLE_ID,
+        columns,
+        data: leaves,
+        settings: {
+            enableSorting: true,
+            enableColumnHiding: true,
+            enableFiltering: true,
+            manualFiltering: true,
+            enableColumnReordering: false,
+        },
+    })
+
+    // Sync URL filter params → store on mount (enables persistence across refresh/new tab)
+    const [filterQuery] = useQueryState('filter')
+    const { setColumnFilter, setSearch, setSearchValue } = useTableStateStore()
+
+    useEffect(() => {
+        if (filterQuery) {
+            const urlFilters = JSON.parse(filterQuery)
+            if (urlFilters.length > 0) {
+                setColumnFilter(LEAVES_TABLE_ID, urlFilters)
+            }
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    const { setColumnFilters, storeFilters } = useFormFilterState({
+        tableId: LEAVES_TABLE_ID,
+        enableQueryUrl: true,
+    })
+    const hasActiveFilters = storeFilters.length > 0
 
     const handleViewParentDetail = useCallback(() => {
         if (selectedParentUid) {
@@ -68,19 +110,33 @@ export const LeavesPanelContainer: FC = () => {
         )
     }
 
-    if (!isLoading && leaves.length === 0) {
-        return (
-            <div
-                className="flex flex-col h-full overflow-hidden"
-                data-testid="system-hierarchy-leaves-panel"
-            >
-                {header}
-                <div className="flex items-center justify-center flex-1 text-muted-foreground text-sm">
-                    {fm({ id: message.systemHierarchy.leaves.noLeaves })}
-                </div>
+    const toolbar = (
+        <LeavesToolbar
+            tableId={LEAVES_TABLE_ID}
+            table={table}
+            enableQueryURL={true}
+        />
+    )
+
+    const emptyState = hasActiveFilters ? (
+        <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
+            <div className="text-center">
+                <p>{fm({ id: message.systemHierarchy.leaves.noLeaves })}</p>
+                <Button
+                    variant="link"
+                    size="sm"
+                    className="mt-2"
+                    onClick={() => {
+                        setColumnFilters([])
+                        setSearch(LEAVES_TABLE_ID, '')
+                        setSearchValue(LEAVES_TABLE_ID, '')
+                    }}
+                >
+                    {fm({ id: message.common.ui.clearFilters })}
+                </Button>
             </div>
-        )
-    }
+        </div>
+    ) : undefined
 
     return (
         <div
@@ -94,6 +150,9 @@ export const LeavesPanelContainer: FC = () => {
                     totalCount={totalCount}
                     isLoading={isLoading}
                     onRowClick={selectLeaf}
+                    table={table}
+                    toolbar={toolbar}
+                    emptyState={emptyState}
                 />
             </div>
         </div>

--- a/src/modules/systemHierarchy/components/leaves/LeavesTable.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesTable.comp.tsx
@@ -1,8 +1,8 @@
-import type { FC } from 'react'
+import type { Table } from '@tanstack/react-table'
+import type { FC, ReactNode } from 'react'
 import { useCallback, useRef } from 'react'
 
 import { PaginationV2 as Pagination } from '@/modules/shared/table/PaginationV2'
-import { usePandaTable } from '@/modules/shared/table/pandaTable/hooks/usePandaTable'
 import {
     PandaTableV2,
     type PandaTableV2Handle,
@@ -10,13 +10,15 @@ import {
 
 import type { SystemLeaf } from '../../types'
 import { LEAVES_TABLE_ID } from '../../types/constants'
-import { useLeavesColumns } from './useLeavesColumns'
 
 interface LeavesTableProps {
     data: SystemLeaf[]
     totalCount: number
     isLoading: boolean
     onRowClick: (uid: string) => void
+    table: Table<SystemLeaf>
+    toolbar?: ReactNode
+    emptyState?: ReactNode
 }
 
 export const LeavesTableComponent: FC<LeavesTableProps> = ({
@@ -24,22 +26,11 @@ export const LeavesTableComponent: FC<LeavesTableProps> = ({
     totalCount,
     isLoading,
     onRowClick,
+    table,
+    toolbar,
+    emptyState,
 }) => {
-    const { columns } = useLeavesColumns()
     const tableRef = useRef<PandaTableV2Handle>(null)
-
-    const table = usePandaTable({
-        tableId: LEAVES_TABLE_ID,
-        columns,
-        data,
-        settings: {
-            enableSorting: true,
-            enableColumnHiding: true,
-            enableFiltering: true,
-            manualFiltering: true,
-            enableColumnReordering: false,
-        },
-    })
 
     const handlePageChange = useCallback(() => {
         tableRef.current?.scrollToTop()
@@ -64,6 +55,8 @@ export const LeavesTableComponent: FC<LeavesTableProps> = ({
                         enableColumnHiding: true,
                         enableColumnReordering: false,
                     }}
+                    toolbar={toolbar}
+                    emptyState={emptyState}
                     className="flex-1 min-h-0"
                 />
             </div>
@@ -71,7 +64,7 @@ export const LeavesTableComponent: FC<LeavesTableProps> = ({
                 <Pagination
                     tableId={LEAVES_TABLE_ID}
                     settings={{
-                        enableQueryURL: false,
+                        enableQueryURL: true,
                         pageSizeDefault: 25,
                         total: totalCount,
                     }}

--- a/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
@@ -1,0 +1,123 @@
+import type { Table } from '@tanstack/react-table'
+import { Filter, Search } from 'lucide-react'
+import { useQueryState } from 'next-usequerystate'
+import type { FC } from 'react'
+import { useDeferredValue, useEffect, useRef, useState } from 'react'
+
+import { Tooltip } from '@/components/Tooltip'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { useFormFilterState } from '@/hooks/form/useFormFilters'
+import { FilterBadges } from '@/modules/shared/form/FilterBadges'
+import { ColumnVisibilityDropdown } from '@/modules/shared/table/ColumnVisibilityDropdown.comp'
+import useTableStateStore from '@/store/useTableStateStore'
+
+import type { SystemLeaf } from '../../types'
+import { useLeavesFilterSheet } from '../filters/hooks/useLeavesFilterSheet'
+
+interface LeavesToolbarProps {
+    tableId: string
+    table: Table<SystemLeaf>
+    enableQueryURL?: boolean
+}
+
+export const LeavesToolbar: FC<LeavesToolbarProps> = ({
+    tableId,
+    table,
+    enableQueryURL = true,
+}) => {
+    const openFilterSheet = useLeavesFilterSheet()
+
+    const { storeFilters } = useFormFilterState({
+        tableId,
+        enableQueryUrl: enableQueryURL,
+    })
+
+    const [, setQuerySearch] = useQueryState('search', {
+        history: 'replace',
+    })
+
+    const { setSearch, instances, setSearchValue } = useTableStateStore()
+    const searchInstance = instances[tableId]?.search
+    const storeValue = instances[tableId]?.searchBarValue
+    const deferredStoreValue = useDeferredValue(storeValue || '')
+
+    const [localValue, setLocalValue] = useState(deferredStoreValue)
+    const [mounted, setMounted] = useState(false)
+
+    useEffect(() => {
+        setLocalValue(deferredStoreValue)
+    }, [deferredStoreValue])
+
+    useEffect(() => {
+        if (!mounted) {
+            setMounted(true)
+            setSearchValue(tableId, searchInstance || '')
+        }
+    }, [mounted, searchInstance, setSearchValue, tableId])
+
+    const mountedRef = useRef(mounted)
+    mountedRef.current = mounted
+
+    useEffect(() => {
+        const delayInputTimeoutId = setTimeout(() => {
+            if (mountedRef.current) {
+                setSearch(tableId, localValue)
+                if (enableQueryURL) {
+                    setQuerySearch(localValue || '', { shallow: true })
+                }
+            }
+        }, 500)
+        return () => clearTimeout(delayInputTimeoutId)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [localValue])
+
+    const hasActiveFilters = storeFilters.length > 0
+
+    return (
+        <div
+            className="border-b border-border px-4 py-2 space-y-2"
+            data-testid="leaves-toolbar"
+        >
+            <div className="flex items-center gap-2">
+                <div className="flex-1">
+                    <div className="relative max-w-md">
+                        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                        <Input
+                            value={localValue}
+                            onChange={e => {
+                                const newValue = e.target.value
+                                setLocalValue(newValue)
+                                setSearchValue(tableId, newValue)
+                            }}
+                            placeholder="Search..."
+                            className="pl-10"
+                            type="search"
+                            name="search"
+                            data-testid="leaves-toolbar-search"
+                        />
+                    </div>
+                </div>
+                <Tooltip content={hasActiveFilters ? 'Filters Applied' : 'Open Filters'}>
+                    <div>
+                        <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => openFilterSheet()}
+                            data-testid="leaves-toolbar-filter-btn"
+                        >
+                            <Filter
+                                className={`h-4 w-4 ${hasActiveFilters ? 'fill-current' : ''}`}
+                                aria-hidden="true"
+                            />
+                        </Button>
+                    </div>
+                </Tooltip>
+                <ColumnVisibilityDropdown table={table} excludeColumns={['icon']} />
+            </div>
+            {hasActiveFilters && (
+                <FilterBadges tableId={tableId} enableQueryURL={enableQueryURL} />
+            )}
+        </div>
+    )
+}

--- a/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
@@ -33,12 +33,12 @@ export const LeavesToolbar: FC<LeavesToolbarProps> = ({
         enableQueryUrl: enableQueryURL,
     })
 
-    const [, setQuerySearch] = useQueryState('search', {
+    const [querySearch, setQuerySearch] = useQueryState('search', {
         history: 'replace',
     })
 
     const { setSearch, instances, setSearchValue } = useTableStateStore()
-    const searchInstance = instances[tableId]?.search
+    const searchInstance = querySearch || instances[tableId]?.search
     const storeValue = instances[tableId]?.searchBarValue
     const deferredStoreValue = useDeferredValue(storeValue || '')
 

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.test.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.test.tsx
@@ -1,0 +1,116 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+
+import { LEAVES_TABLE_ID } from '../../../types/constants'
+import { LeavesToolbar } from '../LeavesToolbar.comp'
+
+const mockOpenFilterSheet = jest.fn()
+jest.mock('../../filters/hooks/useLeavesFilterSheet', () => ({
+    useLeavesFilterSheet: () => mockOpenFilterSheet,
+}))
+
+jest.mock('@/modules/shared/form/FilterBadges', () => ({
+    FilterBadges: ({ tableId }: { tableId: string }) => (
+        <div data-testid="filter-badges">{tableId}</div>
+    ),
+}))
+
+jest.mock('@/modules/shared/table/ColumnVisibilityDropdown.comp', () => ({
+    ColumnVisibilityDropdown: () => <div data-testid="column-visibility-dropdown" />,
+}))
+
+jest.mock('next-usequerystate', () => ({
+    useQueryState: () => ['', jest.fn()],
+}))
+
+const mockSetSearch = jest.fn()
+const mockSetSearchValue = jest.fn()
+jest.mock('@/store/useTableStateStore', () => ({
+    __esModule: true,
+    default: () => ({
+        setSearch: mockSetSearch,
+        setSearchValue: mockSetSearchValue,
+        instances: { [LEAVES_TABLE_ID]: { search: '', searchBarValue: '' } },
+    }),
+}))
+
+jest.mock('@/hooks/form/useFormFilters', () => ({
+    useFormFilterState: () => ({
+        storeFilters: [],
+        setFilter: jest.fn(),
+        setColumnFilters: jest.fn(),
+    }),
+}))
+
+const createMockTable = () => ({
+    getAllLeafColumns: jest.fn(() => []),
+    getIsAllColumnsVisible: jest.fn(() => true),
+    getToggleAllColumnsVisibilityHandler: jest.fn(() => jest.fn()),
+})
+
+const msgs: Record<string, string> = {}
+
+const renderWithIntl = (ui: React.JSX.Element) =>
+    render(
+        <IntlProvider locale="en" messages={msgs}>
+            {ui}
+        </IntlProvider>,
+    )
+
+describe('LeavesToolbar', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('renders search input', () => {
+        const table = createMockTable()
+        renderWithIntl(
+            <LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />,
+        )
+        expect(screen.getByTestId('leaves-toolbar-search')).toBeInTheDocument()
+    })
+
+    it('renders filter button', () => {
+        const table = createMockTable()
+        renderWithIntl(
+            <LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />,
+        )
+        expect(screen.getByTestId('leaves-toolbar-filter-btn')).toBeInTheDocument()
+    })
+
+    it('opens filter sheet on filter button click', () => {
+        const table = createMockTable()
+        renderWithIntl(
+            <LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />,
+        )
+        fireEvent.click(screen.getByTestId('leaves-toolbar-filter-btn'))
+        expect(mockOpenFilterSheet).toHaveBeenCalled()
+    })
+
+    it('renders column visibility dropdown', () => {
+        const table = createMockTable()
+        renderWithIntl(
+            <LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />,
+        )
+        expect(screen.getByTestId('column-visibility-dropdown')).toBeInTheDocument()
+    })
+
+    it('renders toolbar container', () => {
+        const table = createMockTable()
+        renderWithIntl(
+            <LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />,
+        )
+        expect(screen.getByTestId('leaves-toolbar')).toBeInTheDocument()
+    })
+
+    it('updates local value on search input change', () => {
+        const table = createMockTable()
+        renderWithIntl(
+            <LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />,
+        )
+        const searchInput = screen.getByTestId('leaves-toolbar-search')
+        fireEvent.change(searchInput, { target: { value: 'test search' } })
+        expect(searchInput).toHaveValue('test search')
+    })
+})


### PR DESCRIPTION
## Summary
- Add toolbar to hierarchy leaves panel with search input, filter button (opens filter sheet), filter badges, and column visibility dropdown
- Add LeavesFilterSheet with all system filter fields except parentSystem (already selected via tree)
- Replace global TableSettings (Disclosure checkboxes) with shadcn DropdownMenu column visibility dropdown
- Add `toolbar` and `emptyState` render props to PandaTableV2 for composable table customization
- Fix filter URL persistence: `useQueryManager` falls back to URL `?filter=` param when store is empty
- Filters persist across parent changes, page refresh, and new tabs

## Test plan
- [ ] Select parent in tree → toolbar shows with search, filter, columns
- [ ] Search field filters leaves via API
- [ ] Filter button opens filter sheet, applying filters shows badges
- [ ] Column visibility dropdown toggles table columns
- [ ] Refresh page with filters in URL → filters restored, API called with filters, badges visible
- [ ] Copy URL to new tab → same behavior
- [ ] Switch parent in tree → filters persist
- [ ] Empty results with active filters → shows "No subsystems found" + "Clear filters" inside table
- [ ] Empty results without filters → shows default "No results" icon
- [ ] Verify column visibility dropdown works on other tables (zones, grants, orders, etc.)
- [ ] All 492 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)