### PR TITLE
docs(user-guide): System Hierarchy + app basics + templates

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,53 @@
+name: Sync docs to GitHub Wiki
+
+on:
+    push:
+        branches:
+            - dev
+        paths:
+            - 'docs/**'
+            - 'scripts/sync-wiki.mjs'
+            - '.github/workflows/sync-wiki.yml'
+    workflow_dispatch:
+
+jobs:
+    sync:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout main repo
+              uses: actions/checkout@v4
+              with:
+                  path: main
+
+            - name: Checkout wiki repo
+              uses: actions/checkout@v4
+              with:
+                  repository: ${{ github.repository }}.wiki
+                  path: wiki
+                  # Wiki push requires a PAT with `repo` scope; GITHUB_TOKEN does not work.
+                  # Add a repo secret named WIKI_PUSH_TOKEN.
+                  token: ${{ secrets.WIKI_PUSH_TOKEN }}
+
+            - name: Setup Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: '20'
+
+            - name: Run sync script
+              working-directory: main
+              env:
+                  WIKI_OUT: ${{ github.workspace }}/wiki
+              run: node scripts/sync-wiki.mjs
+
+            - name: Commit and push wiki
+              working-directory: wiki
+              run: |
+                  git config user.name 'github-actions[bot]'
+                  git config user.email 'github-actions[bot]@users.noreply.github.com'
+                  git add -A
+                  if git diff --staged --quiet; then
+                      echo "No changes to push"
+                  else
+                      git commit -m "Sync docs from ${GITHUB_SHA::7}"
+                      git push
+                  fi

--- a/docs/Home.md
+++ b/docs/Home.md
@@ -1,0 +1,25 @@
+# ELI PANDA documentation
+
+Welcome to the documentation hub for ELI PANDA — the maintenance management system for ELI scientific facilities.
+
+The documentation is split into two streams:
+
+## [User Guide](User-Guide)
+
+End-user documentation: how to use the application, per-feature workflows, screenshots and walkthroughs. Start with [Getting around the app](User-Guide-Getting-around) for layout, login, keyboard shortcuts, and dark mode.
+
+Currently documented modules:
+
+- [System Hierarchy](User-Guide-System-Hierarchy)
+
+More modules will follow — see the [User Guide](User-Guide) index for the full status table.
+
+## [Technical Documentation](Technical-Documentation)
+
+Engineering-facing documentation: architecture, deployment, data model, ops procedures.
+
+🚧 **Empty for now** — content is being authored.
+
+---
+
+*Source for these pages lives in [`docs/`](https://github.com/eli-eric/ELI-panda/tree/dev/docs) in the main repository. Edits go through pull requests; this wiki is auto-synced on merge to `dev`.*

--- a/docs/technical/README.md
+++ b/docs/technical/README.md
@@ -1,0 +1,33 @@
+# Technical Documentation
+
+Engineering-facing reference material for developers and operators of ELI PANDA.
+
+> 🚧 **Empty for now** — content is being authored. This page exists as a placeholder so the documentation hub has a complete top-level structure.
+
+## Planned sections
+
+- **Architecture overview** — Next.js frontend, Neo4j backend, GraphQL layer, module organization.
+- **GraphQL schema reference** — entities, relationships, authorization rules.
+- **Permissions & roles** — `systems-view`, `systems-edit`, `admin`, planned phases of permission tightening.
+- **Deployment & runbook** — Azure environments, Docker images, release procedure.
+- **Data model & migrations** — Neo4j schema migrations, codebooks, seeding.
+- **Authentication setup** — Microsoft Entra ID app registration, token flow.
+- **Observability & monitoring** — logs, metrics, alerts, dashboards.
+- **Local development** — getting started, common commands, conventions.
+
+## In the meantime
+
+If you need engineering details right now, the codebase itself is the authoritative source:
+
+- **Source code:** <https://github.com/eli-eric/ELI-panda>
+- **GraphQL schema:** [`src/server/apollo/schema.graphql`](https://github.com/eli-eric/ELI-panda/blob/dev/src/server/apollo/schema.graphql) — full entity and authorization rules.
+- **Permissions today:** see *Access & Responsibilities* in each [User Guide](User-Guide) module page.
+- **Repository conventions:** [`CLAUDE.md`](https://github.com/eli-eric/ELI-panda/blob/dev/CLAUDE.md) at the repo root summarizes coding style, build commands, and architecture.
+
+## Contributing
+
+Technical documentation lives alongside user docs in `docs/technical/` in the main repository. To add a section:
+
+1. Create a new `.md` file under `docs/technical/`.
+2. Open a pull request against `dev`.
+3. On merge, the [GitHub wiki](https://github.com/eli-eric/ELI-panda/wiki) is automatically updated.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,54 @@
+# ELI PANDA — user guide
+
+This is the entry point for end-user documentation of the ELI PANDA maintenance management system. Each feature module has its own folder with a README and per-workflow pages.
+
+## Modules
+
+| Module | Status | Documentation |
+|---|---|---|
+| System Hierarchy | 📝 Documented | [systemHierarchy/](./systemHierarchy/README.md) |
+| Systems Relations | 🚧 Planned | — |
+| Systems Moving | 🚧 Planned | — |
+| Catalogue | 🚧 Planned | — |
+| Items | 🚧 Planned | — |
+| Orders | 🚧 Planned | — |
+| Room Cards | 🚧 Planned | — |
+| User Settings | 🚧 Planned | — |
+
+**Status legend:**
+- 📝 **Documented** — the module's README and at least one workflow page exist.
+- 🚧 **Planned** — the module exists in the application; documentation has not been written yet.
+
+## How this guide is organized
+
+Each documented module follows the same structure:
+
+```
+<module>/
+├── README.md         — module overview, access, key concepts, layout, workflow links
+└── workflows/        — one page per user-facing workflow
+    ├── <workflow-a>.md
+    └── <workflow-b>.md
+```
+
+Workflow pages are designed to stand on their own — you can land on one directly via search and find what you need without needing to read the parent README first. Cross-page links are provided where context matters.
+
+## Conventions
+
+- **Audience:** engineers and technicians who actually work with the systems being documented. Engineering-precise language is fine where it helps; access and responsibility sections stay user-friendly.
+- **Personas:** every workflow declares which personas (👁️ Viewer / ✏️ Editor / Admin) can perform it. See each module's *Access & Responsibilities* section for what those personas are.
+- **UI labels** in step instructions match the English UI.
+- **Screenshots and videos** are recorded during the Confluence publishing stage. Placeholder boxes in the Markdown describe what the missing media should show.
+
+## Templates
+
+If you are documenting a new module, copy the templates from [`_template/`](./_template/):
+
+- `README.template.md` — copy to `<module>/README.md` and fill in.
+- `workflow.template.md` — copy to `<module>/workflows/<workflow-name>.md` and fill in.
+
+When the module is ready, update the table above: change 🚧 Planned to 📝 Documented and add the link.
+
+## Language
+
+This documentation is English-only. The app currently ships English translations only; Hungarian is planned for ELI ALPS but not on the immediate roadmap.

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -2,6 +2,10 @@
 
 This is the entry point for end-user documentation of the ELI PANDA maintenance management system. Each feature module has its own folder with a README and per-workflow pages.
 
+## Start here
+
+- [Getting around the app](./getting-around.md) — login, sidebar, keyboard shortcuts, dark mode, logout. Read this once before diving into specific modules.
+
 ## Modules
 
 | Module | Status | Documentation |

--- a/docs/user-guide/_template/README.template.md
+++ b/docs/user-guide/_template/README.template.md
@@ -1,0 +1,83 @@
+# <Module name>
+
+<!--
+Template for a per-module README — the parent page in the user guide for one feature module.
+
+Audience: hybrid engineering/business. The README sets the stage and links out to per-workflow pages. Keep it scannable.
+
+This file maps to one Confluence page (the module's parent). Each workflow under `workflows/` is a separate child page.
+-->
+
+## Overview
+
+<!-- 2-3 sentences: what the module does, who uses it, what part of the facility's lifecycle it covers. -->
+
+`[SCREENSHOT PLACEHOLDER: full module landing screen with all primary panels visible]`
+
+## Access & Responsibilities
+
+<!--
+Two sub-sections:
+1. Today's reality — short list of roles and what they grant in plain English.
+2. A persona table: persona | role(s) | what they can do.
+
+Then 🔮 callouts for coming-soon phases (level-based split, team-based scoping) where they apply.
+-->
+
+**Today's reality:**
+- `systems-view` — read-only.
+- `systems-edit` and `admin` — both grant full edit on every system (functionally equivalent right now).
+
+**Personas (today):**
+
+| Persona | Role(s) | Can do |
+|---|---|---|
+| 👁️ **Viewer** | `systems-view` | … |
+| ✏️ **Editor / Admin** | `systems-edit` or `admin` | … |
+
+> 🔮 **Coming soon — Phase 1: split between Editor and Admin** — admin retains exclusive edit on `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels; Editor is restricted to `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, `TRASH`.
+
+> 🔮 **Coming soon — Phase 2: team-based scoping (policy today, enforced later)** — only members of a system's *responsible team* should edit that system and its subtree. Today this is policy only; technical enforcement is planned but the data structure is not yet in place.
+
+## Key concepts
+
+<!-- Bulleted glossary: term + 1-line definition. No inline schema links. Terms should be the ones users will see in workflow pages. -->
+
+- **Term** — definition.
+
+## Layout
+
+<!-- Describe the main panels/regions of the module. One bullet per panel, plus a screenshot placeholder per area where layout matters. -->
+
+- **Left** — …
+- **Middle** — …
+- **Right** — …
+
+## Common workflows
+
+<!--
+Bulleted list of links to per-workflow files in `./workflows/`, with a 1-line summary each.
+
+Cross-module workflow references go to the [user guide index](../README.md).
+-->
+
+- [Workflow A](./workflows/workflow-a.md) — 1-line summary.
+- [Workflow B](./workflows/workflow-b.md) — 1-line summary.
+
+## Coming soon
+
+<!-- Roadmap items. Each item gets a 🔮 callout-style bullet, short. Include both module features and permission phases. -->
+
+- **Feature X** — short description.
+
+`[VIDEO PLACEHOLDER: 60s end-to-end walkthrough of the module]`
+
+## Data model reference
+
+> 🔧 *This section is for engineers reading the docs in the repo. The Confluence generator strips it.*
+>
+> Authoritative entity definitions live in `src/server/apollo/schema.graphql`. Look up the relevant types for full field shapes and relationship directions. The repo is open-source on GitHub.
+
+## Language
+
+This documentation reflects the English UI. The app currently ships English translations only; Hungarian is planned for ELI ALPS but not on the immediate roadmap.

--- a/docs/user-guide/_template/workflow.template.md
+++ b/docs/user-guide/_template/workflow.template.md
@@ -1,0 +1,97 @@
+# <Workflow title — imperative, e.g. "Copying systems">
+
+<!--
+Template for a single workflow page.
+
+Audience: hybrid engineering/business — technicians and engineers actually working with systems.
+- Engineering parts (entities, relationships, lifecycle, "how it works") may use precise technical terms.
+- Business parts (access, when to use) stay plain and friendly.
+- Never reference .tsx paths or component names.
+- Match UI labels to the EN messages dictionary verbatim.
+- All screenshots and videos are placeholders only — describe what they should show.
+-->
+
+## What this is for
+
+<!-- 1-3 sentences: what this workflow accomplishes, when a user reaches for it. State key constraints up-front (e.g. "structural skeleton only", "1-to-1 cardinality"). -->
+
+## Who can do this
+
+<!--
+Persona badge — pick the lowest tier that can perform the workflow.
+
+Today (Editor and Admin are functionally equivalent):
+✏️ **Editor / Admin** — requires the `systems-edit` role.
+👁️ **Viewer** — requires the `systems-view` role (read-only workflows only).
+👁️ All personas — when the workflow is read-only and visible to anyone with `systems-view`.
+
+If different actions inside this workflow have different gates, follow the badge with a small per-action role table:
+
+| Action | Required role |
+|---|---|
+| View | `systems-view` |
+| Create / delete | `systems-edit` |
+
+If Phase 1 (level-based admin/editor split) or Phase 2 (team scoping) changes the gate for this workflow, add a 🔮 callout under the badge.
+-->
+
+✏️ **Editor / Admin** — requires the `systems-edit` role.
+
+> 🔮 *Coming soon — Phase 1:* …
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+<!-- Bulleted: where the user should be in the app, what they should know going in. Always link out to README key concepts when terminology matters. No inline glossary. -->
+
+- You are looking at the System Hierarchy module.
+- See [Key concepts](../README.md#key-concepts) for terminology.
+
+## Steps
+
+<!--
+Numbered list. Each step is a single bold-led instruction sentence followed by clarifying detail.
+
+Embed `[SCREENSHOT PLACEHOLDER: <description>]` after a step where the UI state matters. Every placeholder MUST describe what should be in the screenshot — never bare `[SCREENSHOT]`.
+
+Use exact UI labels from the EN locale (`src/i18n/src/locale/en.ts`) — wrap them in **bold** or *italic* and quote verbatim.
+
+Tables are encouraged for option matrices.
+-->
+
+1. **Step one.** Explanation.
+
+   `[SCREENSHOT PLACEHOLDER: <what should be visible>]`
+
+2. **Step two.** …
+
+`[VIDEO PLACEHOLDER: <duration + what is demonstrated end-to-end>]`
+
+## What gets <created / changed / removed>
+
+<!-- OPTIONAL section. Use when an action's effect is non-obvious or partial — e.g. copy is "structural skeleton only", spare swap moves items but keeps history.
+
+Use ✅/❌ bulleted lists for what does and does not happen. State this in user-facing terms (Catalogue item / Physical item / Responsible team), not GraphQL types. -->
+
+## Limitations
+
+<!-- OPTIONAL section. Hard constraints the user cannot work around: scope (same facility), depth caps, atomicity, rate limits. Keep to bullets. -->
+
+## Tips & gotchas
+
+<!--
+OPTIONAL combined section: useful tips for efficient use AND edge cases / validation pitfalls / error triggers.
+
+Include this section only when there is real content. Never pad with "no known gotchas".
+-->
+
+- **Tip.** …
+- **Gotcha.** …
+
+## Related
+
+<!-- Bullets: links to sibling workflow files (./other.md). Cross-module references go to the user-guide root index, not to nonexistent module files. -->
+
+- [Other workflow](./other-workflow.md)
+- Other module → see [user guide index](../../README.md).

--- a/docs/user-guide/getting-around.md
+++ b/docs/user-guide/getting-around.md
@@ -1,0 +1,114 @@
+# Getting around the app
+
+Layout, login, keyboard shortcuts, dark mode, and other generic chrome of ELI PANDA. Read this once before using any specific feature module.
+
+## Audience
+
+Everyone using PANDA. No specific role required to read this.
+
+## Logging in and out
+
+### Sign in
+
+PANDA authenticates against **Microsoft Entra ID** (formerly Azure AD).
+
+1. Open the app. The landing page shows the **ELI PANDA** logo and a single **Sign in** button.
+2. Click *Sign in.* You are redirected to the Microsoft login page.
+3. After successful Microsoft login you land on the dashboard. Your account is enriched on first login with name, email, facility, and roles from the internal user database.
+
+`[SCREENSHOT PLACEHOLDER: PANDA landing screen with logo and a Sign in button]`
+
+There is no separate "PANDA password" — credentials are managed by Microsoft Entra ID. **Forgotten passwords are reset via Microsoft**, not in PANDA.
+
+### Sign out
+
+1. Click your profile in the bottom of the left sidebar (avatar + name + email).
+2. In the dropdown, click **Log Out** (bottom option).
+3. The session ends and you are taken back to the sign-in screen.
+
+`[SCREENSHOT PLACEHOLDER: user profile dropdown open at the bottom of the sidebar showing Profile, Dark Mode, Support, Log Out]`
+
+## Layout
+
+### The sidebar (left)
+
+The sidebar is the main navigation surface. Top to bottom:
+
+- **Logo** — *ELI PANDA*. Click to return to the dashboard.
+- **Search bar** — opens the global search. Equivalent to pressing *Cmd / Ctrl + K* anywhere in the app.
+- **Modules** — the feature modules visible to you (filtered by your roles): for example *Systems*, *Catalogue*, *Orders*, etc.
+- **Administration** — facility-specific and admin modules (only shown if you have the right roles).
+- **User profile** — your avatar, name, and email at the bottom; click for the user dropdown.
+
+The sidebar can be collapsed to icon-only mode to free up screen space (see *Keyboard shortcuts* below). On mobile it becomes a sheet drawer hidden behind a menu button.
+
+`[SCREENSHOT PLACEHOLDER: full sidebar expanded, showing logo, search, Modules section with several entries, Administration section, and user profile card at the bottom]`
+
+### Page area
+
+To the right of the sidebar is the main page area. There is **no global top bar** — every module owns its own header (e.g., the breadcrumb in System Hierarchy is a module-specific feature, not a global breadcrumb).
+
+### Toasts
+
+Loading / success / error feedback for actions appears as toast pop-ups in a corner (powered by Sonner). They auto-dismiss; the typical pattern is *Saving…* → *Saved successfully* (or *Failed to save*).
+
+## Keyboard shortcuts
+
+| Shortcut (Mac) | Shortcut (Win/Linux) | Action |
+|---|---|---|
+| **⌘ + K** | **Ctrl + K** | Open global search (command palette). |
+| **⌘ + B** | **Ctrl + B** | Toggle the sidebar (full / icon-only on desktop, open / closed drawer on mobile). |
+| **Esc** | **Esc** | Close the active modal, sheet, or dropdown. |
+
+`[SCREENSHOT PLACEHOLDER: global search command palette open with a few result rows grouped by entity type]`
+
+> 💡 **About the sidebar shortcut.** *Cmd / Ctrl + B* comes for free from the shadcn/ui sidebar component the app is built on — it is a standard shadcn convention, not a PANDA-specific feature. *Cmd / Ctrl + K* for the global search is wired explicitly in PANDA.
+
+### Global search (⌘ / Ctrl + K)
+
+- Press the shortcut anywhere in the app to open the command palette.
+- Type **at least 2 characters** to search across systems, items, orders, and other entities. Results are grouped by entity type with a colored type badge.
+- With fewer than 2 characters, the palette shows quick-navigation entries (recent / pinned views) instead of search results.
+- *Enter* navigates to the selected result; *Esc* closes the palette.
+
+## Light mode and dark mode
+
+PANDA supports both color themes. Switching is per-user and persists across sessions.
+
+1. Click your profile at the bottom of the sidebar.
+2. In the dropdown, click **Dark Mode** (or **Light Mode** if you are already in dark).
+3. The theme switches instantly and is remembered the next time you open the app.
+
+`[SCREENSHOT PLACEHOLDER: user profile dropdown open with the Dark Mode / Light Mode toggle highlighted]`
+
+The choice is stored in your browser; switching browsers or clearing site data resets it to the default (light).
+
+## User profile and other dropdown items
+
+The profile dropdown at the bottom of the sidebar contains:
+
+- **Profile** — opens your user profile settings page.
+- **Dark Mode / Light Mode** — theme toggle (see above).
+- **Support** — link to support documentation.
+- **Log Out** — ends the session.
+
+## Sessions and timeouts
+
+Sessions are managed by NextAuth with JWT tokens. There is no aggressive idle timeout — the session is durable across browser restarts as long as the underlying Microsoft tokens are valid. If a server-side action returns an authentication error, you'll be redirected back to the sign-in screen and can sign in again.
+
+## Language
+
+The app currently ships **English-only** translations. Hungarian is planned for ELI ALPS but not on the immediate roadmap. There is no in-app language switcher today.
+
+## Tips & gotchas
+
+- **The sidebar is your navigation.** PANDA does not use a global top-bar menu — if you can't find a module, expand the sidebar and look in *Modules* or *Administration*.
+- **Use ⌘ / Ctrl + K liberally.** Faster than navigating to the relevant module and searching there. The palette can find systems, catalogue items, orders, and more in one place.
+- **Toggle the sidebar on a small screen** with ⌘ / Ctrl + B — handy when reading wide tables.
+- **Theme is per browser, not per account.** If you sign in on a different machine, you'll get the default theme until you flip it again.
+- **No notifications center.** PANDA does not have a notifications bell. Transient feedback comes via toasts; persistent state is reflected in the data on the relevant module page.
+- **No global page breadcrumb.** Some modules (notably System Hierarchy) have their own internal breadcrumbs for moving around their data structure — that is module-specific, not an app-wide feature.
+
+## Related
+
+- See the per-module pages in this guide for feature-specific workflows.

--- a/docs/user-guide/systemHierarchy/README.md
+++ b/docs/user-guide/systemHierarchy/README.md
@@ -1,0 +1,89 @@
+# System Hierarchy
+
+The System Hierarchy module is the central place to browse, organize, and inspect the tree of systems and subsystems at the facility. It surfaces accountability (responsible person and team), physical-item assignments, engineering relationships between systems, and a full change history.
+
+`[SCREENSHOT PLACEHOLDER: full module landing screen — left tree expanded to a leaf, middle leaves panel in table mode, right Quick Info sidebar visible, breadcrumb at top]`
+
+## Access & Responsibilities
+
+**Today's reality:**
+- `systems-view` — read-only.
+- `systems-edit` and `admin` — both grant full edit on every system (functionally equivalent right now).
+
+**Personas (today):**
+
+| Persona | Role(s) | Can do |
+|---|---|---|
+| 👁️ **Viewer** | `systems-view` | Browse the tree, view details, view relationships, search and filter, view change history |
+| ✏️ **Editor / Admin** | `systems-edit` or `admin` | Everything in Viewer + edit fields, manage persons, manage relationships, view spare parts, copy systems, assign and move physical items |
+
+> 🔮 **Coming soon — Phase 1: split between Editor and Admin**
+> - **Admin** will have exclusive edit on systems at `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels (the strategic top of the tree).
+> - **Editor** (`systems-edit`) will be restricted to `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, and `TRASH` levels.
+> - All derived actions (relationships, persons, items, copy/paste) inherit the same level scope.
+
+> 🔮 **Coming soon — Phase 2: team-based scoping (policy today, enforced later)**
+> Each system has a *responsible person* and a *responsible team*. Only members of the responsible team should edit that system and its subtree. **Today this is policy only — please follow it manually**; technical enforcement is planned but the data structure for it is not yet in place.
+
+## Key concepts
+
+- **System** — a hierarchical entity representing a piece of facility infrastructure (e.g. a beamline, a vacuum chamber, a controller).
+- **Subsystem** — a system nested under a parent system. A system can have any number of subsystems.
+- **System level** — classification of where in the hierarchy a system sits: `SYSTEM_DOMAIN`, `TECHNOLOGY_UNIT`, `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, `TRASH`. Levels drive both visual styling and (in Phase 1) edit permissions. The `TRASH` level marks a holding area for retired or replaced items — see [Managing spare parts](./workflows/managing-spare-parts.md).
+- **System type** — codebook classification of *what kind* of system this is. Used for code generation and filtering.
+- **System code** — short identifier for the system, generated based on type, level, and ancestry.
+- **Responsible person** — the employee accountable for a system.
+- **Responsible team** — the team accountable for a system. Governs edit policy (Phase 2).
+- **Owner** — computed read-only ownership marker.
+- **Operators** — employees authorized to operate the system day-to-day.
+- **Maintained by** — employees responsible for maintenance of the system.
+- **Physical item** — the concrete piece of hardware currently installed in a system. A system holds at most one physical item.
+- **Catalogue item** — the abstract product spec a physical item is based on.
+- **Relationship** — a directed engineering link between two systems (9 types — see [Managing relationships](./workflows/managing-relationships.md)).
+- **Spare part** — a system designated as a spare for another system.
+- **Coverage** — the spare-parts metric: how many of the required spares are currently available, color-coded against the configured minimum.
+
+## Layout
+
+The module is a three-panel explorer:
+
+- **Left — System tree.** Resizable. Top of the tree has a search box (300 ms debounced) and a *Collapse All* button. Each tree node shows the system name, a folder icon colored by system level, and a subsystem-count badge. Selecting a node auto-expands its ancestors. On mobile the tree collapses behind a toggle.
+- **Middle — Leaves panel.** Shows the children of the selected tree node, either as a table (default) or as a relationship graph. Has a toolbar with *Filters*, *Search*, and *Column visibility* controls, and a view switcher between *Tree View* (table) and *Graph View*.
+- **Right — Quick Info sidebar.** On large screens a sticky 320 px panel with statistics (subsystem count, spare-part count, spare coverage) and metadata. On smaller screens accessible via a floating *Info* button.
+- **Top — Breadcrumb.** Shows the ancestor path of the currently selected system. Clicking any ancestor navigates to it. Long paths collapse with an ellipsis (first ancestor + last two).
+
+When a system is selected for full detail view, a tabbed area replaces the leaves panel with: **Detail**, **Persons**, **Physical Item**, **Spare Parts**, **Spare For**, **Relationships**, **Attachments**, **History**, and (depending on context) **Graph**.
+
+## Common workflows
+
+- [Navigating the tree](./workflows/navigating-the-tree.md) — expanding the tree, breadcrumb navigation, switching between table and graph views in the leaves panel.
+- [Searching and filtering](./workflows/searching-and-filtering.md) — search box and the multi-field filter sheet for the leaves panel.
+- [Editing system details](./workflows/editing-system-details.md) — inline edit of name, code, level, type, location, zone, description on the *Detail* tab. Includes system code generation and the special meaning of the `TRASH` level.
+- [Managing system people](./workflows/managing-system-people.md) — responsible person, owner, responsible team, and the operators / maintained-by tables on the *Persons* tab.
+- [Managing relationships](./workflows/managing-relationships.md) — the 9 engineering relationship types, viewing them in the list and the graph, creating and deleting edges.
+- [Managing spare parts](./workflows/managing-spare-parts.md) — read-only *Spare Parts* tab, how the spare-swap flow works conceptually, where assignments are made.
+- [Viewing change history](./workflows/viewing-change-history.md) — the *History* tab timeline and its filters.
+- [Copying systems](./workflows/copying-systems.md) — copy/paste a system (and optionally its subtree) under a different parent.
+- [Managing physical items](./workflows/managing-physical-items.md) — assigning and moving the physical item attached to a system.
+
+For moving a system to a different parent, see the **Systems Moving** module — drag-and-drop rearrangement of the hierarchy lives there. See the [user guide index](../README.md).
+
+## Coming soon
+
+- 🔮 **Permission Phase 1** — split `admin` (top-level system edits at `SYSTEM_DOMAIN`, `TECHNOLOGY_UNIT`) from `systems-edit` (lower levels at `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, `TRASH`). All derived actions scoped accordingly.
+- 🔮 **Permission Phase 2** — team-based edit enforcement (responsible-team membership required to edit subtree). DB structure pending.
+- 🔮 **System creation in Hierarchy** — entry point to create new systems will be added directly in this module.
+- 🔮 **Use Spare action in Hierarchy** — the spare-swap wizard (currently in a deprecated shared flow, feature-flagged off in production) will be brought into this module.
+- 🔮 **Drag-and-drop move at hierarchy level** — currently move lives in the separate Systems Moving module.
+
+`[VIDEO PLACEHOLDER: 60s end-to-end walkthrough — open the module, expand the tree to a key system, browse its subsystems in table view, switch to graph view, open the detail tabs, finish on the History tab]`
+
+## Data model reference
+
+> 🔧 *This section is for engineers reading the docs in the repo. The Confluence generator strips it.*
+>
+> Authoritative entity definitions live in `src/server/apollo/schema.graphql`. Look up `System`, `Item`, `CatalogueItem`, `Order`, `Employee`, `Team`, and `Link` types for full field shapes and relationship directions. The repo is open-source on GitHub.
+
+## Language
+
+This documentation reflects the English UI. The app currently ships English translations only; Hungarian is planned for ELI ALPS but not on the immediate roadmap.

--- a/docs/user-guide/systemHierarchy/workflows/copying-systems.md
+++ b/docs/user-guide/systemHierarchy/workflows/copying-systems.md
@@ -1,0 +1,105 @@
+# Copying systems
+
+## What this is for
+
+Copy a system — and optionally its entire subtree — under a different parent in the hierarchy. Useful when you need to seed a new branch that mirrors an existing one (e.g., a sibling beamline with the same internal structure as one that already exists), or to clone a template subsystem into multiple parents.
+
+The copy is a **structural skeleton only.** New system entities are created with a fresh UID, the original system's name, system level, and system-type assignment — but **no other data carries over** (see [What gets copied](#what-gets-copied) below). After the copy, source and destination subtrees are completely independent.
+
+## Who can do this
+
+✏️ **Editor / Admin** — requires the `systems-edit` role.
+
+> 🔮 *Coming soon — Phase 1:* the copy action will be scoped by system level. Editors will be able to copy systems at `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, and `TRASH` levels only; copying systems at `SYSTEM_DOMAIN` or `TECHNOLOGY_UNIT` will be admin-only.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You are looking at the System Hierarchy module.
+- You know which system you want to copy (the **source**) and which existing system will be the new parent (the **destination**).
+- See [Key concepts](../README.md#key-concepts) for terminology (system, subsystem, system level).
+
+## Steps
+
+The action is available in two surfaces — the left **tree** and the **Leaves Panel Graph** (middle panel, when the leaves view is in graph mode). The interactions are identical in both.
+
+1. **Right-click the source system.**
+   A context menu opens with **Copy System** and **Paste System** entries.
+
+   `[SCREENSHOT PLACEHOLDER: tree node right-clicked, context menu open with "Copy System" and "Paste System" entries visible]`
+
+2. **Click *Copy System*.**
+   The source system is now held in the copy buffer. There is no on-screen indicator — the buffer is invisible until you paste. (Only one system can be in the buffer at a time; copying another system replaces it.)
+
+3. **Right-click the destination system** — the system you want to be the new parent.
+
+4. **Click *Paste System*.**
+   The **Copy System** dialog opens.
+
+   `[SCREENSHOT PLACEHOLDER: Copy System dialog showing Source block (system name + level badge + parent breadcrumb) above a Destination block, two checkboxes below, Cancel and Copy buttons at the bottom]`
+
+5. **Review the source and destination blocks** in the dialog. Each shows the system name, system-level badge, and the full parent path so you can confirm you've picked the right systems.
+
+6. **Choose the copy options.** Two checkboxes, both default to ON. Their interaction:
+
+   | *Copy only children…* | *Copy recursively…* | Result |
+   |---|---|---|
+   | OFF | OFF | The source system **only** (one node) is copied as a child of the destination. No descendants. |
+   | OFF | ON | The source system **and its entire subtree** are copied. |
+   | ON  | OFF | Each **direct child of the source** is copied as a separate child of the destination. The source itself is skipped; deeper descendants are skipped. |
+   | ON  | ON  | **Default.** Each direct child of the source is copied **with its full subtree**. The source itself is skipped. Useful for grafting a parent's contents into a sibling. |
+
+7. **Click *Copy*.**
+   A toast appears with the progress: *Copying system…* → *System copied successfully* (or an error toast on failure).
+
+   The destination subtree refreshes to show the newly created systems. If the destination was collapsed in the tree, it expands.
+
+`[VIDEO PLACEHOLDER: 30s — right-click source in tree → Copy System → right-click destination → Paste System → review dialog → check defaults → click Copy → see new subtree appear under destination]`
+
+## What gets copied
+
+The copy is a **structural skeleton.** Only the bare minimum needed to recreate the hierarchy is carried over.
+
+**✅ What carries over to each new copy:**
+- **Name** of the source system (verbatim).
+- **System level** (e.g. `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`).
+- **System type** — the new copy points at the same system-type record as the original (the type itself is not duplicated; it's just an assignment).
+- **Facility** — the copy is placed in the same facility as the source.
+- **Parent-child structure** — the internal hierarchy among copied nodes is preserved (only when *Copy recursively* is ON).
+- A fresh audit entry on each copy: the operation timestamp and the user who triggered it.
+
+**❌ What does NOT carry over:**
+- All other system attributes: **description**, **system code**, **importance**, **criticality**, **attribute**, custom property bag.
+- **Physical item** — the original's item stays with the original. Copies start without an item.
+- **Location** and **zone** assignments.
+- **Responsible person**, **responsible team**, **owner**, **operators**, **maintained by** — copies start with no people assigned.
+- **Spare-part relationships** — the copy is not flagged as spare for anything, and nothing is flagged as spare for it.
+- **Engineering relationships** — *powered from*, *cooled from*, *controlled by*, *interlocked by*, *provides data to*, *directs beam to*, *provides vacuum for* (none of the 8 non-structural relationship types carry over). See [Managing relationships](./managing-relationships.md).
+- **Photos and attachments.**
+- **Change history** — copies start with a fresh audit trail; the source's history is not duplicated.
+
+After the copy succeeds you typically need to revisit each new system and fill in the data that didn't carry over.
+
+## Limitations
+
+- **Same facility only.** Source and destination must belong to the same facility. Copying across facilities is not supported.
+- **50-level recursion cap.** The recursive copy walks at most 50 levels of parent-child depth from the source. In practice this is well above any real hierarchy, but if you have a pathologically deep tree, anything below level 50 is silently skipped.
+- **Atomic operation.** The whole copy either succeeds or fails as one transaction — you will not end up with a half-built subtree.
+
+## Tips & gotchas
+
+- **Pasting onto the source** is silently ignored. The dialog does not open if destination equals source.
+- **Pasting without copying first** is silently ignored. The *Paste System* item only triggers a dialog when the buffer holds a system.
+- **The copy is not a link.** After copying, edits to the source do not propagate to the copy and vice versa.
+- **Plan to fill in the gaps.** Because only structure + name + level + system-type carry over, expect to revisit each new copy and assign location, zone, responsible team, items, and any engineering relationships you need.
+- **Reuse names with care.** Names are copied verbatim. If you copy a subtree under a sibling and then look at the wider hierarchy, you will see duplicate names — rename copies that need disambiguation.
+- **Bulk copies can be slow.** Recursive copy of a deep subtree creates many new systems server-side; expect the *Copying system…* toast to sit for a few seconds on large branches.
+- **Use the Graph view** in the Leaves Panel for copy/paste when you want to see siblings while choosing the destination — the visual layout often surfaces a better target than a flat tree expansion.
+
+## Related
+
+- [Navigating the tree](./navigating-the-tree.md)
+- [Editing system details](./editing-system-details.md)
+- [Managing relationships](./managing-relationships.md)
+- Moving a system to a different parent → see the `systemsMoving` module documentation in the [user guide index](../../README.md).

--- a/docs/user-guide/systemHierarchy/workflows/editing-system-details.md
+++ b/docs/user-guide/systemHierarchy/workflows/editing-system-details.md
@@ -1,0 +1,89 @@
+# Editing system details
+
+## What this is for
+
+Update the core attributes of a system on the **Detail** tab: name, description, system code, system level, system type, location, and zone. All edits are inline (click a field, change it, blur to save) and confirmed with a toast. The Detail tab also exposes the special workflow for generating and releasing the system code.
+
+## Who can do this
+
+✏️ **Editor / Admin** — requires the `systems-edit` role. Viewers see the same fields but cannot modify them.
+
+> 🔮 *Coming soon — Phase 1:* edits to systems at `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels will be admin-only; Editors will be restricted to lower levels (`KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, `TRASH`).
+
+> 🔮 *Coming soon — Phase 2:* even with the `systems-edit` role you should be a member of the responsible team to edit a system. Today this is policy only.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You have selected a system whose detail you want to edit (either a leaf in the tree or by clicking *View Detail* on a parent).
+- The **Detail** tab is open (it is the default tab in the detail view).
+- See [Key concepts](../README.md#key-concepts) for terminology (system level, system type, system code).
+
+## Steps
+
+### Inline-editable fields
+
+The Detail tab lays out the editable attributes in a vertical stack. All fields share the same pattern: click a field to enter edit mode, change the value, then click outside (blur) to save. A toast confirms with *Saving…* → *Saved successfully* (or *Failed to save* on error).
+
+`[SCREENSHOT PLACEHOLDER: Detail tab with all fields visible — Name at top, then System Code with Generate/Release buttons, System Level, System Type, Location, Zone, Description at the bottom]`
+
+| Field | Editor | Notes |
+|---|---|---|
+| **Name** | free text | Required-ish (avoid empty names). |
+| **System Code** | special — see below | Inline-displayed, edited via the Generate / Release buttons next to it. |
+| **System Level** | dropdown | Five values, see *System level* section below. |
+| **System Type** | modal codebook picker | Click to open *System Type* selection modal. |
+| **Location** | modal codebook picker | Click to open *Location* selection modal. |
+| **Zone** | searchable combobox | Type to search the zone codebook. |
+| **Description** | multi-line textarea | Expands on focus. |
+
+When a field is empty, it shows the placeholder *None entered*. Fields you can edit also show a *Click to edit* hint on hover.
+
+### System code generation
+
+The **System Code** field has two action buttons next to it: **Generate** and **Release**.
+
+1. **Generate the code automatically.** Click *Generate*. The code is generated server-side based on the system's type, level, location, zone, and ancestry. A toast shows *Generating system code…* → *System code generated and saved*.
+
+   `[SCREENSHOT PLACEHOLDER: System Code row with Generate (and possibly Release) buttons highlighted to the right of the code value]`
+
+2. **Generate is disabled** until a *System Type* is set on the system. Hovering the disabled button shows *System Type is required to generate a code*.
+
+3. **Re-generating an existing code** opens a confirmation modal: *Replace existing system code? Current code "<old>" will be replaced with a new generated code. This action cannot be undone.* Confirm to proceed.
+
+4. **Release the code** with *Release* to clear it. Useful when reorganizing the hierarchy and you want the code freed for reuse. The Release button is hidden when there is no code to release.
+
+5. **Duplicate detection.** If the generated code collides with an existing one, the toast shows *System code "<code>" already exists* and the change is rolled back.
+
+### System level — special meaning
+
+The **System Level** field is more than a label — it drives visual styling, filtering, and (in Phase 1) edit permissions. The five values:
+
+| Level | Meaning |
+|---|---|
+| `SYSTEM_DOMAIN` | Top of the tree. Strategic groupings of systems. |
+| `TECHNOLOGY_UNIT` | Major technological unit (e.g., a beamline or an experimental hall). |
+| `KEY_SYSTEMS` | Distinguished system within a technology unit. |
+| `SUBSYSTEMS_AND_PARTS` | Bulk of the working hierarchy: subsystems, components, individual hardware. |
+| `TRASH` | Holding area for retired or replaced items. **Setting a system to *Trash* does not delete it.** |
+
+> 💡 **About `TRASH`.** A system at the `TRASH` level acts as a designated bin in the hierarchy. When a damaged or replaced item is taken out of an in-service system (typically during a spare-part swap), it is moved into the nearest `TRASH` ancestor walking up the tree, unless the user picks a different destination. Mark a *Trash* system at a sensible point in the subtree where you want decommissioned items to accumulate. See [Managing spare parts](./managing-spare-parts.md) for the full lifecycle.
+
+`[VIDEO PLACEHOLDER: 30s — pick a leaf system, change its name inline, change its system level, click into System Type to open the picker, then click Generate next to the system code and watch it populate]`
+
+## Tips & gotchas
+
+- **Save on blur.** All inline fields save when you click out of them. Pressing *Escape* cancels the edit and reverts the value.
+- **Generate before Release.** If you Release a code, the field is empty and Generate becomes available again — but Generate still requires a System Type.
+- **Modal pickers stack.** When you open the System Type or Location picker, it opens on top of the detail view — close it via its own close button or the backdrop, not the browser back button.
+- **Validation feedback comes via toast** — there is no inline error styling. Watch for *Failed to save* and re-check the value.
+- **Setting level to `TRASH`** does not move the system anywhere or remove its content; it just changes its classification. The tree node continues to live under its current parent.
+- **Description supports line breaks** — useful for short maintenance notes. For long-form documentation prefer Attachments or Links.
+
+## Related
+
+- [Managing system people](./managing-system-people.md) — assign responsible person, team, owner, operators, and maintained-by employees on the **Persons** tab.
+- [Managing physical items](./managing-physical-items.md) — physical-item attributes (EUN, serial, condition) are edited in the Catalogue / Items module, not here.
+- [Managing spare parts](./managing-spare-parts.md) — for the role of the `TRASH` level in the spare-swap flow.
+- [Viewing change history](./viewing-change-history.md) — every edit on this tab appears in the system's history feed.

--- a/docs/user-guide/systemHierarchy/workflows/managing-physical-items.md
+++ b/docs/user-guide/systemHierarchy/workflows/managing-physical-items.md
@@ -1,0 +1,118 @@
+# Managing physical items
+
+## What this is for
+
+Attach a concrete piece of hardware (a *physical item*) to the currently-selected system, or move a hardware item from one system to another while preserving its identity, parameters, and service history. Physical items represent the real-world equipment installed against the abstract systems in the hierarchy.
+
+This workflow covers two actions exposed from the system detail's **Actions** menu: **Assign Item** and **Move Item**.
+
+## Who can do this
+
+✏️ **Editor / Admin** — both Assign Item and Move Item require the `systems-edit` role.
+
+> 🔮 *Coming soon — Phase 1 / Phase 2 permissions:* the same level- and team-based scoping described in [Access & Responsibilities](../README.md#access--responsibilities) will apply to item operations.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You have a system selected.
+- You know whether the item already exists in the catalogue (it should — items are created upstream from a catalogue spec via an order; see *Lifecycle recap* below).
+- See [Key concepts](../README.md#key-concepts) for terminology (catalogue item, physical item, EUN, serial number, item usage).
+
+## Lifecycle recap
+
+Before doing the action, here is where physical items come from. The catalogue / order modules cover this end-to-end; the System Hierarchy module only handles the assignment and movement steps:
+
+1. **Catalogue** — every item starts as a *catalogue item*, an abstract product spec with properties, supplier, and manufacturer link.
+2. **Order** — when procuring hardware, an order is created with order lines; each delivered order line produces a *physical item* in the system.
+3. **Assignment** *(this workflow)* — the item is assigned to a system.
+4. **Movement** *(this workflow)* — the item can later be reassigned to a different system without losing its identity, EUN, serial number, condition status, notes, or service history.
+
+> 💡 **Cardinality.** A system has **at most one** physical item. The relationship is *1 system : 0..1 item* — assigning an item to a system that already has one requires moving the existing item out first (or using the *exchange* path of the Move Item wizard).
+
+> Editing the item's own attributes (condition, notes, service entries) happens in the Catalogue / Items module, not here. System Hierarchy only handles which system an item is on.
+
+## Assigning an item
+
+The **Assign Item** action attaches an existing physical item to the currently-selected system.
+
+1. **Open the system in detail view.** In the detail header, expand the **Actions** menu and pick *Assign Item*.
+
+   `[SCREENSHOT PLACEHOLDER: detail view header with the Actions dropdown open and "Assign Item" highlighted]`
+
+2. **The Assign Item modal opens** as a wide dialog with two steps.
+
+3. **Step 1 — Select Item.** A searchable, filterable table of systems with available items. Each row is a system that currently holds a physical item. Only rows with an item attached are selectable; the rest appear grayed out.
+
+   `[SCREENSHOT PLACEHOLDER: Assign Item modal Step 1 showing a search bar at top, filter buttons, and a table of systems-with-items where one row is highlighted in orange as the currently selected source]`
+
+4. **Search and filter** to find the right item. The search bar is free-text; the filter buttons offer system type, level, and other facets.
+
+5. **Click a row** to mark it as the source. The row highlights in orange. *Next* enables.
+
+6. **Click *Next*.** The modal advances to the summary.
+
+7. **Step 2 — Summary.** Review the item that will be assigned and the destination system. Confirm.
+
+8. **Confirm.** A toast confirms the assignment. The system's *Physical Item* tab now shows the assigned item; the *Move Item* action becomes available.
+
+> **Note:** "Assign Item" picks an *existing* item already in the system somewhere, sourced from another system. To create a *brand new* item from scratch, you must do that upstream via an order in the Orders module.
+
+## Moving an item
+
+The **Move Item** action transfers the physical item currently attached to the selected system to a different system.
+
+The wizard has a dynamic step count (3 to 5 steps) depending on the destination's state.
+
+1. **Move Item is only visible** when the current system has a physical item to move. If the system has no item, the action is hidden in the menu.
+
+2. **Open the wizard.** From the **Actions** menu, pick *Move Item*. The wizard opens.
+
+3. **Step — Pick the move mode.** Choose between:
+   - *Move to a new (empty) system.*
+   - *Move to a destination system that already has its own item* (this triggers an *exchange*: the destination's existing item has to go somewhere too).
+
+4. **Step — Select destination system.** A searchable, filterable hierarchy table; click a system to highlight it as the destination.
+
+   `[SCREENSHOT PLACEHOLDER: Move Item wizard step showing the system selection table with one destination row highlighted in orange, search and filters at the top]`
+
+5. **Step — System detail (if creating context).** Confirm or fill in destination metadata.
+
+6. **(Exchange only) Step — Pick parent for the displaced item.** When the destination already has an item, the wizard asks where its current item should go. Pick a parent system to receive it.
+
+7. **Step — Final summary.** Review:
+   - The item being moved.
+   - Source system → destination system.
+   - In the exchange path: the destination's old item and where it will land.
+
+8. **Confirm.** Toast confirms; both the source and destination subtrees refresh.
+
+`[VIDEO PLACEHOLDER: 45s — open Actions on a system that has an item, click Move Item, walk through the wizard for an exchange (pick a destination that has its own item, pick where the displaced item should go), confirm, then verify the source system now has the new item]`
+
+## What carries over on a move
+
+When an item is moved:
+
+- ✅ **Identity** preserved — same database record, same UID.
+- ✅ **EUN, serial number, notes, condition status, item usage** all carry over.
+- ✅ **Service history** preserved.
+- ✅ The catalogue item the physical item is based on is unchanged.
+
+Only the *which system holds this item* assignment changes.
+
+## Tips & gotchas
+
+- **You cannot create new items from System Hierarchy.** Assignment picks from items that already exist in the system somewhere. New items come from orders.
+- **The 1:0..1 cardinality is enforced** — you cannot stack two items onto one system. The Move Item wizard's exchange path is the supported way to swap items between systems.
+- **Service history travels with the item**, not with the system. If you move an item, the destination system's *History* timeline picks up the move event; the item's full service log stays attached to the item itself in the Items module.
+- **Filter by EUN or serial number** in the leaves panel ([Searching and filtering](./searching-and-filtering.md)) when you're trying to track down which system currently holds a specific piece of hardware.
+- **An item-usage change** (in use → in storage, etc.) is done in the Catalogue / Items module, not here. After a move you may also want to update usage there.
+- **Use the *Use Spare* flow when the move is a spare-part swap** — that path moves both items at once and routes the old one toward the nearest TRASH ancestor automatically. See [Managing spare parts](./managing-spare-parts.md) (today the Use Spare action lives in a deprecated shared flow; coming to System Hierarchy).
+
+## Related
+
+- [Managing spare parts](./managing-spare-parts.md) — for the structured swap flow that handles items + relationships in one step.
+- [Editing system details](./editing-system-details.md) — for system-level fields that influence item placement.
+- [Viewing change history](./viewing-change-history.md) — item assignment and move events appear under *Item Changes* and *Item Moves*.
+- Catalogue, Orders, and Items modules → see [user guide index](../../README.md).

--- a/docs/user-guide/systemHierarchy/workflows/managing-relationships.md
+++ b/docs/user-guide/systemHierarchy/workflows/managing-relationships.md
@@ -1,0 +1,129 @@
+# Managing relationships
+
+## What this is for
+
+View, create, and remove **engineering relationships** between systems — the directed links describing how systems depend on each other (one is powered from another, one cools another, one provides data to another, and so on). Unlike the parent-child structural hierarchy of the tree, these relationships cross the tree freely and form a multi-edge graph.
+
+Three different surfaces in the module touch relationships, all documented here.
+
+## Who can do this
+
+| Action | Role required |
+|---|---|
+| View list and graph of relationships | `systems-view` (👁️ Viewer or higher) |
+| Create / delete edges | `systems-edit` (✏️ Editor / Admin) |
+
+> 🔮 *Coming soon — Phase 1:* edge creation and deletion will be scoped by system level. Editors will only be able to manage edges where both endpoints are at `KEY_SYSTEMS` or below; admins handle anything touching `SYSTEM_DOMAIN` or `TECHNOLOGY_UNIT`.
+
+> 🔮 *Coming soon — Phase 2:* even with the `systems-edit` role you should be a member of the responsible team to edit relationships on a system. Today this is policy only.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You have a system selected.
+- See [Key concepts](../README.md#key-concepts) for terminology (system, system level, spare part).
+
+## The 9 relationship types
+
+Eight engineering types plus the structural parent-child relationship. The graph view shows all nine; the *Relationships* list groups them by **Inbound** (things pointing at this system) and **Outbound** (things this system points at).
+
+| Type | Outbound label | Inbound label | Use case |
+|---|---|---|---|
+| **Parent / child** | *(structural)* | *(structural)* | The hierarchy itself — one system is a subsystem of another. |
+| **Has spare** | Spare for | Has spare | One system is designated as a spare for another. See [Managing spare parts](./managing-spare-parts.md). |
+| **Cooling** | Cooled from | Cools | The source system supplies cooling to the target. |
+| **Power** | Powered from | Powers | The source system supplies electrical power to the target. |
+| **Control** | Controlled by | Controls | The target governs the operation of the source. |
+| **Interlock** | Interlocked by | Interlocks | The target is part of the safety interlock chain protecting the source. |
+| **Data** | Provides data to | Receives data from | Data acquisition / telemetry routing. |
+| **Beam** | Directs beam to | Receives beam from | Photon beam routing along the beamline. |
+| **Vacuum** | Provides vacuum for | Receives vacuum from | Vacuum supply dependency. |
+
+## Surfaces
+
+There are three surfaces where relationships are visible. They share the same data; the difference is in scope and interaction.
+
+### 1. Leaves Panel Graph (middle panel)
+
+Shown when the leaves panel is in **Graph View** instead of *Tree View* (toggle in the panel header — see [Navigating the tree](./navigating-the-tree.md)).
+
+- **Nodes:** the *children* of the currently-selected parent system (the same set as the leaves table).
+- **Edges:** all 9 relationship types, including parent-child, between those children.
+- **Use case:** see how the children of a hierarchy node are interconnected — handy when reorganizing a subtree.
+
+`[SCREENSHOT PLACEHOLDER: Leaves panel in Graph View showing several child systems as colored nodes with directed edges of multiple types between them, legend at the side]`
+
+### 2. Detail → Graph tab
+
+Open from the **Graph** tab inside the system detail view.
+
+- **Nodes:** the currently-selected system itself plus everything it directly relates to across the engineering types.
+- **Edges:** **the 8 engineering types — the parent-child structural edge is hidden by default** (this is intentional: the graph is for engineering view; structural parent-child is what the tree is for).
+- **Use case:** "show me the dependencies of *this* specific system."
+
+`[SCREENSHOT PLACEHOLDER: Detail Graph tab with the current system as the central node, engineering relationships radiating to neighbors, legend showing colored edge types]`
+
+### 3. Detail → Relationships tab (list view)
+
+A flat, grouped list. Acts as the read-only / mobile fallback to the graph.
+
+- **Inbound** group at top, **Outbound** below — each labeled with an arrow icon.
+- Each row: direction label (e.g. *Cooled from*) on the left, the related system shown as a navigable pill (item-usage icon, name, system code), and a delete icon on the right (Editors / Admins only).
+- **Click the pill** to navigate to that related system.
+- **Click the delete icon** to delete that edge — see *Deleting an edge* below.
+
+`[SCREENSHOT PLACEHOLDER: Relationships tab showing Inbound section with two rows and Outbound section with three rows, each row has a colored direction label, a system pill in the middle, and a delete icon on the right (Editor view)]`
+
+## Steps
+
+### Viewing relationships
+
+1. **Open the system in detail view.** Click the **Relationships** tab to see the list, or **Graph** for the graph view.
+
+2. **In the graph,** use the legend to identify edge types by color. Pan with click-drag, zoom with the scroll wheel.
+
+3. **Filter the graph.** The graph header has filter controls: by system level, by system type, and by relationship type. The relationship-type filter on the Detail Graph persists between sessions.
+
+4. **Click a node** in the graph to navigate to that system.
+
+### Creating an edge
+
+5. **Switch to a graph view** (Leaves Panel Graph or Detail Graph tab) — edges cannot be created from the list view.
+
+6. **Initiate edge creation** by dragging from a node's connector handle to the target node, or via the node action menu (depends on the connector). The graph offers a *Source* and *Target* selection prompt — confirm both.
+
+   `[SCREENSHOT PLACEHOLDER: graph view with two nodes highlighted as Source and Target during an in-progress edge creation, the relationship-type picker visible]`
+
+7. **Pick the relationship type** when prompted. The 8 engineering types are available; structural parent-child cannot be created from here (use Systems Moving for that).
+
+8. **Confirm.** A toast confirms creation. The edge appears immediately and is also listed under *Relationships*.
+
+### Deleting an edge
+
+9. **From the list view:** click the delete icon at the right of the row, then confirm in the *Delete this relationship?* modal. Toast: *Deleting relationship…* → *Relationship deleted*.
+
+   `[SCREENSHOT PLACEHOLDER: confirmation dialog "Delete this relationship?" with Cancel and Confirm buttons]`
+
+10. **From a graph view:** select the edge (click it) and use the delete action in the edge inspector. Same confirmation modal.
+
+11. **Already-deleted edges** show a friendly message: *Relationship was not found (may have been already deleted)*.
+
+`[VIDEO PLACEHOLDER: 30s — open a system in detail, view the Relationships tab list, switch to the Graph tab and pan around, click an edge to inspect, delete it via the inspector, confirm the modal]`
+
+## Tips & gotchas
+
+- **Parent-child is hidden by default in Detail Graph.** If you want to see the structural edge, enable it in the relationship-type filter — but for browsing the hierarchy, the tree on the left is faster.
+- **Direction matters.** *Cooled from A* means the cooling supply flows *from* A into this system. Read the direction label carefully; the graph also shows direction with arrows.
+- **Use the Leaves Panel Graph when reorganizing.** It shows children of the current parent, so you see siblings at a glance — useful when you need to move dependencies during a refactor.
+- **Spare relationships** appear here too, but the Spare Parts table on its own tab is a more useful view if you only care about coverage. See [Managing spare parts](./managing-spare-parts.md).
+- **Edge counts on the side panel** include all relationship types — if a number looks high, the parent-child edge is included.
+- **Deletion is permanent.** Edges have no soft-delete; the only way to restore one is to recreate it.
+- **Where edges are created in production.** Today the most reliable way to create engineering relationships is the Systems Relations module (see [user guide index](../../README.md)) which has dedicated bulk and per-pair flows. The graph creation in System Hierarchy is a quick path for one-off changes.
+
+## Related
+
+- [Navigating the tree](./navigating-the-tree.md) — for the structural hierarchy and the table↔graph toggle.
+- [Managing spare parts](./managing-spare-parts.md) — for the *Has spare* / *Spare for* relationship in detail.
+- [Editing system details](./editing-system-details.md) — system attributes, including system level which scopes Phase 1 permissions.
+- [Viewing change history](./viewing-change-history.md) — relationship changes appear in the History timeline as well.

--- a/docs/user-guide/systemHierarchy/workflows/managing-spare-parts.md
+++ b/docs/user-guide/systemHierarchy/workflows/managing-spare-parts.md
@@ -1,0 +1,100 @@
+# Managing spare parts
+
+## What this is for
+
+See which systems have been designated as spare parts for the currently-selected system, how well-covered the system is against its required minimum, and understand how a spare swap works conceptually. **The Spare Parts tab in System Hierarchy is read-only** — assignments and the swap action live in other modules today.
+
+## Who can do this
+
+| Action | Where | Role required |
+|---|---|---|
+| View the Spare Parts tab and coverage | System Hierarchy → Spare Parts tab | `systems-view` (👁️ Viewer or higher) |
+| Assign / unassign a system as a spare | **Systems Relations** module | `systems-edit` (✏️ Editor / Admin) |
+| Perform a spare swap (*Use Spare*) | Currently the deprecated shared spare flow (feature-flagged off in production) | `systems-edit` (✏️ Editor / Admin) |
+
+> 🔮 *Coming soon — Use Spare in System Hierarchy:* the spare-swap wizard will be brought into this module. Today it lives in a deprecated flow that is disabled in production via the `enableSparePartsAssignment` feature flag.
+
+> 🔮 *Coming soon — Phase 1 / Phase 2 permissions:* the same level- and team-based scoping described in [Access & Responsibilities](../README.md#access--responsibilities) will apply.
+
+## Prerequisites
+
+- You have a system selected and the **Spare Parts** tab is open in the detail view.
+- See [Key concepts](../README.md#key-concepts) for terminology (spare part, coverage, physical item, catalogue item).
+
+## What the Spare Parts tab shows
+
+The tab shows all systems flagged as a spare for the currently-selected system, plus the aggregate coverage at the top.
+
+`[SCREENSHOT PLACEHOLDER: Spare Parts tab with header reading "Available 3 out of 5 required" and a table below with columns Icon, Name, Location, Coverage, Part Number, EUN — coverage values in red and green]`
+
+**Header:** *Available {available} out of {required} required* — sum of available spare units against the configured minimum on the parent system.
+
+**Columns:**
+
+| Column | What it shows |
+|---|---|
+| (Icon) | Item-usage icon for the spare's physical item (in use, in storage, …). Sticky and not hideable. |
+| **Name** | Spare-part system name. Hovering shows the full ancestor path. |
+| **Location** | Location name and code (e.g. *Lab A — LC-001*). |
+| **Coverage** | Numeric coverage value, two decimals, color-coded — see *Coverage colors* below. |
+| **Part Number** | Catalogue number of the spare's physical item. |
+| **EUN** | Equipment Unique Number of the spare's physical item. |
+
+**Coverage colors:**
+
+- 🟢 **Green** — coverage **meets or exceeds** the configured minimum on the parent.
+- 🔴 **Red** — coverage is **below** the configured minimum (insufficient spares).
+- ⚪ **Gray** — no minimum threshold is configured on the parent.
+
+**Interactions:**
+
+- **Click a row** to navigate to the spare system's detail.
+- **Sort and reorder columns** like any other table; column visibility is configurable, except the icon column.
+- **No row-level actions** — the tab is read-only.
+
+## How spares conceptually work
+
+Even though System Hierarchy doesn't expose the swap action today, you should know how the underlying flow works because the *Spare Parts* tab and the [Managing relationships](./managing-relationships.md) view both reflect it.
+
+### The swap
+
+A spare swap operates on **physical items at the system level**, not on the systems themselves. The hierarchy stays put.
+
+1. **Source system** — the in-service system whose item failed or is being replaced.
+2. **Spare system** — a system designated as a spare for the source (an *Has spare* relationship).
+3. The spare's *physical item* moves into the **source system**.
+4. The source system's **old item** is moved out — see *Old item destination* below.
+
+After the swap, the source system continues to operate (now with the spare's item installed) and the spare system has been emptied of its physical item.
+
+### Old item destination
+
+The old item that just came out of the source system has to go somewhere:
+
+- **Default** — it is moved into the **nearest ancestor whose system level is `TRASH`**, walking up the tree. This is why placing one or more `TRASH`-level systems sensibly in your hierarchy matters: they are the natural collection points for retired or damaged items.
+- **User-chosen** — when running the swap, the user can override the default and pick a different target system to receive the old item. This is useful when the item still has life and you want it parked under a "to be repaired" branch instead of plain `TRASH`.
+
+> 💡 The item's identity, parameters (EUN, serial, condition status), notes, and service history all carry over with the move. The item is the same database record from before the swap; only its assignment to a system changes.
+
+## Where assignments are made
+
+**Today:** spare-part relationships (an *Has spare* edge between two systems) are created in the **Systems Relations** module — see [user guide index](../../README.md). System Hierarchy only shows the result on the *Spare Parts* tab and on the *Relationships* tab.
+
+When the Use Spare action ships in System Hierarchy, this section will be updated.
+
+`[VIDEO PLACEHOLDER: 30s — select a key system, open the Spare Parts tab, point out the coverage header (red vs green), click a spare row to navigate to it, then back to the source]`
+
+## Tips & gotchas
+
+- **Coverage is computed automatically** from the spare relationships and their items — you don't enter it manually.
+- **A spare without a physical item is still listed** but contributes nothing to coverage. If a spare row shows up in red and has no Part Number / EUN, the assigned spare system has no item attached yet.
+- **Plan your `TRASH` levels.** A facility-wide convention for where TRASH systems sit (one per technology unit? one global?) makes the swap default predictable.
+- **"Has spare" vs "Spare for"** appear mirrored on the source and on the spare system. Same edge, different perspective.
+- **Use the relationship view for the engineering picture** — spares are also visible in the Detail → Graph tab as colored edges. See [Managing relationships](./managing-relationships.md).
+
+## Related
+
+- [Managing relationships](./managing-relationships.md) — for the *Has spare* / *Spare for* edges in the broader graph.
+- [Editing system details](./editing-system-details.md) — for the `TRASH` level and other system-level meanings.
+- [Managing physical items](./managing-physical-items.md) — for how items are assigned and moved (the swap is a special case of moving items).
+- Systems Relations module → see [user guide index](../../README.md) — for creating spare-part assignments.

--- a/docs/user-guide/systemHierarchy/workflows/managing-system-people.md
+++ b/docs/user-guide/systemHierarchy/workflows/managing-system-people.md
@@ -1,0 +1,76 @@
+# Managing system people
+
+## What this is for
+
+Assign and update the people accountable for a system on the **Persons** tab: the responsible person, the responsible team, the (read-only) owner, plus the *Authorized Operators* and *Maintained By* tables. These assignments drive accountability today and — once Phase 2 ships — the technical edit permissions for the system's subtree.
+
+## Who can do this
+
+✏️ **Editor / Admin** — requires the `systems-edit` role to make changes. Viewers see the Persons tab but cannot modify it.
+
+> 🔮 *Coming soon — Phase 1:* changes to systems at `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels (where responsibility decisions are most consequential) will be admin-only.
+
+> 🔮 *Coming soon — Phase 2:* responsible-team membership will technically gate edits to a system and its subtree. **Today this is policy only — the application does not enforce it.**
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You have a system selected and the **Persons** tab is open in the detail view.
+- You know which employee or team to assign.
+- See [Key concepts](../README.md#key-concepts) for terminology (responsible person, responsible team, owner, operators, maintained by).
+
+## Steps
+
+### Single-person fields
+
+The top of the tab shows three single-employee fields. All save on blur (toast: *Saving…* → *Saved successfully*).
+
+`[SCREENSHOT PLACEHOLDER: top of the Persons tab showing Responsible Person, Owner (greyed out), and Team (responsible team) as inline combobox fields]`
+
+| Field | Editor | Notes |
+|---|---|---|
+| **Responsible Person** | searchable combobox (employee codebook) | Single value. The person ultimately accountable for the system. |
+| **Owner** | read-only | Computed by the system; not directly editable. |
+| **Team** (responsible team) | searchable combobox (team codebook) | Single value. **High-impact field** — see below. |
+
+1. **Set the Responsible Person.** Click the *Responsible Person* field, type to search the employee codebook, pick the result. The field saves as soon as you blur it.
+
+2. **Set the Responsible Team.** Same pattern with the *Team* field. Read the warning below before changing this on an established subtree.
+
+3. **Owner is informational only.** It reflects an ownership computation and cannot be edited from this UI.
+
+> ⚠️ **Changing the responsible team is a high-impact change.**
+> The responsible team determines who *should* be allowed to edit this system and its subtree (per documented policy today, technically enforced in Phase 2). Reassigning the team can move edit-rights for the entire subtree from one team to another. Make sure the new team is aware before changing this.
+
+### Operators and Maintained-By tables
+
+The lower portion of the tab shows two employee-list tables: **Authorized Operators** and **Maintained By**. They behave identically.
+
+> **Note:** these tables are only shown when the system level is **not** `SUBSYSTEMS_AND_PARTS`. At the lowest level of the hierarchy individual operator/maintainer assignments aren't tracked here — they roll up from a higher-level system.
+
+`[SCREENSHOT PLACEHOLDER: Authorized Operators and Maintained By tables stacked, each showing 2-3 employee rows with a delete icon on the right and a "+" button in the table header]`
+
+4. **Add an employee to a table.** Click the **+** button in the table header. A modal opens with a searchable list of employees; employees already on the table are excluded so you cannot add duplicates.
+
+5. **Pick an employee** from the modal. The row appears in the table immediately.
+
+6. **Remove an employee.** Click the delete icon at the right of a row. A confirmation appears (*Remove <employee name>?*); confirming removes the row.
+
+7. **The + and delete controls are hidden** for users without the `systems-edit` role. Read-only users see the assignment list but no add or remove affordances.
+
+`[VIDEO PLACEHOLDER: 30s — open the Persons tab on a key system, change the Responsible Person inline, then click + on Authorized Operators, pick two employees from the modal, remove one of them via the delete icon and confirm the dialog]`
+
+## Tips & gotchas
+
+- **Search the codebook by typing.** All three single-person fields and the operator/maintained-by modals search on free text — type a partial last name to narrow down quickly.
+- **Each system has at most one responsible person and one responsible team.** Operators and maintained-by are multi-value lists.
+- **The Persons tab feeds the *Quick Info* sidebar** — assignment changes show up there immediately on the right.
+- **Operator and maintained-by changes are mid-impact.** They affect day-to-day operation and on-call rotas; mention any change to the affected employees.
+- **When the operator/maintained-by tables don't appear,** check the system level — they are intentionally hidden at `SUBSYSTEMS_AND_PARTS`.
+
+## Related
+
+- [Editing system details](./editing-system-details.md) — for non-people fields on the Detail tab.
+- [Managing relationships](./managing-relationships.md) — engineering links between systems.
+- [Viewing change history](./viewing-change-history.md) — all assignment changes (responsible person/team, operators, maintained-by) appear in the system's history feed.

--- a/docs/user-guide/systemHierarchy/workflows/navigating-the-tree.md
+++ b/docs/user-guide/systemHierarchy/workflows/navigating-the-tree.md
@@ -1,0 +1,72 @@
+# Navigating the tree
+
+## What this is for
+
+Move around the system hierarchy: open a tree node, drill down to its subsystems, jump up via the breadcrumb, and switch between a table view and a relationship-graph view of the children. This is the foundation of every other workflow — most user journeys start by selecting a system in the tree.
+
+## Who can do this
+
+👁️ **All personas** — navigation is read-only and available to anyone with the `systems-view` role.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You are looking at the System Hierarchy module.
+- See [Key concepts](../README.md#key-concepts) for terminology (system, subsystem, system level, system code).
+
+## Steps
+
+### Browsing the tree
+
+1. **Open the System Tree on the left.** The header shows *System Tree*, a search input, and a *Collapse All* button.
+
+   `[SCREENSHOT PLACEHOLDER: left tree panel with several top-level system domains visible, one expanded showing two levels of children, count badges on the right of each node]`
+
+2. **Click the chevron** next to a node to expand it, or click the node label to select it. Selecting a node automatically expands all its ancestors so you can always see where you are in the tree.
+
+3. **Read each node:** name on the left (highlighted if a search term matches), a folder icon colored by system level, and a small badge with the count of direct subsystems. The badge shows `…` while the count is loading.
+
+4. **Click *Collapse All*** to fold the entire tree back to the top level.
+
+### Reading the breadcrumb
+
+5. **Look above the leaves panel** for the breadcrumb. It shows the full ancestor path of the currently selected system, ending with the system name and its system-code badge in bold.
+
+   `[SCREENSHOT PLACEHOLDER: breadcrumb showing ancestors separated by ">" arrows, ending with the current system in bold and a code badge]`
+
+6. **Click any ancestor** in the breadcrumb to navigate to it. The leaves panel and detail update to that ancestor.
+
+7. **Long paths collapse** with an ellipsis: if there are more than four ancestors, the breadcrumb shows the first ancestor, an ellipsis, and the last two. The ellipsis itself is not clickable.
+
+### Working with the leaves panel
+
+8. **Pick a parent in the tree.** The middle panel shows that parent's direct subsystems — its *leaves*. The panel header reads *Subsystems*. If the parent has no children, you see *No subsystems found*.
+
+9. **Use the view switcher** in the panel header to flip between two layouts:
+
+   - **Tree View** (default) — a sortable, paginated table of subsystems with columns for code, path, name, type, location, zone, importance, and spare counts. See [Searching and filtering](./searching-and-filtering.md) for the toolbar above it.
+   - **Graph View** — a relationship graph centered on the selected parent's children, showing how they relate to each other. See [Managing relationships](./managing-relationships.md) for full graph controls.
+
+   `[SCREENSHOT PLACEHOLDER: Subsystems panel with the view switcher (Tree View / Graph View buttons) at the top right of the header, currently in Tree View showing a table of subsystems]`
+
+10. **Click any subsystem row** in the table to open its detail view (or click any node in the graph). The breadcrumb updates and the right sidebar populates with that system's *Quick Info*.
+
+11. **Use *View Detail*** in the leaves panel header to open the full detail of the *currently-selected parent itself* (rather than one of its children).
+
+`[VIDEO PLACEHOLDER: 30s — expand a top-level domain in the tree, drill two levels down by clicking nodes, watch the breadcrumb update, click an ancestor in the breadcrumb to jump back, then switch the leaves panel to Graph View and back]`
+
+## Tips & gotchas
+
+- **Selecting and expanding are different.** Clicking a node selects it (and the leaves panel updates); clicking the chevron expands without selecting. This is useful when you want to inspect a sibling without losing your current selection.
+- **The graph view is per-parent.** It shows children of the parent you've selected, not the whole tree. To see relationships from a specific system's perspective, open its full detail and use the *Graph* tab — see [Managing relationships](./managing-relationships.md).
+- **The quick-info sidebar** on the right always reflects the *currently selected* system, not the parent you're browsing in the leaves panel. Selecting a leaf row updates it.
+- **Mobile layout** collapses the tree behind a toggle and replaces the right sidebar with a floating *Info* button.
+- **The tree shows folder icons** colored by system level — use this as a quick visual cue for what kind of node you're looking at without having to read the breadcrumb.
+
+## Related
+
+- [Searching and filtering](./searching-and-filtering.md) — narrow down what's shown in the leaves panel.
+- [Editing system details](./editing-system-details.md) — once you've reached a system, edit its attributes.
+- [Managing relationships](./managing-relationships.md) — full graph view controls and edge editing.
+- [Copying systems](./copying-systems.md) — right-click context menu on a tree node.

--- a/docs/user-guide/systemHierarchy/workflows/searching-and-filtering.md
+++ b/docs/user-guide/systemHierarchy/workflows/searching-and-filtering.md
@@ -1,0 +1,104 @@
+# Searching and filtering
+
+## What this is for
+
+Quickly find specific subsystems within the *currently selected* parent, either by free-text search across common fields or by a multi-field filter sheet that can combine many criteria. The active filter set is reflected in the URL so you can share or bookmark a view.
+
+## Who can do this
+
+👁️ **All personas** — search and filter are read-only and available to anyone with the `systems-view` role.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You are looking at the System Hierarchy module.
+- You have selected a parent system in the tree (search and filter operate on its subsystems — the leaves panel).
+- See [Key concepts](../README.md#key-concepts) for terminology (system level, system type, EUN, catalogue item).
+
+## Steps
+
+### Free-text search
+
+1. **Find the search box** in the leaves panel toolbar (next to the *Filters* button at the top of the *Subsystems* table).
+
+   `[SCREENSHOT PLACEHOLDER: leaves panel toolbar with Filters button on the left, search input in the middle, column-visibility dropdown on the right]`
+
+2. **Type a query.** Search is debounced — results update shortly after you stop typing. The query also becomes part of the URL so you can copy the link to a colleague.
+
+3. **Clear the search** by emptying the input. The full subsystem list returns.
+
+> **Tip:** the toolbar search filters only the *leaves panel* (children of the selected parent), not the whole hierarchy. To search the whole tree, use the search box at the top of the System Tree on the left — see [Navigating the tree](./navigating-the-tree.md).
+
+### Opening the filter sheet
+
+4. **Click *Filters*** in the leaves panel toolbar. A side sheet slides in with all available filter fields.
+
+5. **Watch the filter button:** when one or more filters are active, the button is filled (vs. outline when empty) and a *Filters Applied* tooltip appears on hover. A row of filter badges appears below the toolbar summarizing what is active.
+
+   `[SCREENSHOT PLACEHOLDER: leaves panel with the Filters button highlighted/filled and a row of small filter badges visible below the toolbar]`
+
+### Filter fields
+
+The filter sheet is laid out in two columns. All fields combine with AND.
+
+| Group | Field | Type |
+|---|---|---|
+| **System** | Name | text |
+|  | System Code | text |
+|  | System Level | multi-select (multi-checkbox) |
+|  | System Type | combobox |
+|  | Importance | multi-select |
+|  | Description | text |
+|  | Spare Parts Coverage | numeric range (Min / Max) |
+|  | Critical SP Coverage | checkbox |
+| **People** | Responsible Person | multi-select (employee codebook) |
+| **Place** | Zone | multi-select |
+|  | Location | location combobox |
+| **Item / Catalogue** | Item Usage | multi-checkbox (e.g. *In use*, *In storage*) |
+|  | EUN | text |
+|  | Part Number / Catalogue Number | text |
+|  | Serial Number | text |
+|  | Catalogue Name | text |
+|  | Category | catalogue category combobox (tree picker) |
+|  | Supplier | multi-select |
+|  | Price | range slider (min/max derived from data) |
+| **Order** | Order Name | text |
+|  | Order Number | text |
+|  | Order Request Number | text |
+|  | Order Contract Number | text |
+
+`[SCREENSHOT PLACEHOLDER: filter sheet open with several fields filled in across both columns, showing the variety of types — text inputs, multi-checkboxes, a range slider]`
+
+### Dynamic property filters
+
+6. **Pick a *Category*** in the catalogue section. When a category is selected, two extra sections appear at the bottom of the sheet:
+
+   - **Category Properties** — filters keyed to the properties defined on that catalogue category.
+   - **Item Properties** — filters keyed to per-item property values within that category.
+
+   These are dynamic and depend on which category you picked, so they only show up when relevant.
+
+### Applying, saving, and clearing
+
+7. **Save your filter setup** with *Save Settings* in the footer of the sheet — this stores the current filter combination as a named preset for later reuse.
+
+8. **Clear everything** with *Clear Filters* in the footer. The form resets and all column filters in the table clear.
+
+9. **Close the sheet** by clicking outside it or using the close icon. Active filters remain applied.
+
+`[VIDEO PLACEHOLDER: 30s — type a search term and watch the table filter, then open the Filters sheet, set a system level + responsible person + price range, see the badge row appear below the toolbar, then clear all filters]`
+
+## Tips & gotchas
+
+- **Filters live in the URL.** The current filter set is encoded as a query parameter — you can share the URL or bookmark it to come back to the same view.
+- **Search and filters compose.** A free-text search applies on top of any active filter set; the displayed table is the intersection.
+- **Spare-part coverage range** treats blank Min/Max as "no bound" — leave one side empty to filter only on the other.
+- **Category-driven property filters** disappear if you remove the category. If you saved a preset that included property filters, switching categories may leave you with stale property filters that no longer match anything — clear and reapply.
+- **The price range** picks up its dynamic min/max from the currently visible data set, so the slider bounds shift as the rest of the filters narrow the data.
+
+## Related
+
+- [Navigating the tree](./navigating-the-tree.md) — for searching the whole tree (left search box) instead of just the current leaves panel.
+- [Editing system details](./editing-system-details.md) — once you've found the system you wanted.
+- [Managing physical items](./managing-physical-items.md) — many of the filter fields key off catalogue and order data attached to physical items.

--- a/docs/user-guide/systemHierarchy/workflows/viewing-change-history.md
+++ b/docs/user-guide/systemHierarchy/workflows/viewing-change-history.md
@@ -1,0 +1,102 @@
+# Viewing change history
+
+## What this is for
+
+See a chronological feed of every change that has ever been made to a system: who made the change, when, what kind of change, and the exact field values before and after. The History tab is the audit trail for the system — useful for figuring out why a system is in its current state, who reassigned a responsible team, or when a physical item was moved.
+
+## Who can do this
+
+👁️ **All personas** — viewing history requires only the `systems-view` role. There is no "edit history" — entries are written automatically as side effects of other actions.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
+
+## Prerequisites
+
+- You have a system selected and the **History** tab is open in the detail view.
+- See [Key concepts](../README.md#key-concepts) for terminology (system, physical item, responsible team).
+
+## What the History tab shows
+
+The History tab is a vertically scrolling timeline of events. Each entry shows:
+
+- **User** — who made the change.
+- **Action badge** — color-coded by event type (see *Event types* below).
+- **Message** — the human-readable description of what happened, with the changed field and its values inline.
+- **Timestamp** — right-aligned, when the change happened.
+
+`[SCREENSHOT PLACEHOLDER: History tab with the filter bar at the top (action-type radio group + user dropdown), and below it a vertical feed of 4-5 history entries showing user, action badge, change message, and timestamp]`
+
+### Event types
+
+The action badge maps to one of four types:
+
+| Type | Meaning |
+|---|---|
+| **General** | Any change to system attributes (name, code, level, location, zone, type, description, importance, persons, etc.). |
+| **Item Changes** | Edits to the physical item attached to this system (condition, usage, notes, etc.). |
+| **System Moves** | This system was moved to a different parent in the hierarchy. |
+| **Item Moves** | The physical item attached to this system was moved (assigned to a different system). |
+
+### Field-change message format
+
+Most *General* and *Item Changes* entries describe a specific field that changed. The message format follows one of three patterns:
+
+| Situation | Message |
+|---|---|
+| Value was **set** (previously empty) | *set **<field>** to **<newValue>*** |
+| Value was **changed** | *changed **<field>** from **<oldValue>** to **<newValue>*** |
+| Value was **cleared** | *cleared **<field>*** |
+
+Empty values are rendered as **(empty)** in the message — useful when distinguishing "field was set to blank" from "field was unchanged".
+
+## Steps
+
+### Browsing the timeline
+
+1. **Open the History tab.** The most recent entries appear at the top. Scroll down to see older entries.
+
+2. **Read the message** to understand what changed. Bolded values are the field name and the before/after values. The user shown is whoever was logged in when the change was made.
+
+3. **Hover the timestamp** if you need finer time precision than the rendered format.
+
+### Filtering by action type
+
+4. **Use the *Filter by action type*** radio group at the top of the tab to narrow to one event class:
+
+   - **All** (default) — all event types.
+   - **General** — system-attribute edits.
+   - **Item Changes** — physical-item edits.
+   - **System Moves** — hierarchy moves of this system.
+   - **Item Moves** — moves of the physical item that was on this system.
+
+   `[SCREENSHOT PLACEHOLDER: filter bar with the action-type radio group expanded showing All / General / Item Changes / System Moves / Item Moves options]`
+
+### Filtering by user
+
+5. **Use the *Filter by user*** dropdown next to the action-type filter. The dropdown is populated from the users who appear in the history of *this specific system* — so you only see relevant users, not the entire workforce.
+
+6. **Pick *All users*** to clear the user filter without resetting the action-type filter.
+
+### Reading move events
+
+7. **System Moves** entries describe a move of this system itself: *"<user> moved this system from <oldParent> to <newParent>"* (paraphrased — exact wording depends on the data).
+
+8. **Item Moves** entries record when the physical item attached to this system was reassigned — note the lifecycle: an item that *moves out* of this system stops contributing to its history afterwards.
+
+`[VIDEO PLACEHOLDER: 30s — open the History tab, scroll the timeline, filter to "General" and watch the feed shrink, then add a user filter and watch it shrink further, then reset filters]`
+
+## Tips & gotchas
+
+- **History is per-system.** When you select a different system, the timeline resets to that system's events. Move events are only recorded once — on the system that moved.
+- **History does not include relationship changes** the same way it includes attribute changes — relationship create/delete shows up under *General* but with less granular detail than field-by-field diffs.
+- **Filtering does not affect what's loaded** — the feed loads the full history and filters in place. For very long-lived systems with many edits, scrolling is the only navigation; there is no pagination.
+- **Empty history** shows *No history available*. This happens for very new systems, or for systems where all changes happened before history tracking was introduced.
+- **The timeline is read-only.** You cannot edit, undo, or annotate entries here. To revert a bad change, edit the field again on the appropriate tab — the revert itself becomes a new history entry.
+- **Use this tab when troubleshooting.** "Who set the responsible team?" / "When was this moved into TRASH?" / "When did the spare swap happen?" are all answered fastest from here.
+
+## Related
+
+- [Editing system details](./editing-system-details.md) — every Detail-tab edit shows up under *General*.
+- [Managing system people](./managing-system-people.md) — every Persons-tab change shows up under *General*.
+- [Managing relationships](./managing-relationships.md) — relationship create/delete events.
+- [Managing physical items](./managing-physical-items.md) — item assignment and move events appear under *Item Changes* and *Item Moves*.

--- a/scripts/sync-wiki.mjs
+++ b/scripts/sync-wiki.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// Walks docs/, mirrors its hierarchy into a flat wiki layout, rewrites internal
+// markdown links to wiki page slugs, and emits a _Sidebar.md.
+//
+// Usage:
+//   WIKI_OUT=/path/to/wiki-checkout node scripts/sync-wiki.mjs
+//
+// Conventions:
+//   docs/Home.md                                          -> Home.md
+//   docs/<top>/README.md                                  -> <Top>.md
+//   docs/<top>/<file>.md                                  -> <Top>-<File>.md
+//   docs/<top>/<sub>/README.md                            -> <Top>-<Sub>.md
+//   docs/<top>/<sub>/<group>/<file>.md                    -> <Top>-<Sub>-<File>.md  (selected groups skipped)
+//
+// Folder display names and skipped groups are configured in DISPLAY_NAMES and
+// SKIP_FOLDERS below.
+
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+const ROOT = path.resolve('.')
+const DOCS = path.join(ROOT, 'docs')
+const WIKI_OUT = process.env.WIKI_OUT || path.join(ROOT, '.wiki-out')
+
+// Folders skipped entirely (no wiki output for any file inside).
+const SKIP_TREES = new Set(['_template', 'implementation-plans'])
+
+// Folders whose name is dropped from the slug (children appear directly under parent slug).
+const SKIP_FOLDERS = new Set(['workflows'])
+
+const DISPLAY_NAMES = {
+    'user-guide': 'User-Guide',
+    systemHierarchy: 'System-Hierarchy',
+    technical: 'Technical-Documentation',
+}
+
+function capFirst(s) {
+    return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+function segmentToSlug(seg) {
+    if (DISPLAY_NAMES[seg]) return DISPLAY_NAMES[seg]
+    return capFirst(seg)
+}
+
+function relPathToSlug(relPath) {
+    if (relPath === 'Home.md') return 'Home'
+    const parts = relPath.replace(/\.md$/, '').split('/')
+    const filtered = parts.filter((p) => !SKIP_FOLDERS.has(p))
+    if (filtered[filtered.length - 1] === 'README') filtered.pop()
+    return filtered.map(segmentToSlug).join('-')
+}
+
+async function walk(dir) {
+    const out = []
+    const entries = await fs.readdir(dir, { withFileTypes: true })
+    for (const e of entries) {
+        if (SKIP_TREES.has(e.name)) continue
+        const p = path.join(dir, e.name)
+        if (e.isDirectory()) {
+            out.push(...(await walk(p)))
+        } else if (e.name.endsWith('.md')) {
+            out.push(p)
+        }
+    }
+    return out
+}
+
+function resolveLink(currentSrcAbs, linkPath, manifest) {
+    if (
+        linkPath.startsWith('http://') ||
+        linkPath.startsWith('https://') ||
+        linkPath.startsWith('mailto:') ||
+        linkPath.startsWith('#')
+    ) {
+        return null
+    }
+    const [pathPart, hash] = linkPath.split('#')
+    if (!pathPart || !pathPart.endsWith('.md')) return null
+    const targetAbs = path.resolve(path.dirname(currentSrcAbs), pathPart)
+    const targetRel = path.relative(DOCS, targetAbs)
+    const slug = manifest[targetRel]
+    if (!slug) return null
+    return hash ? `${slug}#${hash}` : slug
+}
+
+function rewriteLinks(content, srcAbs, manifest) {
+    return content.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (full, text, link) => {
+        const resolved = resolveLink(srcAbs, link, manifest)
+        if (resolved === null) return full
+        return `[${text}](${resolved})`
+    })
+}
+
+function buildSidebar(manifest) {
+    const groups = {}
+    for (const rel of Object.keys(manifest)) {
+        if (rel === 'Home.md') continue
+        const top = rel.split('/')[0]
+        if (!groups[top]) groups[top] = []
+        groups[top].push(rel)
+    }
+
+    const ordered = ['user-guide', 'technical', ...Object.keys(groups).filter((g) => !['user-guide', 'technical'].includes(g))]
+
+    let out = '## ELI PANDA\n\n[Home](Home)\n\n'
+
+    for (const top of ordered) {
+        const items = groups[top]
+        if (!items) continue
+        const topSlug = relPathToSlug(`${top}/README.md`)
+        const topTitle = (DISPLAY_NAMES[top] || capFirst(top)).replace(/-/g, ' ')
+        out += `### [${topTitle}](${topSlug})\n\n`
+
+        const others = items
+            .filter((rel) => rel !== `${top}/README.md`)
+            .sort((a, b) => a.localeCompare(b))
+        for (const rel of others) {
+            const slug = manifest[rel]
+            // Use the file's basename (or, for README under a sub-folder, the parent folder name)
+            const segs = rel.replace(/\.md$/, '').split('/').filter((p) => !SKIP_FOLDERS.has(p))
+            if (segs[segs.length - 1] === 'README') segs.pop()
+            const lastSeg = segs[segs.length - 1]
+            const displayName = (DISPLAY_NAMES[lastSeg] || capFirst(lastSeg)).replace(/-/g, ' ')
+            const indent = '  '.repeat(Math.max(0, segs.length - 2))
+            out += `${indent}- [${displayName}](${slug})\n`
+        }
+        out += '\n'
+    }
+
+    out += '\n---\n\n*Sources in [`docs/`](https://github.com/eli-eric/ELI-panda/tree/dev/docs); auto-synced on merge to `dev`.*\n'
+    return out
+}
+
+async function main() {
+    const files = await walk(DOCS)
+    const manifest = {}
+    for (const f of files) {
+        const rel = path.relative(DOCS, f).split(path.sep).join('/')
+        manifest[rel] = relPathToSlug(rel)
+    }
+
+    await fs.mkdir(WIKI_OUT, { recursive: true })
+
+    const existing = await fs.readdir(WIKI_OUT).catch(() => [])
+    for (const name of existing) {
+        if (name.endsWith('.md')) {
+            await fs.unlink(path.join(WIKI_OUT, name))
+        }
+    }
+
+    for (const f of files) {
+        const rel = path.relative(DOCS, f).split(path.sep).join('/')
+        const slug = manifest[rel]
+        const raw = await fs.readFile(f, 'utf8')
+        const rewritten = rewriteLinks(raw, f, manifest)
+        await fs.writeFile(path.join(WIKI_OUT, `${slug}.md`), rewritten)
+    }
+
+    await fs.writeFile(path.join(WIKI_OUT, '_Sidebar.md'), buildSidebar(manifest))
+
+    console.log(`Synced ${files.length} pages to ${WIKI_OUT}`)
+}
+
+main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+})


### PR DESCRIPTION
## Summary

Phase 1 of the user-guide initiative — Markdown source of truth in the repo, generated to Confluence in Phase 2 (already done for these pages).

- New **`docs/user-guide/`** tree:
  - root index with module status table (📝 Documented / 🚧 Planned)
  - **`getting-around.md`** — login (Microsoft Entra ID), sidebar layout, ⌘/Ctrl+K (global search) + ⌘/Ctrl+B (sidebar toggle, shadcn-provided), light/dark mode, logout
  - **`systemHierarchy/`** — module README + 9 workflow pages: navigating, searching/filtering, editing details, managing people/relationships/spare parts/physical items, viewing history, copying systems
  - **`_template/`** — reusable per-module + per-workflow templates locked from the vertical-slice prototype

- Permission model documented in 3 phases (today: `systems-edit` ≈ `admin`; Phase 1 split by system level; Phase 2 team-based scoping)
- Every workflow page is self-contained: persona badge, prerequisites, numbered steps, screenshot/video placeholders with descriptions, tips & gotchas, related links
- Verified against UI code + EN i18n labels + copy API contract (skeleton-only, 50-level cap, same-facility, atomic)

Confluence equivalents already published under [PANDA user manual / User Guide](https://eli-eric.atlassian.net/wiki/spaces/PUM/pages/2425520213/User+Guide).

## Test plan

- [ ] Open each `.md` in a Markdown preview — confirm tables, code blocks, and callouts render
- [ ] Click through every cross-page link in the repo (relative paths)
- [ ] Spot-check workflow steps against the running app for any UI label drift
- [ ] Confirm placeholder boxes (`[SCREENSHOT PLACEHOLDER: ...]` / `[VIDEO PLACEHOLDER: ...]`) all carry a descriptive caption
- [ ] No `.png` / `.jpg` / `.mp4` committed under `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)