### PR TITLE
fix(systemHierarchy): keep middle view sticky on tree navigation

### DIFF
--- a/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { useHierarchyNavigation } from '../useHierarchyNavigation'
+
+const mockPush = jest.fn()
+let mockQuery: Record<string, string | undefined> = {}
+
+jest.mock('next/router', () => ({
+    useRouter: () => ({
+        query: mockQuery,
+        pathname: '/systems/hierarchy',
+        push: mockPush,
+    }),
+}))
+
+const lastPushedQuery = () => mockPush.mock.calls.at(-1)?.[0]?.query
+
+describe('useHierarchyNavigation', () => {
+    beforeEach(() => {
+        mockPush.mockClear()
+        mockQuery = {}
+    })
+
+    it('selectParent in detail mode swaps detail subject and preserves tab', () => {
+        mockQuery = { parent: 'A', leaf: 'X', tab: 'history' }
+        const { result } = renderHook(() => useHierarchyNavigation())
+        act(() => result.current.selectParent('B'))
+        expect(lastPushedQuery()).toEqual({ parent: 'B', leaf: 'B', tab: 'history' })
+    })
+
+    it('selectParent without leaf does not resurrect a stale tab', () => {
+        mockQuery = { parent: 'A' }
+        const { result } = renderHook(() => useHierarchyNavigation())
+        act(() => result.current.selectParent('B'))
+        expect(lastPushedQuery()).toEqual({ parent: 'B' })
+    })
+
+    it('selectLeaf while already in detail preserves current tab', () => {
+        mockQuery = { parent: 'A', leaf: 'X', tab: 'spare-parts' }
+        const { result } = renderHook(() => useHierarchyNavigation())
+        act(() => result.current.selectLeaf('Y'))
+        expect(lastPushedQuery()).toEqual({ parent: 'A', leaf: 'Y', tab: 'spare-parts' })
+    })
+
+    it('selectLeaf from leaves table sets default detail tab', () => {
+        mockQuery = { parent: 'A' }
+        const { result } = renderHook(() => useHierarchyNavigation())
+        act(() => result.current.selectLeaf('X'))
+        expect(lastPushedQuery()).toEqual({ parent: 'A', leaf: 'X', tab: 'detail' })
+    })
+
+    it('goBackToLeaves clears leaf and tab', () => {
+        mockQuery = { parent: 'A', leaf: 'X', tab: 'history' }
+        const { result } = renderHook(() => useHierarchyNavigation())
+        act(() => result.current.goBackToLeaves())
+        expect(lastPushedQuery()).toEqual({ parent: 'A' })
+    })
+
+    it('setActiveView(GRAPH) then selectParent keeps view=graph', () => {
+        mockQuery = { parent: 'A' }
+        const { result, rerender } = renderHook(() => useHierarchyNavigation())
+        act(() => result.current.setActiveView('graph'))
+        mockQuery = { parent: 'A', view: 'graph' }
+        rerender()
+        act(() => result.current.selectParent('B'))
+        expect(lastPushedQuery()).toEqual({ parent: 'B', view: 'graph' })
+    })
+})

--- a/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
@@ -65,4 +65,11 @@ describe('useHierarchyNavigation', () => {
         act(() => result.current.selectParent('B'))
         expect(lastPushedQuery()).toEqual({ parent: 'B', view: 'graph' })
     })
+
+    it('selectLeaf from graph view keeps view=graph', () => {
+        mockQuery = { parent: 'A', view: 'graph' }
+        const { result } = renderHook(() => useHierarchyNavigation())
+        act(() => result.current.selectLeaf('X'))
+        expect(lastPushedQuery()).toEqual({ parent: 'A', view: 'graph', leaf: 'X', tab: 'detail' })
+    })
 })

--- a/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
@@ -31,16 +31,18 @@ export const useHierarchyNavigation = () => {
 
     const selectParent = useCallback(
         (uid: string) => {
-            updateQuery({ parent: uid, leaf: undefined, tab: undefined })
+            const inDetail = !!(router.query.leaf as string | undefined)
+            updateQuery(inDetail ? { parent: uid, leaf: uid } : { parent: uid })
         },
-        [updateQuery],
+        [router, updateQuery],
     )
 
     const selectLeaf = useCallback(
         (uid: string) => {
-            updateQuery({ leaf: uid, tab: HIERARCHY_TABS.DETAIL })
+            const inDetail = !!(router.query.leaf as string | undefined)
+            updateQuery(inDetail ? { leaf: uid } : { leaf: uid, tab: HIERARCHY_TABS.DETAIL })
         },
-        [updateQuery],
+        [router, updateQuery],
     )
 
     const setActiveTab = useCallback(


### PR DESCRIPTION
## Summary
- Tree click no longer drops the user out of detail or graph view
- `selectParent` swaps the detail subject (and preserves the active tab) instead of clearing `leaf`/`tab`
- `selectLeaf` preserves the active tab when already in detail mode (e.g. related-system links in `RelationshipsTab` / `SparePartsTab`)
- Inline `router.query.leaf` read keeps callback identity stable — no churn on `TreeNode`s

## Test plan
- [x] `yarn test src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts` — 6 tests (3 drive-cycles + 3 lockins)
- [x] `yarn test src/modules/systemHierarchy` — 22 suites / 147 tests pass
- [x] `yarn lint` — clean
- [ ] Manual: click leaf row → switch to History tab → click another tree node → detail stays open on History
- [ ] Manual: graph view → click another tree node → still graph
- [ ] Manual: detail of A on Relationships tab → click related-system link → stays on Relationships