### PR TITLE
feat(systemHierarchy): clickable parent breadcrumbs in detail + leaves headers

### DIFF
--- a/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
@@ -6,14 +6,23 @@ import { Button } from '@/components/ui/button'
 import { message } from '@/i18n/src/messages'
 
 import type { SystemLeaf } from '../../types'
+import { SystemBreadcrumbs } from '../shared/SystemBreadcrumbs.comp'
 import { ActionsDropdown } from './ActionsDropdown.comp'
 
 interface SystemDetailHeaderProps {
     system: SystemLeaf
     onBack: () => void
+    onSelectAncestor: (
+        uid: string,
+        hint: { name: string; parentPath: { uid: string; name: string }[] },
+    ) => void
 }
 
-export const SystemDetailHeader: FC<SystemDetailHeaderProps> = ({ system, onBack }) => {
+export const SystemDetailHeader: FC<SystemDetailHeaderProps> = ({
+    system,
+    onBack,
+    onSelectAncestor,
+}) => {
     const { formatMessage: fm } = useIntl()
 
     return (
@@ -32,14 +41,12 @@ export const SystemDetailHeader: FC<SystemDetailHeaderProps> = ({ system, onBack
                 {fm({ id: message.systemHierarchy.detail.backToLeaves })}
             </Button>
             <div className="flex-1 min-w-0">
-                <div className="flex items-center gap-2">
-                    <h2 className="text-sm font-semibold truncate">{system.name}</h2>
-                    {system.systemCode && (
-                        <code className="text-[10px] text-muted-foreground shrink-0 rounded bg-muted px-1.5 py-0.5">
-                            {system.systemCode}
-                        </code>
-                    )}
-                </div>
+                <SystemBreadcrumbs
+                    parentPath={system.parentPath ?? null}
+                    currentName={system.name}
+                    currentCode={system.systemCode}
+                    onSelectAncestor={onSelectAncestor}
+                />
             </div>
             <ActionsDropdown system={system} />
         </div>

--- a/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
@@ -6,16 +6,14 @@ import { Button } from '@/components/ui/button'
 import { message } from '@/i18n/src/messages'
 
 import type { SystemLeaf } from '../../types'
+import type { SelectAncestorHandler } from '../shared/SystemBreadcrumbs.comp'
 import { SystemBreadcrumbs } from '../shared/SystemBreadcrumbs.comp'
 import { ActionsDropdown } from './ActionsDropdown.comp'
 
 interface SystemDetailHeaderProps {
     system: SystemLeaf
     onBack: () => void
-    onSelectAncestor: (
-        uid: string,
-        hint: { name: string; parentPath: { uid: string; name: string }[] },
-    ) => void
+    onSelectAncestor: SelectAncestorHandler
 }
 
 export const SystemDetailHeader: FC<SystemDetailHeaderProps> = ({

--- a/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
@@ -8,7 +8,7 @@ import { SystemDetailHeader } from './SystemDetailHeader.comp'
 import { SystemDetailTabsContainer } from './SystemDetailTabs.cont'
 
 export const SystemDetailViewContainer: FC = () => {
-    const { selectedLeafUid, goBackToLeaves } = useHierarchyNavigation()
+    const { selectedLeafUid, goBackToLeaves, selectParent } = useHierarchyNavigation()
     const { system, isLoading } = useSystemDetail(selectedLeafUid)
 
     if (isLoading || !system) {
@@ -28,7 +28,11 @@ export const SystemDetailViewContainer: FC = () => {
 
     return (
         <div className="flex flex-col h-full overflow-hidden">
-            <SystemDetailHeader system={system} onBack={goBackToLeaves} />
+            <SystemDetailHeader
+                system={system}
+                onBack={goBackToLeaves}
+                onSelectAncestor={selectParent}
+            />
             <div className="flex-1 min-h-0">
                 <SystemDetailTabsContainer system={system} />
             </div>

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -1,6 +1,6 @@
 import { useQueryState } from 'next-usequerystate'
 import type { FC } from 'react'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Button } from '@/components/ui/button'
@@ -22,8 +22,14 @@ import { useLeavesColumns } from './useLeavesColumns'
 
 export const LeavesPanelContainer: FC = () => {
     const { formatMessage: fm } = useIntl()
-    const { selectedParentUid, selectedLeafUid, selectLeaf, activeView, setActiveView } =
-        useHierarchyNavigation()
+    const {
+        selectedParentUid,
+        selectedLeafUid,
+        selectLeaf,
+        selectParent,
+        activeView,
+        setActiveView,
+    } = useHierarchyNavigation()
     const { system: parentSystem, isLoading: isParentLoading } = useSystemDetail(selectedParentUid)
     const { leaves, totalCount, isLoading } = useSystemLeaves(selectedParentUid)
 
@@ -44,7 +50,15 @@ export const LeavesPanelContainer: FC = () => {
 
     // Sync URL filter params → store on mount (enables persistence across refresh/new tab)
     const [filterQuery] = useQueryState('filter')
-    const { setColumnFilter, setSearch, setSearchValue } = useTableStateStore()
+    const { setColumnFilter, setSearch, setSearchValue, setPaginationState } = useTableStateStore()
+
+    const prevParentRef = useRef<string | null>(null)
+    useEffect(() => {
+        if (prevParentRef.current && prevParentRef.current !== selectedParentUid) {
+            setPaginationState(LEAVES_TABLE_ID, undefined)
+        }
+        prevParentRef.current = selectedParentUid
+    }, [selectedParentUid, setPaginationState])
 
     useEffect(() => {
         if (filterQuery) {
@@ -93,9 +107,11 @@ export const LeavesPanelContainer: FC = () => {
             parentName={parentSystem?.name ?? null}
             parentSystemCode={parentSystem?.systemCode ?? null}
             parentSystemType={parentSystem?.systemType?.name ?? null}
+            parentPath={parentSystem?.parentPath ?? null}
             totalCount={totalCount}
             isLoading={isParentLoading}
             onViewParentDetail={handleViewParentDetail}
+            onSelectAncestor={selectParent}
             activeView={activeView}
             onViewChange={setActiveView}
         />

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -52,6 +52,10 @@ export const LeavesPanelContainer: FC = () => {
     const [filterQuery] = useQueryState('filter')
     const { setColumnFilter, setSearch, setSearchValue, setPaginationState } = useTableStateStore()
 
+    // Pagination reset on parent change has two halves: selectParent clears the ?page
+    // URL param; this effect clears the zustand paginationState (which useQueryManager
+    // reads with higher priority than the URL). Mount guard via prevParentRef preserves
+    // ?page on initial deep-link reload.
     const prevParentRef = useRef<string | null>(null)
     useEffect(() => {
         if (prevParentRef.current && prevParentRef.current !== selectedParentUid) {

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -1,6 +1,6 @@
 import { useQueryState } from 'next-usequerystate'
 import type { FC } from 'react'
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Button } from '@/components/ui/button'
@@ -50,19 +50,19 @@ export const LeavesPanelContainer: FC = () => {
 
     // Sync URL filter params → store on mount (enables persistence across refresh/new tab)
     const [filterQuery] = useQueryState('filter')
+    const [pageQuery] = useQueryState('page')
     const { setColumnFilter, setSearch, setSearchValue, setPaginationState } = useTableStateStore()
 
-    // Pagination reset on parent change has two halves: selectParent clears the ?page
-    // URL param; this effect clears the zustand paginationState (which useQueryManager
-    // reads with higher priority than the URL). Mount guard via prevParentRef preserves
-    // ?page on initial deep-link reload.
-    const prevParentRef = useRef<string | null>(null)
+    // Pagination reset has two halves: selectParent clears ?page when the parent
+    // changes; this effect clears zustand paginationState (which useQueryManager
+    // prioritises over the URL) whenever the URL has no explicit ?page. That covers
+    // both same-mount parent changes and fresh mounts where a previous visit's
+    // store entry would otherwise leak. Deep-link reloads with ?page=N keep their page.
     useEffect(() => {
-        if (prevParentRef.current && prevParentRef.current !== selectedParentUid) {
+        if (!pageQuery) {
             setPaginationState(LEAVES_TABLE_ID, undefined)
         }
-        prevParentRef.current = selectedParentUid
-    }, [selectedParentUid, setPaginationState])
+    }, [pageQuery, selectedParentUid, setPaginationState])
 
     useEffect(() => {
         if (filterQuery) {

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanelHeader.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanelHeader.comp.tsx
@@ -8,20 +8,21 @@ import { message } from '@/i18n/src/messages'
 
 import type { HierarchyView } from '../../types/constants'
 import { ViewSwitcher } from '../graph/ViewSwitcher.comp'
+import type {
+    ParentPathItem,
+    SelectAncestorHandler,
+} from '../shared/SystemBreadcrumbs.comp'
 import { SystemBreadcrumbs } from '../shared/SystemBreadcrumbs.comp'
 
 interface LeavesPanelHeaderProps {
     parentName: string | null
     parentSystemCode: string | null
     parentSystemType: string | null
-    parentPath: { uid: string; name: string }[] | null
+    parentPath: ParentPathItem[] | null
     totalCount: number
     isLoading: boolean
     onViewParentDetail: () => void
-    onSelectAncestor: (
-        uid: string,
-        hint: { name: string; parentPath: { uid: string; name: string }[] },
-    ) => void
+    onSelectAncestor: SelectAncestorHandler
     activeView: HierarchyView
     onViewChange: (view: HierarchyView) => void
 }

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanelHeader.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanelHeader.comp.tsx
@@ -8,14 +8,20 @@ import { message } from '@/i18n/src/messages'
 
 import type { HierarchyView } from '../../types/constants'
 import { ViewSwitcher } from '../graph/ViewSwitcher.comp'
+import { SystemBreadcrumbs } from '../shared/SystemBreadcrumbs.comp'
 
 interface LeavesPanelHeaderProps {
     parentName: string | null
     parentSystemCode: string | null
     parentSystemType: string | null
+    parentPath: { uid: string; name: string }[] | null
     totalCount: number
     isLoading: boolean
     onViewParentDetail: () => void
+    onSelectAncestor: (
+        uid: string,
+        hint: { name: string; parentPath: { uid: string; name: string }[] },
+    ) => void
     activeView: HierarchyView
     onViewChange: (view: HierarchyView) => void
 }
@@ -24,9 +30,11 @@ export const LeavesPanelHeader: FC<LeavesPanelHeaderProps> = ({
     parentName,
     parentSystemCode,
     parentSystemType,
+    parentPath,
     totalCount,
     isLoading,
     onViewParentDetail,
+    onSelectAncestor,
     activeView,
     onViewChange,
 }) => {
@@ -50,14 +58,14 @@ export const LeavesPanelHeader: FC<LeavesPanelHeaderProps> = ({
 
     return (
         <div id="page-head" className="border-b border-border px-4 py-2">
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 min-w-0">
                 <Folder className="size-4 text-muted-foreground shrink-0" />
-                <h2 className="text-sm font-semibold truncate">{parentName}</h2>
-                {parentSystemCode && (
-                    <code className="text-[10px] text-muted-foreground shrink-0 rounded bg-muted px-1.5 py-0.5">
-                        {parentSystemCode}
-                    </code>
-                )}
+                <SystemBreadcrumbs
+                    parentPath={parentPath}
+                    currentName={parentName ?? ''}
+                    currentCode={parentSystemCode}
+                    onSelectAncestor={onSelectAncestor}
+                />
             </div>
             <div className="flex items-center justify-between mt-1">
                 <span className="text-xs text-muted-foreground truncate">

--- a/src/modules/systemHierarchy/components/shared/SystemBreadcrumbs.comp.tsx
+++ b/src/modules/systemHierarchy/components/shared/SystemBreadcrumbs.comp.tsx
@@ -1,0 +1,112 @@
+import type { FC } from 'react'
+import { Fragment } from 'react'
+
+import {
+    Breadcrumb,
+    BreadcrumbEllipsis,
+    BreadcrumbItem,
+    BreadcrumbList,
+    BreadcrumbPage,
+    BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb'
+
+interface ParentPathItem {
+    uid: string
+    name: string
+}
+
+interface AncestorClickHint {
+    name: string
+    parentPath: ParentPathItem[]
+}
+
+interface SystemBreadcrumbsProps {
+    parentPath: ParentPathItem[] | null
+    currentName: string
+    currentCode?: string | null
+    onSelectAncestor: (uid: string, hint: AncestorClickHint) => void
+}
+
+const COLLAPSE_THRESHOLD = 4
+
+interface VisibleItem {
+    uid: string
+    name: string
+    originalIndex: number
+}
+
+const buildVisible = (
+    ancestors: ParentPathItem[],
+): { items: VisibleItem[]; ellipsisAfterIndex: number | null } => {
+    const withIndex = ancestors.map((a, i) => ({ ...a, originalIndex: i }))
+    const total = ancestors.length + 1
+    if (total <= COLLAPSE_THRESHOLD) {
+        return { items: withIndex, ellipsisAfterIndex: null }
+    }
+    return {
+        items: [withIndex[0], ...withIndex.slice(-2)],
+        ellipsisAfterIndex: 0,
+    }
+}
+
+export const SystemBreadcrumbs: FC<SystemBreadcrumbsProps> = ({
+    parentPath,
+    currentName,
+    currentCode,
+    onSelectAncestor,
+}) => {
+    const ancestors = parentPath ?? []
+    const { items, ellipsisAfterIndex } = buildVisible(ancestors)
+
+    return (
+        <Breadcrumb className="min-w-0">
+            <BreadcrumbList className="flex-nowrap text-xs">
+                {items.map((item, idx) => (
+                    <Fragment key={item.uid}>
+                        <BreadcrumbItem>
+                            <button
+                                type="button"
+                                data-testid="system-breadcrumb-ancestor"
+                                data-uid={item.uid}
+                                onClick={() =>
+                                    onSelectAncestor(item.uid, {
+                                        name: item.name,
+                                        parentPath: ancestors.slice(0, item.originalIndex),
+                                    })
+                                }
+                                className="hover:text-foreground transition-colors truncate max-w-[160px]"
+                            >
+                                {item.name}
+                            </button>
+                        </BreadcrumbItem>
+                        <BreadcrumbSeparator />
+                        {ellipsisAfterIndex === idx && (
+                            <>
+                                <BreadcrumbItem>
+                                    <BreadcrumbEllipsis
+                                        data-testid="system-breadcrumb-ellipsis"
+                                        className="size-4"
+                                    />
+                                </BreadcrumbItem>
+                                <BreadcrumbSeparator />
+                            </>
+                        )}
+                    </Fragment>
+                ))}
+                <BreadcrumbItem className="min-w-0">
+                    <BreadcrumbPage
+                        data-testid="system-breadcrumb-current"
+                        className="font-semibold truncate"
+                    >
+                        {currentName}
+                    </BreadcrumbPage>
+                    {currentCode && (
+                        <code className="text-[10px] text-muted-foreground shrink-0 rounded bg-muted px-1.5 py-0.5">
+                            {currentCode}
+                        </code>
+                    )}
+                </BreadcrumbItem>
+            </BreadcrumbList>
+        </Breadcrumb>
+    )
+}

--- a/src/modules/systemHierarchy/components/shared/SystemBreadcrumbs.comp.tsx
+++ b/src/modules/systemHierarchy/components/shared/SystemBreadcrumbs.comp.tsx
@@ -10,21 +10,23 @@ import {
     BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb'
 
-interface ParentPathItem {
+export interface ParentPathItem {
     uid: string
     name: string
 }
 
-interface AncestorClickHint {
+export interface AncestorClickHint {
     name: string
     parentPath: ParentPathItem[]
 }
+
+export type SelectAncestorHandler = (uid: string, hint: AncestorClickHint) => void
 
 interface SystemBreadcrumbsProps {
     parentPath: ParentPathItem[] | null
     currentName: string
     currentCode?: string | null
-    onSelectAncestor: (uid: string, hint: AncestorClickHint) => void
+    onSelectAncestor: SelectAncestorHandler
 }
 
 const COLLAPSE_THRESHOLD = 4
@@ -94,6 +96,7 @@ export const SystemBreadcrumbs: FC<SystemBreadcrumbsProps> = ({
                     </Fragment>
                 ))}
                 <BreadcrumbItem className="min-w-0">
+                    <h2 className="sr-only">{currentName}</h2>
                     <BreadcrumbPage
                         data-testid="system-breadcrumb-current"
                         className="font-semibold truncate"

--- a/src/modules/systemHierarchy/components/shared/__tests__/SystemBreadcrumbs.test.tsx
+++ b/src/modules/systemHierarchy/components/shared/__tests__/SystemBreadcrumbs.test.tsx
@@ -1,0 +1,143 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+
+import { SystemBreadcrumbs } from '../SystemBreadcrumbs.comp'
+
+const path = (n: number) =>
+    Array.from({ length: n }, (_, i) => ({ uid: `u${i}`, name: `A${i}` }))
+
+describe('SystemBreadcrumbs', () => {
+    it('renders only current name when parentPath is null', () => {
+        render(
+            <SystemBreadcrumbs
+                parentPath={null}
+                currentName="Root"
+                onSelectAncestor={jest.fn()}
+            />,
+        )
+        expect(screen.getByTestId('system-breadcrumb-current')).toHaveTextContent('Root')
+        expect(screen.queryAllByTestId('system-breadcrumb-ancestor')).toHaveLength(0)
+        expect(screen.queryByTestId('system-breadcrumb-ellipsis')).not.toBeInTheDocument()
+    })
+
+    it('renders all ancestors + current when total displayed <= 4', () => {
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(3)}
+                currentName="Leaf"
+                onSelectAncestor={jest.fn()}
+            />,
+        )
+        const ancestors = screen.getAllByTestId('system-breadcrumb-ancestor')
+        expect(ancestors).toHaveLength(3)
+        expect(ancestors[0]).toHaveTextContent('A0')
+        expect(ancestors[2]).toHaveTextContent('A2')
+        expect(screen.getByTestId('system-breadcrumb-current')).toHaveTextContent('Leaf')
+        expect(screen.queryByTestId('system-breadcrumb-ellipsis')).not.toBeInTheDocument()
+    })
+
+    it('collapses middle ancestors with ellipsis when total displayed > 4', () => {
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(5)}
+                currentName="Leaf"
+                onSelectAncestor={jest.fn()}
+            />,
+        )
+        const ancestors = screen.getAllByTestId('system-breadcrumb-ancestor')
+        // first + last two ancestors visible
+        expect(ancestors).toHaveLength(3)
+        expect(ancestors[0]).toHaveTextContent('A0')
+        expect(ancestors[1]).toHaveTextContent('A3')
+        expect(ancestors[2]).toHaveTextContent('A4')
+        expect(screen.getByTestId('system-breadcrumb-ellipsis')).toBeInTheDocument()
+    })
+
+    it('collapses correctly for very deep paths', () => {
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(10)}
+                currentName="Leaf"
+                onSelectAncestor={jest.fn()}
+            />,
+        )
+        const ancestors = screen.getAllByTestId('system-breadcrumb-ancestor')
+        expect(ancestors.map(b => b.textContent)).toEqual(['A0', 'A8', 'A9'])
+        expect(screen.getByTestId('system-breadcrumb-ellipsis')).toBeInTheDocument()
+    })
+
+    it('fires onSelectAncestor with uid + hint when an ancestor is clicked', () => {
+        const onSelectAncestor = jest.fn()
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(3)}
+                currentName="Leaf"
+                onSelectAncestor={onSelectAncestor}
+            />,
+        )
+        fireEvent.click(screen.getAllByTestId('system-breadcrumb-ancestor')[1])
+        expect(onSelectAncestor).toHaveBeenCalledWith('u1', {
+            name: 'A1',
+            parentPath: [{ uid: 'u0', name: 'A0' }],
+        })
+    })
+
+    it('hint slices full original parentPath even when ellipsis collapses display', () => {
+        const onSelectAncestor = jest.fn()
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(6)}
+                currentName="Leaf"
+                onSelectAncestor={onSelectAncestor}
+            />,
+        )
+        // Click the visible second-to-last ancestor (A4 — original index 4)
+        const buttons = screen.getAllByTestId('system-breadcrumb-ancestor')
+        fireEvent.click(buttons[1]) // visible: [A0, A4, A5]
+        expect(onSelectAncestor).toHaveBeenCalledWith('u4', {
+            name: 'A4',
+            parentPath: [
+                { uid: 'u0', name: 'A0' },
+                { uid: 'u1', name: 'A1' },
+                { uid: 'u2', name: 'A2' },
+                { uid: 'u3', name: 'A3' },
+            ],
+        })
+    })
+
+    it('current item is not a button', () => {
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(2)}
+                currentName="Leaf"
+                onSelectAncestor={jest.fn()}
+            />,
+        )
+        const current = screen.getByTestId('system-breadcrumb-current')
+        expect(current.tagName).not.toBe('BUTTON')
+    })
+
+    it('renders code chip when currentCode is provided', () => {
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(1)}
+                currentName="Leaf"
+                currentCode="LF-001"
+                onSelectAncestor={jest.fn()}
+            />,
+        )
+        expect(screen.getByText('LF-001')).toBeInTheDocument()
+    })
+
+    it('omits code chip when currentCode is null', () => {
+        render(
+            <SystemBreadcrumbs
+                parentPath={path(1)}
+                currentName="Leaf"
+                currentCode={null}
+                onSelectAncestor={jest.fn()}
+            />,
+        )
+        expect(screen.queryByText(/LF-/)).not.toBeInTheDocument()
+    })
+})

--- a/src/modules/systemHierarchy/components/tree/SystemTree.cont.tsx
+++ b/src/modules/systemHierarchy/components/tree/SystemTree.cont.tsx
@@ -1,6 +1,6 @@
 import { FoldVertical, Search } from 'lucide-react'
 import type { FC } from 'react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Button } from '@/components/ui/button'
@@ -12,6 +12,7 @@ import { useSystemHierarchy } from '../../hooks/queries/useSystemHierarchy'
 import { useHierarchyNavigation } from '../../hooks/useHierarchyNavigation'
 import { useSystemCopyPaste } from '../../hooks/useSystemCopyPaste'
 import { useHierarchyStore } from '../../store/useHierarchyStore'
+import { findHierarchyPath } from '../../utils/treePath'
 import { collectAllNodeUids, filterTree } from '../../utils/treeSearch'
 import { SystemTreeComponent } from './SystemTree.comp'
 import { TreeNodeSkeleton } from './TreeNodeSkeleton.comp'
@@ -36,6 +37,23 @@ export const SystemTreeContainer: FC = () => {
     }, [searchInput])
 
     const filteredNodes = useMemo(() => filterTree(nodes, search), [nodes, search])
+
+    const handleSelect = useCallback(
+        (uid: string) => {
+            const path = findHierarchyPath(nodes, uid)
+            if (path.length === 0) {
+                selectParent(uid)
+                return
+            }
+            const target = path[path.length - 1]
+            selectParent(uid, {
+                name: target.name,
+                systemCode: target.systemCode,
+                parentPath: path.slice(0, -1).map(n => ({ uid: n.uid, name: n.name })),
+            })
+        },
+        [nodes, selectParent],
+    )
 
     useEffect(() => {
         if (search && filteredNodes.length > 0) {
@@ -100,7 +118,7 @@ export const SystemTreeContainer: FC = () => {
                         expandedNodes={expandedNodes}
                         selectedParentUid={selectedParentUid}
                         onToggle={toggleNode}
-                        onSelect={selectParent}
+                        onSelect={handleSelect}
                         search={search}
                         copiedSystemUid={copiedSystemUid}
                         onCopySystem={canEdit ? handleCopySystem : undefined}

--- a/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
@@ -1,6 +1,11 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
+import React from 'react'
 
 import { useHierarchyNavigation } from '../useHierarchyNavigation'
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: new QueryClient() }, children)
 
 const mockPush = jest.fn()
 let mockQuery: Record<string, string | undefined> = {}
@@ -23,42 +28,42 @@ describe('useHierarchyNavigation', () => {
 
     it('selectParent in detail mode swaps detail subject and preserves tab', () => {
         mockQuery = { parent: 'A', leaf: 'X', tab: 'history' }
-        const { result } = renderHook(() => useHierarchyNavigation())
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
         act(() => result.current.selectParent('B'))
         expect(lastPushedQuery()).toEqual({ parent: 'B', leaf: 'B', tab: 'history' })
     })
 
     it('selectParent without leaf does not resurrect a stale tab', () => {
         mockQuery = { parent: 'A' }
-        const { result } = renderHook(() => useHierarchyNavigation())
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
         act(() => result.current.selectParent('B'))
         expect(lastPushedQuery()).toEqual({ parent: 'B' })
     })
 
     it('selectLeaf while already in detail preserves current tab', () => {
         mockQuery = { parent: 'A', leaf: 'X', tab: 'spare-parts' }
-        const { result } = renderHook(() => useHierarchyNavigation())
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
         act(() => result.current.selectLeaf('Y'))
         expect(lastPushedQuery()).toEqual({ parent: 'A', leaf: 'Y', tab: 'spare-parts' })
     })
 
     it('selectLeaf from leaves table sets default detail tab', () => {
         mockQuery = { parent: 'A' }
-        const { result } = renderHook(() => useHierarchyNavigation())
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
         act(() => result.current.selectLeaf('X'))
         expect(lastPushedQuery()).toEqual({ parent: 'A', leaf: 'X', tab: 'detail' })
     })
 
     it('goBackToLeaves clears leaf and tab', () => {
         mockQuery = { parent: 'A', leaf: 'X', tab: 'history' }
-        const { result } = renderHook(() => useHierarchyNavigation())
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
         act(() => result.current.goBackToLeaves())
         expect(lastPushedQuery()).toEqual({ parent: 'A' })
     })
 
     it('setActiveView(GRAPH) then selectParent keeps view=graph', () => {
         mockQuery = { parent: 'A' }
-        const { result, rerender } = renderHook(() => useHierarchyNavigation())
+        const { result, rerender } = renderHook(() => useHierarchyNavigation(), { wrapper })
         act(() => result.current.setActiveView('graph'))
         mockQuery = { parent: 'A', view: 'graph' }
         rerender()
@@ -68,8 +73,29 @@ describe('useHierarchyNavigation', () => {
 
     it('selectLeaf from graph view keeps view=graph', () => {
         mockQuery = { parent: 'A', view: 'graph' }
-        const { result } = renderHook(() => useHierarchyNavigation())
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
         act(() => result.current.selectLeaf('X'))
         expect(lastPushedQuery()).toEqual({ parent: 'A', view: 'graph', leaf: 'X', tab: 'detail' })
+    })
+
+    it('selectParent to a different parent clears stale page query', () => {
+        mockQuery = { parent: 'A', page: '9' }
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+        act(() => result.current.selectParent('B'))
+        expect(lastPushedQuery()).toEqual({ parent: 'B' })
+    })
+
+    it('selectParent to the same parent preserves page query', () => {
+        mockQuery = { parent: 'A', page: '9' }
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+        act(() => result.current.selectParent('A'))
+        expect(lastPushedQuery()).toEqual({ parent: 'A', page: '9' })
+    })
+
+    it('selectParent in detail mode also clears page when parent changes', () => {
+        mockQuery = { parent: 'A', leaf: 'X', page: '9' }
+        const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+        act(() => result.current.selectParent('B'))
+        expect(lastPushedQuery()).toEqual({ parent: 'B', leaf: 'B' })
     })
 })

--- a/src/modules/systemHierarchy/hooks/queries/__tests__/primeSystemDetailCache.test.ts
+++ b/src/modules/systemHierarchy/hooks/queries/__tests__/primeSystemDetailCache.test.ts
@@ -40,10 +40,26 @@ describe('primeSystemDetailCache', () => {
         const qc = new QueryClient()
         const existing = { systems: [{ uid: 'sys-3', name: 'Existing' }] }
         qc.setQueryData([SYSTEM_DETAIL_QUERY_KEY, 'sys-3'], existing)
+        const fetchSpy = jest.spyOn(qc, 'fetchQuery')
 
         primeSystemDetailCache(qc, 'sys-3', { name: 'Replacement' })
 
         const data = qc.getQueryData<any>([SYSTEM_DETAIL_QUERY_KEY, 'sys-3'])
         expect(data.systems[0].name).toBe('Existing')
+        expect(fetchSpy).not.toHaveBeenCalled()
+    })
+
+    it('dispatches a background fetchQuery to refine the seed', () => {
+        const qc = new QueryClient()
+        const fetchSpy = jest.spyOn(qc, 'fetchQuery').mockImplementation(() => Promise.resolve({}))
+
+        primeSystemDetailCache(qc, 'sys-4', { name: 'Optimistic' })
+
+        expect(fetchSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                queryKey: [SYSTEM_DETAIL_QUERY_KEY, 'sys-4'],
+                queryFn: expect.any(Function),
+            }),
+        )
     })
 })

--- a/src/modules/systemHierarchy/hooks/queries/__tests__/primeSystemDetailCache.test.ts
+++ b/src/modules/systemHierarchy/hooks/queries/__tests__/primeSystemDetailCache.test.ts
@@ -1,0 +1,49 @@
+import { QueryClient } from '@tanstack/react-query'
+
+import { SYSTEM_DETAIL_QUERY_KEY } from '../../../types/constants'
+import { primeSystemDetailCache } from '../useSystemDetail'
+
+describe('primeSystemDetailCache', () => {
+    it('seeds the cache with a minimal SystemDetail-shaped payload', () => {
+        const qc = new QueryClient()
+        primeSystemDetailCache(qc, 'sys-1', {
+            name: 'System One',
+            systemCode: 'S-1',
+            parentPath: [
+                { uid: 'p0', name: 'Root' },
+                { uid: 'p1', name: 'Group' },
+            ],
+        })
+
+        const data = qc.getQueryData<any>([SYSTEM_DETAIL_QUERY_KEY, 'sys-1'])
+        expect(data?.systems).toHaveLength(1)
+        const node = data.systems[0]
+        expect(node.uid).toBe('sys-1')
+        expect(node.name).toBe('System One')
+        expect(node.systemCode).toBe('S-1')
+        expect(node.parentPath).toEqual([
+            { __typename: 'System', uid: 'p0', name: 'Root', systemLevel: null },
+            { __typename: 'System', uid: 'p1', name: 'Group', systemLevel: null },
+        ])
+    })
+
+    it('handles missing parentPath and systemCode by defaulting to empty / null', () => {
+        const qc = new QueryClient()
+        primeSystemDetailCache(qc, 'sys-2', { name: 'Solo' })
+
+        const node = qc.getQueryData<any>([SYSTEM_DETAIL_QUERY_KEY, 'sys-2']).systems[0]
+        expect(node.systemCode).toBeNull()
+        expect(node.parentPath).toEqual([])
+    })
+
+    it('does not overwrite an existing cache entry', () => {
+        const qc = new QueryClient()
+        const existing = { systems: [{ uid: 'sys-3', name: 'Existing' }] }
+        qc.setQueryData([SYSTEM_DETAIL_QUERY_KEY, 'sys-3'], existing)
+
+        primeSystemDetailCache(qc, 'sys-3', { name: 'Replacement' })
+
+        const data = qc.getQueryData<any>([SYSTEM_DETAIL_QUERY_KEY, 'sys-3'])
+        expect(data.systems[0].name).toBe('Existing')
+    })
+})

--- a/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
@@ -19,6 +19,10 @@ export interface OptimisticSystemHint {
     parentPath?: { uid: string; name: string }[]
 }
 
+// Seeds a partial SystemDetailFragment so the breadcrumb renders before the network
+// resolves. Only sets fields the breadcrumb reads (name, systemCode, parentPath).
+// useSystemDetail's mapping defends missing fields with ?? null. Skips when an entry
+// already exists — relies on staleTime (60s) to refresh stale paths via background refetch.
 export const primeSystemDetailCache = (
     queryClient: QueryClient,
     uid: string,

--- a/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { keepPreviousData } from '@tanstack/react-query'
+import { request } from 'graphql-request'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
 
@@ -13,6 +14,19 @@ import {
 
 import { SYSTEM_DETAIL_QUERY_KEY } from '../../types/constants'
 
+const systemHierarchyDetailQuery = gql(`
+  query SystemHierarchyDetail($where: SystemWhere) {
+    systems(where: $where) {
+      ...SystemDetail
+    }
+  }
+`)
+
+const fetchSystemDetail = (uid: string) =>
+    request('/api/graphql', systemHierarchyDetailQuery, {
+        where: { deleted: false, uid },
+    })
+
 export interface OptimisticSystemHint {
     name: string
     systemCode?: string | null
@@ -20,9 +34,10 @@ export interface OptimisticSystemHint {
 }
 
 // Seeds a partial SystemDetailFragment so the breadcrumb renders before the network
-// resolves. Only sets fields the breadcrumb reads (name, systemCode, parentPath).
-// useSystemDetail's mapping defends missing fields with ?? null. Skips when an entry
-// already exists — relies on staleTime (60s) to refresh stale paths via background refetch.
+// resolves, then kicks off a background fetch to replace the seed with the full fragment.
+// Background fetch is required because useSystemDetail uses refetchOnMount: false — a
+// seed alone would otherwise stick and the consumer would never see physicalItem,
+// operators, etc. Skips when an entry already exists (live cache or in-flight fetch).
 export const primeSystemDetailCache = (
     queryClient: QueryClient,
     uid: string,
@@ -45,15 +60,16 @@ export const primeSystemDetailCache = (
             },
         ],
     })
+    queryClient
+        .fetchQuery({
+            queryKey: [SYSTEM_DETAIL_QUERY_KEY, uid],
+            queryFn: () => fetchSystemDetail(uid),
+            staleTime: 60 * 1000,
+        })
+        .catch(() => {
+            // errors surface via the active consumer's useQuery state
+        })
 }
-
-const systemHierarchyDetailQuery = gql(`
-  query SystemHierarchyDetail($where: SystemWhere) {
-    systems(where: $where) {
-      ...SystemDetail
-    }
-  }
-`)
 
 export const useSystemDetail = (leafUid: string | null) => {
     const { data, error, isLoading, refetch } = useGraphQL(systemHierarchyDetailQuery, {

--- a/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
@@ -1,3 +1,5 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { keepPreviousData } from '@tanstack/react-query'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
 
@@ -10,6 +12,36 @@ import {
 } from '@/utils/graphql/fragments'
 
 import { SYSTEM_DETAIL_QUERY_KEY } from '../../types/constants'
+
+export interface OptimisticSystemHint {
+    name: string
+    systemCode?: string | null
+    parentPath?: { uid: string; name: string }[]
+}
+
+export const primeSystemDetailCache = (
+    queryClient: QueryClient,
+    uid: string,
+    hint: OptimisticSystemHint,
+) => {
+    if (queryClient.getQueryData([SYSTEM_DETAIL_QUERY_KEY, uid])) return
+    queryClient.setQueryData([SYSTEM_DETAIL_QUERY_KEY, uid], {
+        systems: [
+            {
+                __typename: 'System',
+                uid,
+                name: hint.name,
+                systemCode: hint.systemCode ?? null,
+                parentPath: (hint.parentPath ?? []).map(p => ({
+                    __typename: 'System',
+                    uid: p.uid,
+                    name: p.name,
+                    systemLevel: null,
+                })),
+            },
+        ],
+    })
+}
 
 const systemHierarchyDetailQuery = gql(`
   query SystemHierarchyDetail($where: SystemWhere) {
@@ -33,6 +65,7 @@ export const useSystemDetail = (leafUid: string | null) => {
         refetchOnWindowFocus: false,
         retry: false,
         staleTime: 60 * 1000, // 60 seconds
+        placeholderData: keepPreviousData,
     })
 
     useEffect(() => {

--- a/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
@@ -1,11 +1,15 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/router'
 import { useCallback, useMemo } from 'react'
 
 import type { HierarchyTab, HierarchyView } from '../types/constants'
 import { HIERARCHY_TABS, HIERARCHY_VIEWS } from '../types/constants'
+import type { OptimisticSystemHint } from './queries/useSystemDetail'
+import { primeSystemDetailCache } from './queries/useSystemDetail'
 
 export const useHierarchyNavigation = () => {
     const router = useRouter()
+    const queryClient = useQueryClient()
 
     const selectedParentUid = (router.query.parent as string) ?? null
     const selectedLeafUid = (router.query.leaf as string) ?? null
@@ -30,19 +34,27 @@ export const useHierarchyNavigation = () => {
     )
 
     const selectParent = useCallback(
-        (uid: string) => {
+        (uid: string, optimistic?: OptimisticSystemHint) => {
+            if (optimistic) primeSystemDetailCache(queryClient, uid, optimistic)
             const inDetail = !!(router.query.leaf as string | undefined)
-            updateQuery(inDetail ? { parent: uid, leaf: uid } : { parent: uid })
+            const parentChanged = (router.query.parent as string | undefined) !== uid
+            const pageReset = parentChanged ? { page: undefined } : {}
+            updateQuery(
+                inDetail
+                    ? { parent: uid, leaf: uid, ...pageReset }
+                    : { parent: uid, ...pageReset },
+            )
         },
-        [router, updateQuery],
+        [queryClient, router, updateQuery],
     )
 
     const selectLeaf = useCallback(
-        (uid: string) => {
+        (uid: string, optimistic?: OptimisticSystemHint) => {
+            if (optimistic) primeSystemDetailCache(queryClient, uid, optimistic)
             const inDetail = !!(router.query.leaf as string | undefined)
             updateQuery(inDetail ? { leaf: uid } : { leaf: uid, tab: HIERARCHY_TABS.DETAIL })
         },
-        [router, updateQuery],
+        [queryClient, router, updateQuery],
     )
 
     const setActiveTab = useCallback(

--- a/src/modules/systemHierarchy/utils/__tests__/treePath.test.ts
+++ b/src/modules/systemHierarchy/utils/__tests__/treePath.test.ts
@@ -1,0 +1,42 @@
+import { SystemLevel } from '@/types/gql/graphql'
+
+import type { HierarchyNode } from '../../types'
+import { findHierarchyPath } from '../treePath'
+
+const node = (uid: string, name: string, children: HierarchyNode[] = []): HierarchyNode => ({
+    uid,
+    name,
+    systemCode: null,
+    systemLevel: SystemLevel.KeySystems,
+    hasLeafChildren: false,
+    children,
+})
+
+describe('findHierarchyPath', () => {
+    const tree: HierarchyNode[] = [
+        node('r1', 'Root1', [
+            node('a', 'A', [node('b', 'B', [node('c', 'C')])]),
+            node('d', 'D'),
+        ]),
+        node('r2', 'Root2'),
+    ]
+
+    it('returns empty array when uid is not found', () => {
+        expect(findHierarchyPath(tree, 'missing')).toEqual([])
+    })
+
+    it('returns single-element path for a root node', () => {
+        const path = findHierarchyPath(tree, 'r2')
+        expect(path.map(n => n.uid)).toEqual(['r2'])
+    })
+
+    it('returns full root-to-target path for a deeply nested node', () => {
+        const path = findHierarchyPath(tree, 'c')
+        expect(path.map(n => n.uid)).toEqual(['r1', 'a', 'b', 'c'])
+    })
+
+    it('returns short branch when target is mid-tree', () => {
+        const path = findHierarchyPath(tree, 'd')
+        expect(path.map(n => n.uid)).toEqual(['r1', 'd'])
+    })
+})

--- a/src/modules/systemHierarchy/utils/treePath.ts
+++ b/src/modules/systemHierarchy/utils/treePath.ts
@@ -1,0 +1,13 @@
+import type { HierarchyNode } from '../types'
+
+export const findHierarchyPath = (
+    nodes: HierarchyNode[],
+    targetUid: string,
+): HierarchyNode[] => {
+    for (const node of nodes) {
+        if (node.uid === targetUid) return [node]
+        const childPath = findHierarchyPath(node.children, targetUid)
+        if (childPath.length > 0) return [node, ...childPath]
+    }
+    return []
+}


### PR DESCRIPTION
## Summary
- New shared SystemBreadcrumbs component renders the full ancestor path in both LeavesPanelHeader and SystemDetailHeader; ellipsis collapses paths past 4 levels (first / … / last2 / current).
- Ancestor clicks call selectParent — identical behavior to clicking the corresponding node in the left tree.
- Optimistic UX: clicks from breadcrumb or tree prime the system-detail React Query cache with known {name, parentPath, systemCode}, so the new breadcrumb renders instantly and is then refined by the network response. useSystemDetail also gets placeholderData: keepPreviousData as a fallback.
- selectParent clears the stale ?page query param and the store paginationState (LEAVES_TABLE_ID) when the parent changes, fixing the bug where switching from page 6 of parent A to parent B kept calling the API with page=6.
- View parent button kept (different action from breadcrumb — opens detail of current parent).

## Test plan
- [x] yarn lint clean (only pre-existing warnings)
- [x] yarn tsc --noEmit clean
- [x] yarn test src/modules/systemHierarchy — 28 suites / 181 tests pass (added SystemBreadcrumbs, treePath, and 3 new selectParent page-reset cases)
- [ ] Manual: open a system with depth ≥ 5 and depth ≤ 3 — verify ellipsis kicks in only at depth ≥ 5
- [ ] Manual: leaves panel — click each visible ancestor, tree selection follows, leaves table re-queries
- [ ] Manual: leaf detail (depth ≥ 3) — breadcrumb shows full path, current item bold/non-clickable; click an ancestor → both parent and leaf URL params update, detail switches
- [ ] Manual: paginate to page N on parent A, click another parent — UI shows page 1 AND API request body uses page 1 (no stale page in pagination= query)
- [ ] Manual: reload on ?parent=A&page=6 — page 6 still respected (mount guard)
- [ ] Manual: header height stays stable across depths (no wrapping/jitter)