### PR TITLE
feat(systemHierarchy): add graph tab to system detail view

### DIFF
--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1432,6 +1432,7 @@ export const messages = {
             relationships: 'Relationships',
             attachments: 'Attachments',
             history: 'History',
+            graph: 'Graph',
         },
         sidebar: {
             title: 'Quick Info',

--- a/src/modules/systemHierarchy/components/detail/SystemDetailTabs.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailTabs.cont.tsx
@@ -13,6 +13,7 @@ import { HIERARCHY_TABS } from '../../types/constants'
 import { hasPhysicalItem, hasSpareFor, hasSpareParts } from '../../utils/predicates'
 import { AttachmentsTabContainer } from '../tabs/AttachmentsTab.cont'
 import { DetailTabContainer } from '../tabs/DetailTab.cont'
+import { GraphTabContainer } from '../tabs/GraphTab.cont'
 import { HistoryTabContainer } from '../tabs/HistoryTab.cont'
 import { PersonsTabContainer } from '../tabs/PersonsTab.cont'
 import { PhysicalItemTabContainer } from '../tabs/PhysicalItemTab.cont'
@@ -104,6 +105,12 @@ export const SystemDetailTabsContainer: FC<SystemDetailTabsProps> = ({ system })
                 >
                     {fm({ id: message.systemHierarchy.tabs.history })}
                 </TabsTrigger>
+                <TabsTrigger
+                    value={HIERARCHY_TABS.GRAPH}
+                    data-testid="system-hierarchy-tab-graph"
+                >
+                    {fm({ id: message.systemHierarchy.tabs.graph })}
+                </TabsTrigger>
             </TabsList>
             <div className="flex-1 min-h-0">
                 <TabsContent
@@ -161,6 +168,12 @@ export const SystemDetailTabsContainer: FC<SystemDetailTabsProps> = ({ system })
                     className="h-full min-h-0 overflow-hidden"
                 >
                     <HistoryTabContainer system={system} />
+                </TabsContent>
+                <TabsContent
+                    value={HIERARCHY_TABS.GRAPH}
+                    className="h-full min-h-0 overflow-hidden"
+                >
+                    <GraphTabContainer system={system} />
                 </TabsContent>
             </div>
         </Tabs>

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailTabs.test.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailTabs.test.tsx
@@ -1,0 +1,122 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+
+import type { SystemLeaf } from '../../../types'
+import { HIERARCHY_TABS } from '../../../types/constants'
+import { SystemDetailTabsContainer } from '../SystemDetailTabs.cont'
+
+let activeTab: string = HIERARCHY_TABS.DETAIL
+
+jest.mock('../../../hooks/useHierarchyNavigation', () => ({
+    useHierarchyNavigation: () => ({
+        activeTab,
+        setActiveTab: jest.fn(),
+        selectedParentUid: null,
+        selectedLeafUid: 'sys-1',
+        activeView: 'tree',
+        selectParent: jest.fn(),
+        selectLeaf: jest.fn(),
+        setActiveView: jest.fn(),
+        goBackToLeaves: jest.fn(),
+    }),
+}))
+
+jest.mock('../../../hooks/queries/useSystemRelationships', () => ({
+    useSystemRelationships: () => ({
+        inbound: [],
+        outbound: [],
+        hasRelationships: false,
+        isLoading: false,
+        isError: false,
+    }),
+}))
+
+jest.mock('@/hooks/use-large-screen', () => ({
+    useIsLargeScreen: () => true,
+}))
+
+jest.mock('../../tabs/DetailTab.cont', () => ({
+    DetailTabContainer: () => <div data-testid="detail-tab-stub" />,
+}))
+jest.mock('../../tabs/PersonsTab.cont', () => ({
+    PersonsTabContainer: () => <div data-testid="persons-tab-stub" />,
+}))
+jest.mock('../../tabs/PhysicalItemTab.cont', () => ({
+    PhysicalItemTabContainer: () => <div data-testid="physical-item-tab-stub" />,
+}))
+jest.mock('../../tabs/SparePartsTab.cont', () => ({
+    SparePartsTabContainer: () => <div data-testid="spare-parts-tab-stub" />,
+}))
+jest.mock('../../tabs/SpareForTab.cont', () => ({
+    SpareForTabContainer: () => <div data-testid="spare-for-tab-stub" />,
+}))
+jest.mock('../../tabs/RelationshipsTab.cont', () => ({
+    RelationshipsTabContainer: () => <div data-testid="relationships-tab-stub" />,
+}))
+jest.mock('../../tabs/AttachmentsTab.cont', () => ({
+    AttachmentsTabContainer: () => <div data-testid="attachments-tab-stub" />,
+}))
+jest.mock('../../tabs/HistoryTab.cont', () => ({
+    HistoryTabContainer: () => <div data-testid="history-tab-stub" />,
+}))
+jest.mock('../../tabs/GraphTab.cont', () => ({
+    GraphTabContainer: ({ system }: { system: SystemLeaf }) => (
+        <div data-testid="graph-tab-stub" data-root-uid={system.uid} />
+    ),
+}))
+
+const messages: Record<string, string> = {
+    'systemHierarchy.tabs.detail': 'Detail',
+    'systemHierarchy.tabs.persons': 'Persons',
+    'systemHierarchy.tabs.physicalItem': 'Physical Item',
+    'systemHierarchy.tabs.spareParts': 'Spare Parts',
+    'systemHierarchy.tabs.spareFor': 'Spare For',
+    'systemHierarchy.tabs.relationships': 'Relationships',
+    'systemHierarchy.tabs.attachments': 'Attachments',
+    'systemHierarchy.tabs.history': 'History',
+    'systemHierarchy.tabs.graph': 'Graph',
+}
+
+const system: SystemLeaf = {
+    uid: 'sys-1',
+    name: 'Test System',
+    systemCode: 'SYS-001',
+    physicalItem: null,
+    parentPath: null,
+} as SystemLeaf
+
+const renderTabs = () =>
+    render(
+        <IntlProvider locale="en" messages={messages}>
+            <SystemDetailTabsContainer system={system} />
+        </IntlProvider>,
+    )
+
+describe('SystemDetailTabsContainer — Graph tab integration', () => {
+    beforeEach(() => {
+        activeTab = HIERARCHY_TABS.DETAIL
+    })
+
+    it('renders the Graph tab trigger after History', () => {
+        renderTabs()
+        const triggers = screen.getAllByRole('tab')
+        const labels = triggers.map(t => t.textContent)
+        const historyIdx = labels.indexOf('History')
+        const graphIdx = labels.indexOf('Graph')
+        expect(graphIdx).toBeGreaterThan(-1)
+        expect(graphIdx).toBe(historyIdx + 1)
+    })
+
+    it('Graph tab trigger has the expected testid', () => {
+        renderTabs()
+        expect(screen.getByTestId('system-hierarchy-tab-graph')).toBeInTheDocument()
+    })
+
+    it('renders GraphTabContainer with system uid when activeTab="graph"', () => {
+        activeTab = HIERARCHY_TABS.GRAPH
+        renderTabs()
+        const stub = screen.getByTestId('graph-tab-stub')
+        expect(stub).toHaveAttribute('data-root-uid', 'sys-1')
+    })
+})

--- a/src/modules/systemHierarchy/components/graph/RelationshipGraph.cont.tsx
+++ b/src/modules/systemHierarchy/components/graph/RelationshipGraph.cont.tsx
@@ -1,12 +1,17 @@
 import type { FC } from 'react'
 
-import { useRelationshipGraphContainerState } from '@/modules/systemHierarchy/hooks/useRelationshipGraphContainerState'
+import { useDetailGraphState } from '@/modules/systemHierarchy/hooks/useDetailGraphState'
+import { useLeavesGraphState } from '@/modules/systemHierarchy/hooks/useLeavesGraphState'
 
 import { RelationshipGraphCanvas } from './RelationshipGraphCanvas.comp'
 import { RelationshipGraphHeader } from './RelationshipGraphHeader.comp'
 
-export const RelationshipGraphContainer: FC = () => {
-    const { headerProps, canvasProps } = useRelationshipGraphContainerState()
+interface RelationshipGraphContainerProps {
+    rootUid?: string | null
+}
+
+const LeavesPanelGraph: FC = () => {
+    const { headerProps, canvasProps } = useLeavesGraphState()
 
     return (
         <div className="h-full w-full flex flex-col">
@@ -14,4 +19,20 @@ export const RelationshipGraphContainer: FC = () => {
             <RelationshipGraphCanvas {...canvasProps} />
         </div>
     )
+}
+
+const DetailGraph: FC<{ rootUid: string }> = ({ rootUid }) => {
+    const { headerProps, canvasProps } = useDetailGraphState(rootUid)
+
+    return (
+        <div className="h-full w-full flex flex-col">
+            <RelationshipGraphHeader {...headerProps} />
+            <RelationshipGraphCanvas {...canvasProps} />
+        </div>
+    )
+}
+
+export const RelationshipGraphContainer: FC<RelationshipGraphContainerProps> = ({ rootUid }) => {
+    if (rootUid) return <DetailGraph rootUid={rootUid} />
+    return <LeavesPanelGraph />
 }

--- a/src/modules/systemHierarchy/components/tabs/GraphTab.cont.tsx
+++ b/src/modules/systemHierarchy/components/tabs/GraphTab.cont.tsx
@@ -1,0 +1,14 @@
+import type { FC } from 'react'
+
+import type { SystemLeaf } from '../../types'
+import { RelationshipGraphContainer } from '../graph/RelationshipGraph.cont'
+
+interface GraphTabProps {
+    system: SystemLeaf
+}
+
+export const GraphTabContainer: FC<GraphTabProps> = ({ system }) => (
+    <div className="h-full w-full">
+        <RelationshipGraphContainer rootUid={system.uid} />
+    </div>
+)

--- a/src/modules/systemHierarchy/components/tabs/__tests__/GraphTab.test.tsx
+++ b/src/modules/systemHierarchy/components/tabs/__tests__/GraphTab.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+
+import type { SystemLeaf } from '../../../types'
+import { GraphTabContainer } from '../GraphTab.cont'
+
+jest.mock('../../graph/RelationshipGraph.cont', () => ({
+    RelationshipGraphContainer: ({ rootUid }: { rootUid?: string | null }) => (
+        <div data-testid="relationship-graph-stub" data-root-uid={rootUid ?? ''} />
+    ),
+}))
+
+const system: SystemLeaf = {
+    uid: 'sys-42',
+    name: 'Beam Diagnostics',
+    systemCode: 'BD-001',
+    physicalItem: null,
+    parentPath: null,
+} as SystemLeaf
+
+describe('GraphTabContainer', () => {
+    it('renders RelationshipGraphContainer with the system uid as rootUid', () => {
+        render(<GraphTabContainer system={system} />)
+        const stub = screen.getByTestId('relationship-graph-stub')
+        expect(stub).toHaveAttribute('data-root-uid', 'sys-42')
+    })
+})

--- a/src/modules/systemHierarchy/hooks/__tests__/useDetailGraphFilters.test.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDetailGraphFilters.test.tsx
@@ -10,7 +10,7 @@ import { useDetailGraphFilters } from '../useGraphFilters'
 const STORAGE_KEY = 'systemHierarchy-detail-graph'
 
 const resetStore = () => {
-    localStorage.clear()
+    localStorage.removeItem(STORAGE_KEY)
     useDetailGraphStore.setState({
         relationshipTypes: null,
         layoutMode: GRAPH_LAYOUT_MODES.VERTICAL,
@@ -42,14 +42,16 @@ describe('useDetailGraphFilters', () => {
         expect(persisted.relationshipTypes).toContain('HAS_SUBSYSTEM')
     })
 
-    it('toggleRelationshipType twice removes the type back to 8-item list', () => {
+    it('toggleRelationshipType twice normalizes back to null sentinel (matches default)', () => {
         const { result } = renderHook(() => useDetailGraphFilters())
         act(() => {
             result.current.toggleRelationshipType('HAS_SUBSYSTEM')
             result.current.toggleRelationshipType('HAS_SUBSYSTEM')
         })
         expect(result.current.filters.relationshipTypes).not.toContain('HAS_SUBSYSTEM')
-        expect(useDetailGraphStore.getState().relationshipTypes).toEqual(
+        // Normalization: explicit list equal to default collapses to null sentinel for forward-compat.
+        expect(useDetailGraphStore.getState().relationshipTypes).toBeNull()
+        expect(result.current.filters.relationshipTypes).toEqual(
             getDefaultDetailGraphRelationshipTypes(),
         )
     })

--- a/src/modules/systemHierarchy/hooks/__tests__/useDetailGraphFilters.test.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDetailGraphFilters.test.tsx
@@ -79,6 +79,28 @@ describe('useDetailGraphFilters', () => {
         )
     })
 
+    it('toggling off the last remaining type writes null sentinel (no empty-list inversion)', () => {
+        const { result } = renderHook(() => useDetailGraphFilters())
+        act(() => {
+            result.current.toggleRelationshipType('HAS_SUBSYSTEM')
+        })
+        const explicitNine = useDetailGraphStore.getState().relationshipTypes ?? []
+        expect(explicitNine).toHaveLength(9)
+
+        act(() => {
+            useDetailGraphStore.getState().setRelationshipTypes(['IS_SPARE_FOR'])
+        })
+        expect(useDetailGraphStore.getState().relationshipTypes).toEqual(['IS_SPARE_FOR'])
+
+        act(() => {
+            result.current.toggleRelationshipType('IS_SPARE_FOR')
+        })
+        expect(useDetailGraphStore.getState().relationshipTypes).toBeNull()
+        expect(result.current.filters.relationshipTypes).toEqual(
+            getDefaultDetailGraphRelationshipTypes(),
+        )
+    })
+
     it('search is session-only — does not persist to localStorage', () => {
         const { result } = renderHook(() => useDetailGraphFilters())
         act(() => {

--- a/src/modules/systemHierarchy/hooks/__tests__/useDetailGraphFilters.test.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDetailGraphFilters.test.tsx
@@ -1,0 +1,93 @@
+import { act, renderHook } from '@testing-library/react'
+
+import {
+    getDefaultDetailGraphRelationshipTypes,
+    useDetailGraphStore,
+} from '../../store/useDetailGraphStore'
+import { GRAPH_LAYOUT_MODES } from '../../types/graph'
+import { useDetailGraphFilters } from '../useGraphFilters'
+
+const STORAGE_KEY = 'systemHierarchy-detail-graph'
+
+const resetStore = () => {
+    localStorage.clear()
+    useDetailGraphStore.setState({
+        relationshipTypes: null,
+        layoutMode: GRAPH_LAYOUT_MODES.VERTICAL,
+        expandedNodes: [],
+        expandedEdges: [],
+    })
+}
+
+describe('useDetailGraphFilters', () => {
+    beforeEach(() => {
+        resetStore()
+    })
+
+    it('returns default allowlist (all-except-HAS_SUBSYSTEM) when store has null sentinel', () => {
+        const { result } = renderHook(() => useDetailGraphFilters())
+        const expected = getDefaultDetailGraphRelationshipTypes()
+        expect(result.current.filters.relationshipTypes).toEqual(expected)
+        expect(result.current.filters.relationshipTypes).not.toContain('HAS_SUBSYSTEM')
+    })
+
+    it('toggleRelationshipType("HAS_SUBSYSTEM") promotes filter to explicit 9-item list', () => {
+        const { result } = renderHook(() => useDetailGraphFilters())
+        act(() => {
+            result.current.toggleRelationshipType('HAS_SUBSYSTEM')
+        })
+        expect(result.current.filters.relationshipTypes).toContain('HAS_SUBSYSTEM')
+        expect(useDetailGraphStore.getState().relationshipTypes).toContain('HAS_SUBSYSTEM')
+        const persisted = JSON.parse(localStorage.getItem(STORAGE_KEY) as string).state
+        expect(persisted.relationshipTypes).toContain('HAS_SUBSYSTEM')
+    })
+
+    it('toggleRelationshipType twice removes the type back to 8-item list', () => {
+        const { result } = renderHook(() => useDetailGraphFilters())
+        act(() => {
+            result.current.toggleRelationshipType('HAS_SUBSYSTEM')
+            result.current.toggleRelationshipType('HAS_SUBSYSTEM')
+        })
+        expect(result.current.filters.relationshipTypes).not.toContain('HAS_SUBSYSTEM')
+        expect(useDetailGraphStore.getState().relationshipTypes).toEqual(
+            getDefaultDetailGraphRelationshipTypes(),
+        )
+    })
+
+    it('resetFilters clears search/level/type AND restores null sentinel for relationshipTypes', () => {
+        const { result } = renderHook(() => useDetailGraphFilters())
+        act(() => {
+            result.current.setSearch('turbo')
+            result.current.toggleSystemLevel('Lvl1')
+            result.current.setSystemType('Pump')
+            result.current.toggleRelationshipType('HAS_SUBSYSTEM')
+        })
+        expect(result.current.filters.search).toBe('turbo')
+        expect(result.current.filters.systemLevels).toEqual(['Lvl1'])
+        expect(result.current.filters.systemType).toBe('Pump')
+        expect(useDetailGraphStore.getState().relationshipTypes).toContain('HAS_SUBSYSTEM')
+
+        act(() => {
+            result.current.resetFilters()
+        })
+        expect(result.current.filters.search).toBe('')
+        expect(result.current.filters.systemLevels).toEqual([])
+        expect(result.current.filters.systemType).toBeNull()
+        expect(useDetailGraphStore.getState().relationshipTypes).toBeNull()
+        expect(result.current.filters.relationshipTypes).toEqual(
+            getDefaultDetailGraphRelationshipTypes(),
+        )
+    })
+
+    it('search is session-only — does not persist to localStorage', () => {
+        const { result } = renderHook(() => useDetailGraphFilters())
+        act(() => {
+            result.current.setSearch('turbo')
+        })
+        const raw = localStorage.getItem(STORAGE_KEY)
+        if (raw) {
+            const persisted = JSON.parse(raw).state
+            expect(persisted.search).toBeUndefined()
+        }
+    })
+})

--- a/src/modules/systemHierarchy/hooks/useDetailGraphState.ts
+++ b/src/modules/systemHierarchy/hooks/useDetailGraphState.ts
@@ -1,0 +1,27 @@
+import { useDetailGraphStore } from '../store/useDetailGraphStore'
+import { useDetailGraphFilters } from './useGraphFilters'
+import { useRelationshipGraphContainerState } from './useRelationshipGraphContainerState'
+
+export const useDetailGraphState = (rootUid: string) => {
+    const layoutMode = useDetailGraphStore(state => state.layoutMode)
+    const setLayoutMode = useDetailGraphStore(state => state.setLayoutMode)
+    const expandedNodes = useDetailGraphStore(state => state.expandedNodes)
+    const expandedEdges = useDetailGraphStore(state => state.expandedEdges)
+    const addExpanded = useDetailGraphStore(state => state.addExpanded)
+    const setExpanded = useDetailGraphStore(state => state.setExpanded)
+    const resetExpanded = useDetailGraphStore(state => state.resetExpanded)
+
+    const filtersHook = useDetailGraphFilters()
+
+    return useRelationshipGraphContainerState({
+        rootUid,
+        layoutMode,
+        setLayoutMode,
+        expandedNodes,
+        expandedEdges,
+        addExpanded,
+        setExpanded,
+        resetExpanded,
+        filtersHook,
+    })
+}

--- a/src/modules/systemHierarchy/hooks/useGraphFilters.ts
+++ b/src/modules/systemHierarchy/hooks/useGraphFilters.ts
@@ -112,8 +112,13 @@ export const useDetailGraphFilters = (): GraphFiltersApi => {
             const next = current.includes(type)
                 ? current.filter(t => t !== type)
                 : [...current, type]
-            // Empty list would invert filterEdges to "show all" (incl. HAS_SUBSYSTEM); fall back to default.
-            setStoredRelationshipTypes(next.length === 0 ? null : next)
+            // Normalize to null when:
+            // - empty (would invert filterEdges to "show all" incl. HAS_SUBSYSTEM), or
+            // - equals default (so future registry additions auto-flow in).
+            const defaults = getDefaultDetailGraphRelationshipTypes()
+            const matchesDefault =
+                next.length === defaults.length && next.every(t => defaults.includes(t))
+            setStoredRelationshipTypes(next.length === 0 || matchesDefault ? null : next)
         },
         [setStoredRelationshipTypes],
     )

--- a/src/modules/systemHierarchy/hooks/useGraphFilters.ts
+++ b/src/modules/systemHierarchy/hooks/useGraphFilters.ts
@@ -6,7 +6,16 @@ import {
 } from '../store/useDetailGraphStore'
 import { DEFAULT_GRAPH_FILTERS, type GraphFilterState } from '../utils/graphFilters'
 
-export const useGraphFilters = () => {
+export interface GraphFiltersApi {
+    filters: GraphFilterState
+    setSearch: (value: string) => void
+    toggleSystemLevel: (level: string) => void
+    setSystemType: (value: string | null) => void
+    toggleRelationshipType: (type: string) => void
+    resetFilters: () => void
+}
+
+export const useGraphFilters = (): GraphFiltersApi => {
     const [filters, setFilters] = useState<GraphFilterState>(DEFAULT_GRAPH_FILTERS)
 
     const setSearch = useCallback((search: string) => {
@@ -59,7 +68,7 @@ export const useGraphFilters = () => {
     )
 }
 
-export const useDetailGraphFilters = () => {
+export const useDetailGraphFilters = (): GraphFiltersApi => {
     const storedRelationshipTypes = useDetailGraphStore(state => state.relationshipTypes)
     const setStoredRelationshipTypes = useDetailGraphStore(state => state.setRelationshipTypes)
 
@@ -103,7 +112,8 @@ export const useDetailGraphFilters = () => {
             const next = current.includes(type)
                 ? current.filter(t => t !== type)
                 : [...current, type]
-            setStoredRelationshipTypes(next)
+            // Empty list would invert filterEdges to "show all" (incl. HAS_SUBSYSTEM); fall back to default.
+            setStoredRelationshipTypes(next.length === 0 ? null : next)
         },
         [setStoredRelationshipTypes],
     )

--- a/src/modules/systemHierarchy/hooks/useGraphFilters.ts
+++ b/src/modules/systemHierarchy/hooks/useGraphFilters.ts
@@ -1,5 +1,9 @@
 import { useCallback, useMemo, useState } from 'react'
 
+import {
+    getDefaultDetailGraphRelationshipTypes,
+    useDetailGraphStore,
+} from '../store/useDetailGraphStore'
 import { DEFAULT_GRAPH_FILTERS, type GraphFilterState } from '../utils/graphFilters'
 
 export const useGraphFilters = () => {
@@ -34,6 +38,82 @@ export const useGraphFilters = () => {
     const resetFilters = useCallback(() => {
         setFilters(DEFAULT_GRAPH_FILTERS)
     }, [])
+
+    return useMemo(
+        () => ({
+            filters,
+            setSearch,
+            toggleSystemLevel,
+            setSystemType,
+            toggleRelationshipType,
+            resetFilters,
+        }),
+        [
+            filters,
+            setSearch,
+            toggleSystemLevel,
+            setSystemType,
+            toggleRelationshipType,
+            resetFilters,
+        ],
+    )
+}
+
+export const useDetailGraphFilters = () => {
+    const storedRelationshipTypes = useDetailGraphStore(state => state.relationshipTypes)
+    const setStoredRelationshipTypes = useDetailGraphStore(state => state.setRelationshipTypes)
+
+    const [search, setSearchState] = useState<string>('')
+    const [systemLevels, setSystemLevels] = useState<string[]>([])
+    const [systemType, setSystemTypeState] = useState<string | null>(null)
+
+    const effectiveRelationshipTypes = useMemo(
+        () => storedRelationshipTypes ?? getDefaultDetailGraphRelationshipTypes(),
+        [storedRelationshipTypes],
+    )
+
+    const filters: GraphFilterState = useMemo(
+        () => ({
+            search,
+            systemLevels,
+            systemType,
+            relationshipTypes: effectiveRelationshipTypes,
+        }),
+        [search, systemLevels, systemType, effectiveRelationshipTypes],
+    )
+
+    const setSearch = useCallback((value: string) => {
+        setSearchState(value)
+    }, [])
+
+    const toggleSystemLevel = useCallback((level: string) => {
+        setSystemLevels(prev =>
+            prev.includes(level) ? prev.filter(l => l !== level) : [...prev, level],
+        )
+    }, [])
+
+    const setSystemType = useCallback((value: string | null) => {
+        setSystemTypeState(value)
+    }, [])
+
+    const toggleRelationshipType = useCallback(
+        (type: string) => {
+            const stored = useDetailGraphStore.getState().relationshipTypes
+            const current = stored ?? getDefaultDetailGraphRelationshipTypes()
+            const next = current.includes(type)
+                ? current.filter(t => t !== type)
+                : [...current, type]
+            setStoredRelationshipTypes(next)
+        },
+        [setStoredRelationshipTypes],
+    )
+
+    const resetFilters = useCallback(() => {
+        setSearchState('')
+        setSystemLevels([])
+        setSystemTypeState(null)
+        setStoredRelationshipTypes(null)
+    }, [setStoredRelationshipTypes])
 
     return useMemo(
         () => ({

--- a/src/modules/systemHierarchy/hooks/useLeavesGraphState.ts
+++ b/src/modules/systemHierarchy/hooks/useLeavesGraphState.ts
@@ -1,0 +1,29 @@
+import { useHierarchyStore } from '../store/useHierarchyStore'
+import { useGraphFilters } from './useGraphFilters'
+import { useHierarchyNavigation } from './useHierarchyNavigation'
+import { useRelationshipGraphContainerState } from './useRelationshipGraphContainerState'
+
+export const useLeavesGraphState = () => {
+    const { selectedParentUid } = useHierarchyNavigation()
+    const graphLayoutMode = useHierarchyStore(state => state.graphLayoutMode)
+    const setGraphLayoutMode = useHierarchyStore(state => state.setGraphLayoutMode)
+    const graphExpandedNodes = useHierarchyStore(state => state.graphExpandedNodes)
+    const graphExpandedEdges = useHierarchyStore(state => state.graphExpandedEdges)
+    const addGraphExpanded = useHierarchyStore(state => state.addGraphExpanded)
+    const setGraphExpanded = useHierarchyStore(state => state.setGraphExpanded)
+    const resetGraphExpanded = useHierarchyStore(state => state.resetGraphExpanded)
+
+    const filtersHook = useGraphFilters()
+
+    return useRelationshipGraphContainerState({
+        rootUid: selectedParentUid,
+        layoutMode: graphLayoutMode,
+        setLayoutMode: setGraphLayoutMode,
+        expandedNodes: graphExpandedNodes,
+        expandedEdges: graphExpandedEdges,
+        addExpanded: addGraphExpanded,
+        setExpanded: setGraphExpanded,
+        resetExpanded: resetGraphExpanded,
+        filtersHook,
+    })
+}

--- a/src/modules/systemHierarchy/hooks/useRelationshipGraphContainerState.ts
+++ b/src/modules/systemHierarchy/hooks/useRelationshipGraphContainerState.ts
@@ -6,7 +6,7 @@ import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 import type { GraphLayoutMode, RelationshipGraphEdge, RelationshipGraphNode } from '../types/graph'
 import { isNodeScopeKey, toGraphScopeKey } from '../utils/graphScope'
 import { useRelationshipGraph } from './queries/useRelationshipGraph'
-import type { useDetailGraphFilters, useGraphFilters } from './useGraphFilters'
+import type { GraphFiltersApi } from './useGraphFilters'
 import { useHierarchyNavigation } from './useHierarchyNavigation'
 import { useRelationshipGraphApiQuery } from './useRelationshipGraphApiQuery'
 import { useRelationshipGraphExpansionActions } from './useRelationshipGraphExpansionActions'
@@ -15,10 +15,6 @@ import { useRelationshipGraphInteractions } from './useRelationshipGraphInteract
 import { useRelationshipGraphScopes } from './useRelationshipGraphScopes'
 import { useRelationshipGraphViewModel } from './useRelationshipGraphViewModel'
 import { useSystemCopyPaste } from './useSystemCopyPaste'
-
-type FiltersHookResult =
-    | ReturnType<typeof useGraphFilters>
-    | ReturnType<typeof useDetailGraphFilters>
 
 interface UseRelationshipGraphContainerStateParams {
     rootUid: string | null
@@ -29,7 +25,7 @@ interface UseRelationshipGraphContainerStateParams {
     addExpanded: (nodes: RelationshipGraphNode[], edges: RelationshipGraphEdge[]) => void
     setExpanded: (nodes: RelationshipGraphNode[], edges: RelationshipGraphEdge[]) => void
     resetExpanded: () => void
-    filtersHook: FiltersHookResult
+    filtersHook: GraphFiltersApi
 }
 
 export const useRelationshipGraphContainerState = ({

--- a/src/modules/systemHierarchy/hooks/useRelationshipGraphContainerState.ts
+++ b/src/modules/systemHierarchy/hooks/useRelationshipGraphContainerState.ts
@@ -3,10 +3,10 @@ import { useCallback, useMemo, useState } from 'react'
 import { useSystemEditSheet } from '@/modules/shared/system/system-edit/useSystemEditSheet'
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 
-import { useHierarchyStore } from '../store/useHierarchyStore'
+import type { GraphLayoutMode, RelationshipGraphEdge, RelationshipGraphNode } from '../types/graph'
 import { isNodeScopeKey, toGraphScopeKey } from '../utils/graphScope'
 import { useRelationshipGraph } from './queries/useRelationshipGraph'
-import { useGraphFilters } from './useGraphFilters'
+import type { useDetailGraphFilters, useGraphFilters } from './useGraphFilters'
 import { useHierarchyNavigation } from './useHierarchyNavigation'
 import { useRelationshipGraphApiQuery } from './useRelationshipGraphApiQuery'
 import { useRelationshipGraphExpansionActions } from './useRelationshipGraphExpansionActions'
@@ -16,17 +16,34 @@ import { useRelationshipGraphScopes } from './useRelationshipGraphScopes'
 import { useRelationshipGraphViewModel } from './useRelationshipGraphViewModel'
 import { useSystemCopyPaste } from './useSystemCopyPaste'
 
-export const useRelationshipGraphContainerState = () => {
-    const { selectedParentUid, selectLeaf } = useHierarchyNavigation()
-    const {
-        graphLayoutMode,
-        setGraphLayoutMode,
-        graphExpandedNodes,
-        graphExpandedEdges,
-        addGraphExpanded,
-        setGraphExpanded,
-        resetGraphExpanded,
-    } = useHierarchyStore()
+type FiltersHookResult =
+    | ReturnType<typeof useGraphFilters>
+    | ReturnType<typeof useDetailGraphFilters>
+
+interface UseRelationshipGraphContainerStateParams {
+    rootUid: string | null
+    layoutMode: GraphLayoutMode
+    setLayoutMode: (mode: GraphLayoutMode) => void
+    expandedNodes: RelationshipGraphNode[]
+    expandedEdges: RelationshipGraphEdge[]
+    addExpanded: (nodes: RelationshipGraphNode[], edges: RelationshipGraphEdge[]) => void
+    setExpanded: (nodes: RelationshipGraphNode[], edges: RelationshipGraphEdge[]) => void
+    resetExpanded: () => void
+    filtersHook: FiltersHookResult
+}
+
+export const useRelationshipGraphContainerState = ({
+    rootUid,
+    layoutMode: storedLayoutMode,
+    setLayoutMode: setStoredLayoutMode,
+    expandedNodes,
+    expandedEdges,
+    addExpanded,
+    setExpanded,
+    resetExpanded,
+    filtersHook,
+}: UseRelationshipGraphContainerStateParams) => {
+    const { selectLeaf } = useHierarchyNavigation()
     const { openModal } = useDynamicModalStore()
     const openSystemEdit = useSystemEditSheet()
     const [fitViewVersion, setFitViewVersion] = useState(0)
@@ -34,7 +51,7 @@ export const useRelationshipGraphContainerState = () => {
         setFitViewVersion(version => version + 1)
     }, [])
 
-    const graphUid = selectedParentUid
+    const graphUid = rootUid
     const graphScopeKey = useMemo(() => toGraphScopeKey(graphUid), [graphUid])
 
     const {
@@ -44,7 +61,7 @@ export const useRelationshipGraphContainerState = () => {
         setSystemType,
         toggleRelationshipType,
         resetFilters,
-    } = useGraphFilters()
+    } = filtersHook
     const { apiFilterQuery, filterQueryKey, initialScopeQuery } =
         useRelationshipGraphApiQuery(filters)
 
@@ -72,11 +89,11 @@ export const useRelationshipGraphContainerState = () => {
         applyPageToScopeState,
         setLoadMoreTypeLoading,
     } = useRelationshipGraphScopes({
-        selectedParentUid,
+        graphUid,
         filterQueryKey,
         graphScopeKey,
         apiMeta,
-        resetGraphExpanded,
+        resetGraphExpanded: resetExpanded,
     })
 
     const {
@@ -93,8 +110,8 @@ export const useRelationshipGraphContainerState = () => {
     } = useRelationshipGraphViewModel({
         apiNodes,
         apiEdges,
-        graphExpandedNodes,
-        graphExpandedEdges,
+        graphExpandedNodes: expandedNodes,
+        graphExpandedEdges: expandedEdges,
         graphUid,
         expandedScopeUids,
         filters,
@@ -122,8 +139,8 @@ export const useRelationshipGraphContainerState = () => {
             activeScopeKey,
             scopeStates,
             relationshipTypeFilters: filters.relationshipTypes,
-            addGraphExpanded,
-            setGraphExpanded,
+            addGraphExpanded: addExpanded,
+            setGraphExpanded: setExpanded,
             registerExpandedScopeUid,
             setNodeScopeMeta,
             setNodeScopesMeta,
@@ -142,8 +159,8 @@ export const useRelationshipGraphContainerState = () => {
             visibleNodes,
             filteredEdges,
             hiddenRelationshipsByNodeUid,
-            graphLayoutMode,
-            setGraphLayoutMode,
+            graphLayoutMode: storedLayoutMode,
+            setGraphLayoutMode: setStoredLayoutMode,
             onExpand: handleExpand,
             onNodeLoadMore: handleNodeLoadMore,
             onViewDetail: handleViewDetail,

--- a/src/modules/systemHierarchy/hooks/useRelationshipGraphScopes.ts
+++ b/src/modules/systemHierarchy/hooks/useRelationshipGraphScopes.ts
@@ -10,7 +10,7 @@ import {
 } from '../utils/graphScope'
 
 interface UseRelationshipGraphScopesParams {
-    selectedParentUid: string | null
+    graphUid: string | null
     filterQueryKey: string
     graphScopeKey: string
     apiMeta?: RelationshipGraphMeta
@@ -31,7 +31,7 @@ interface UseRelationshipGraphScopesResult {
 }
 
 export const useRelationshipGraphScopes = ({
-    selectedParentUid,
+    graphUid,
     filterQueryKey,
     graphScopeKey,
     apiMeta,
@@ -42,18 +42,18 @@ export const useRelationshipGraphScopes = ({
     const [loadMoreLoading, setLoadMoreLoading] = useState<Record<string, boolean>>({})
     const [expandedScopeUids, setExpandedScopeUids] = useState<string[]>([])
 
-    const prevParentRef = useRef(selectedParentUid)
+    const prevGraphUidRef = useRef(graphUid)
     const previousFilterQueryKeyRef = useRef(filterQueryKey)
 
     useEffect(() => {
-        if (prevParentRef.current !== selectedParentUid) {
-            prevParentRef.current = selectedParentUid
+        if (prevGraphUidRef.current !== graphUid) {
+            prevGraphUidRef.current = graphUid
             resetGraphExpanded()
             setExpandedScopeUids([])
             setScopeStates({})
             setLoadMoreLoading({})
         }
-    }, [selectedParentUid, resetGraphExpanded])
+    }, [graphUid, resetGraphExpanded])
 
     useEffect(() => {
         if (previousFilterQueryKeyRef.current === filterQueryKey) return

--- a/src/modules/systemHierarchy/store/__tests__/useDetailGraphStore.test.ts
+++ b/src/modules/systemHierarchy/store/__tests__/useDetailGraphStore.test.ts
@@ -1,0 +1,102 @@
+import { act } from '@testing-library/react'
+
+import { GRAPH_LAYOUT_MODES, type RelationshipGraphEdge, type RelationshipGraphNode } from '../../types/graph'
+import {
+    getDefaultDetailGraphRelationshipTypes,
+    useDetailGraphStore,
+} from '../useDetailGraphStore'
+
+const STORAGE_KEY = 'systemHierarchy-detail-graph'
+
+const resetStore = () => {
+    localStorage.clear()
+    useDetailGraphStore.setState({
+        relationshipTypes: null,
+        layoutMode: GRAPH_LAYOUT_MODES.VERTICAL,
+        expandedNodes: [],
+        expandedEdges: [],
+    })
+}
+
+const node = (uid: string): RelationshipGraphNode =>
+    ({
+        uid,
+        name: uid,
+        systemCode: null,
+        systemLevel: 'Lvl1',
+        systemType: null,
+    }) as unknown as RelationshipGraphNode
+
+const edge = (uid: string, source: string, target: string): RelationshipGraphEdge =>
+    ({
+        uid,
+        source,
+        target,
+        relationship: 'IS_SPARE_FOR',
+    }) as unknown as RelationshipGraphEdge
+
+describe('useDetailGraphStore', () => {
+    beforeEach(() => {
+        resetStore()
+    })
+
+    it('starts with relationshipTypes === null (sentinel for "use default")', () => {
+        expect(useDetailGraphStore.getState().relationshipTypes).toBeNull()
+    })
+
+    it('default helper returns all RELATIONSHIP_DEFINITIONS keys except HAS_SUBSYSTEM', () => {
+        const defaults = getDefaultDetailGraphRelationshipTypes()
+        expect(defaults).not.toContain('HAS_SUBSYSTEM')
+        expect(defaults.length).toBeGreaterThan(0)
+        expect(defaults).toContain('IS_SPARE_FOR')
+    })
+
+    it('setRelationshipTypes writes explicit list', () => {
+        act(() => {
+            useDetailGraphStore.getState().setRelationshipTypes(['IS_SPARE_FOR'])
+        })
+        expect(useDetailGraphStore.getState().relationshipTypes).toEqual(['IS_SPARE_FOR'])
+    })
+
+    it('setRelationshipTypes(null) restores sentinel for default', () => {
+        act(() => {
+            useDetailGraphStore.getState().setRelationshipTypes(['IS_SPARE_FOR'])
+            useDetailGraphStore.getState().setRelationshipTypes(null)
+        })
+        expect(useDetailGraphStore.getState().relationshipTypes).toBeNull()
+    })
+
+    it('partialize persists only relationshipTypes + layoutMode', () => {
+        act(() => {
+            useDetailGraphStore.getState().setRelationshipTypes(['IS_SPARE_FOR'])
+            useDetailGraphStore.getState().setLayoutMode(GRAPH_LAYOUT_MODES.HORIZONTAL)
+            useDetailGraphStore.getState().addExpanded([node('a')], [edge('e1', 'a', 'b')])
+        })
+        const raw = localStorage.getItem(STORAGE_KEY)
+        expect(raw).not.toBeNull()
+        const persisted = JSON.parse(raw as string).state
+        expect(persisted.relationshipTypes).toEqual(['IS_SPARE_FOR'])
+        expect(persisted.layoutMode).toEqual(GRAPH_LAYOUT_MODES.HORIZONTAL)
+        expect(persisted.expandedNodes).toBeUndefined()
+        expect(persisted.expandedEdges).toBeUndefined()
+    })
+
+    it('addExpanded deduplicates by uid', () => {
+        act(() => {
+            useDetailGraphStore.getState().addExpanded([node('a'), node('b')], [edge('e1', 'a', 'b')])
+            useDetailGraphStore.getState().addExpanded([node('a'), node('c')], [edge('e1', 'a', 'b'), edge('e2', 'b', 'c')])
+        })
+        const { expandedNodes, expandedEdges } = useDetailGraphStore.getState()
+        expect(expandedNodes.map(n => n.uid)).toEqual(['a', 'b', 'c'])
+        expect(expandedEdges.map(e => e.uid)).toEqual(['e1', 'e2'])
+    })
+
+    it('resetExpanded clears nodes + edges', () => {
+        act(() => {
+            useDetailGraphStore.getState().addExpanded([node('a')], [edge('e1', 'a', 'b')])
+            useDetailGraphStore.getState().resetExpanded()
+        })
+        expect(useDetailGraphStore.getState().expandedNodes).toEqual([])
+        expect(useDetailGraphStore.getState().expandedEdges).toEqual([])
+    })
+})

--- a/src/modules/systemHierarchy/store/__tests__/useDetailGraphStore.test.ts
+++ b/src/modules/systemHierarchy/store/__tests__/useDetailGraphStore.test.ts
@@ -9,7 +9,7 @@ import {
 const STORAGE_KEY = 'systemHierarchy-detail-graph'
 
 const resetStore = () => {
-    localStorage.clear()
+    localStorage.removeItem(STORAGE_KEY)
     useDetailGraphStore.setState({
         relationshipTypes: null,
         layoutMode: GRAPH_LAYOUT_MODES.VERTICAL,

--- a/src/modules/systemHierarchy/store/useDetailGraphStore.ts
+++ b/src/modules/systemHierarchy/store/useDetailGraphStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+import type { GraphLayoutMode, RelationshipGraphEdge, RelationshipGraphNode } from '../types/graph'
+import { GRAPH_LAYOUT_MODES, RELATIONSHIP_DEFINITIONS } from '../types/graph'
+
+interface DetailGraphStore {
+    relationshipTypes: string[] | null
+    layoutMode: GraphLayoutMode
+    expandedNodes: RelationshipGraphNode[]
+    expandedEdges: RelationshipGraphEdge[]
+    setRelationshipTypes: (types: string[] | null) => void
+    setLayoutMode: (mode: GraphLayoutMode) => void
+    addExpanded: (nodes: RelationshipGraphNode[], edges: RelationshipGraphEdge[]) => void
+    setExpanded: (nodes: RelationshipGraphNode[], edges: RelationshipGraphEdge[]) => void
+    resetExpanded: () => void
+}
+
+export const useDetailGraphStore = create<DetailGraphStore>()(
+    persist(
+        (set, get) => ({
+            relationshipTypes: null,
+            layoutMode: GRAPH_LAYOUT_MODES.VERTICAL as GraphLayoutMode,
+            expandedNodes: [],
+            expandedEdges: [],
+            setRelationshipTypes: types => set({ relationshipTypes: types }),
+            setLayoutMode: mode => set({ layoutMode: mode }),
+            addExpanded: (nodes, edges) => {
+                const { expandedNodes, expandedEdges } = get()
+                const seenNodes = new Set(expandedNodes.map(n => n.uid))
+                const seenEdges = new Set(expandedEdges.map(e => e.uid))
+                set({
+                    expandedNodes: [
+                        ...expandedNodes,
+                        ...nodes.filter(n => !seenNodes.has(n.uid)),
+                    ],
+                    expandedEdges: [
+                        ...expandedEdges,
+                        ...edges.filter(e => !seenEdges.has(e.uid)),
+                    ],
+                })
+            },
+            setExpanded: (nodes, edges) =>
+                set({ expandedNodes: nodes, expandedEdges: edges }),
+            resetExpanded: () => set({ expandedNodes: [], expandedEdges: [] }),
+        }),
+        {
+            name: 'systemHierarchy-detail-graph',
+            partialize: state => ({
+                relationshipTypes: state.relationshipTypes,
+                layoutMode: state.layoutMode,
+            }),
+        },
+    ),
+)
+
+export const getDefaultDetailGraphRelationshipTypes = (): string[] =>
+    Object.keys(RELATIONSHIP_DEFINITIONS).filter(type => type !== 'HAS_SUBSYSTEM')

--- a/src/modules/systemHierarchy/store/useDetailGraphStore.ts
+++ b/src/modules/systemHierarchy/store/useDetailGraphStore.ts
@@ -1,8 +1,19 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
 
-import type { GraphLayoutMode, RelationshipGraphEdge, RelationshipGraphNode } from '../types/graph'
+import type {
+    GraphLayoutMode,
+    RelationshipGraphEdge,
+    RelationshipGraphNode,
+    RelationshipType,
+} from '../types/graph'
 import { GRAPH_LAYOUT_MODES, RELATIONSHIP_DEFINITIONS } from '../types/graph'
+
+const HIDDEN_BY_DEFAULT: RelationshipType[] = ['HAS_SUBSYSTEM']
+
+const DEFAULT_DETAIL_GRAPH_RELATIONSHIP_TYPES: string[] = (
+    Object.keys(RELATIONSHIP_DEFINITIONS) as RelationshipType[]
+).filter(type => !HIDDEN_BY_DEFAULT.includes(type))
 
 interface DetailGraphStore {
     relationshipTypes: string[] | null
@@ -55,4 +66,4 @@ export const useDetailGraphStore = create<DetailGraphStore>()(
 )
 
 export const getDefaultDetailGraphRelationshipTypes = (): string[] =>
-    Object.keys(RELATIONSHIP_DEFINITIONS).filter(type => type !== 'HAS_SUBSYSTEM')
+    DEFAULT_DETAIL_GRAPH_RELATIONSHIP_TYPES

--- a/src/modules/systemHierarchy/types/constants.ts
+++ b/src/modules/systemHierarchy/types/constants.ts
@@ -23,6 +23,7 @@ export const HIERARCHY_TABS = {
     RELATIONSHIPS: 'relationships',
     ATTACHMENTS: 'attachments',
     HISTORY: 'history',
+    GRAPH: 'graph',
 } as const
 
 export type HierarchyTab = (typeof HIERARCHY_TABS)[keyof typeof HIERARCHY_TABS]


### PR DESCRIPTION
## Summary
- New **Graph** tab in `SystemDetailView` rendering the relationship-graph rooted at the selected leaf system, with state isolated from the leaves-panel graph.
- Default filter hides `HAS_SUBSYSTEM` (checkbox un-selected; user can opt in). Selected `relationshipTypes` and `layoutMode` persist to `localStorage` between sessions.
- Refactor: `useRelationshipGraphContainerState` parameterised, driven by two thin wrappers (`useLeavesGraphState`, `useDetailGraphState`). Scope reset keyed on `graphUid` so leaf switches drop stale scope state.

## Architecture
- New `useDetailGraphStore` (zustand + persist, key `systemHierarchy-detail-graph`):
  - `relationshipTypes: string[] | null` — `null` sentinel = "use computed default" (all-except-`HAS_SUBSYSTEM`). Forward-compatible when new relationship types are added.
  - `layoutMode` persisted; `expandedNodes` / `expandedEdges` in-memory.
- `useDetailGraphFilters`: store-backed for `relationshipTypes`; `search` / `systemLevels` / `systemType` are session-only React state.
- Reset writes `null` so the default re-derives from `RELATIONSHIP_DEFINITIONS`.

## Behaviour
- Tab is always visible (last, after History).
- Node click → `selectLeaf(uid)` (already in detail) → only `leaf` query updates → tab stays on Graph → graph re-roots → expansion state resets via `graphUid` change.
- Tab unmount uses default Radix behaviour; persisted store fields survive remount.

## Test plan
- [x] Unit: `useDetailGraphStore` — sentinel default, partialize roundtrip, dedupe addExpanded, reset.
- [x] Unit: `useDetailGraphFilters` — default allowlist, HAS_SUBSYSTEM toggle, twice-toggle restores 8-list, reset clears + null sentinel, search session-only.
- [x] Smoke: `GraphTabContainer` passes `system.uid` as `rootUid`.
- [x] Integration: `SystemDetailTabs` — Graph trigger after History, correct testid, content renders when active.
- [x] `yarn tsc --noEmit` clean, `yarn lint` clean (only pre-existing warnings), `yarn test` 684/684 pass.
- [x] Manual: leaf-detail Graph rooted at the leaf; HAS_SUBSYSTEM hidden by default; toggle persists across reload; node click re-roots; leaves-panel graph state independent.