### PR TITLE
feat(catalogue): UID as sort id for custom property columns + sort cycle fix

### DIFF
--- a/src/modules/shared/catalogue/select/CatalogueItemSelect.columns.tsx
+++ b/src/modules/shared/catalogue/select/CatalogueItemSelect.columns.tsx
@@ -105,13 +105,13 @@ export const useCatalogueItemSelectColumns = ({
             },
             {
                 header: intl.formatMessage({ id: messages.supplier }),
-                accessorFn: row => row.supplier?.name,
+                accessorFn: row => row.supplier?.name ?? '',
                 id: 'supplier',
                 size: 200,
             },
             {
                 header: intl.formatMessage({ id: messages.supplierUrl }),
-                accessorFn: row => row.manufacturerUrl,
+                accessorFn: row => row.manufacturerUrl ?? '',
                 id: 'manufacturerUrl',
                 size: 250,
                 cell: ManufacturerUrl,

--- a/src/modules/shared/catalogue/select/CatalogueItemSelect.columns.tsx
+++ b/src/modules/shared/catalogue/select/CatalogueItemSelect.columns.tsx
@@ -169,7 +169,7 @@ export const useCatalogueItemSelectColumns = ({
                             </Tooltip>
                         )
                     },
-                    id: detail.property.name.replace(/\s/g, ''),
+                    id: detail.property.uid,
                     size: 150,
                     accessorFn: row =>
                         row.details?.find(

--- a/src/modules/shared/catalogue/table/CatalogueItems.columns.tsx
+++ b/src/modules/shared/catalogue/table/CatalogueItems.columns.tsx
@@ -164,7 +164,7 @@ export const useCatalogueItemsColumns = ({
                             </Tooltip>
                         )
                     },
-                    id: detail.property.name.replace(/\s/g, ''),
+                    id: detail.property.uid,
                     size: 150,
                     accessorFn: row =>
                         row.details?.find(

--- a/src/modules/shared/catalogue/table/CatalogueItems.columns.tsx
+++ b/src/modules/shared/catalogue/table/CatalogueItems.columns.tsx
@@ -100,13 +100,13 @@ export const useCatalogueItemsColumns = ({
             },
             {
                 header: intl.formatMessage({ id: messages.supplier }),
-                accessorFn: row => row.supplier?.name,
+                accessorFn: row => row.supplier?.name ?? '',
                 id: 'supplier',
                 size: 200,
             },
             {
                 header: intl.formatMessage({ id: messages.supplierUrl }),
-                accessorFn: row => row.manufacturerUrl,
+                accessorFn: row => row.manufacturerUrl ?? '',
                 id: 'manufacturerUrl',
                 size: 250,
                 cell: ManufacturerUrl,

--- a/src/modules/shared/catalogue/table/CatalogueTableSelect.columns.tsx
+++ b/src/modules/shared/catalogue/table/CatalogueTableSelect.columns.tsx
@@ -167,7 +167,7 @@ export const useCatalogueTableSelectColumns = ({
                             </Tooltip>
                         )
                     },
-                    id: detail.property.name.replace(/\s/g, ''),
+                    id: detail.property.uid,
                     size: 150,
                     accessorFn: row =>
                         row.details?.find(

--- a/src/modules/shared/catalogue/table/CatalogueTableSelect.columns.tsx
+++ b/src/modules/shared/catalogue/table/CatalogueTableSelect.columns.tsx
@@ -103,13 +103,13 @@ export const useCatalogueTableSelectColumns = ({
             },
             {
                 header: intl.formatMessage({ id: messages.supplier }),
-                accessorFn: row => row.supplier?.name,
+                accessorFn: row => row.supplier?.name ?? '',
                 id: 'supplier',
                 size: 200,
             },
             {
                 header: intl.formatMessage({ id: messages.supplierUrl }),
-                accessorFn: row => row.manufacturerUrl,
+                accessorFn: row => row.manufacturerUrl ?? '',
                 id: 'manufacturerUrl',
                 size: 250,
                 cell: ManufacturerUrl,


### PR DESCRIPTION
## Summary
- Custom catalogue property columns now use `property.uid` as the column id (matching the filter convention). Aligns FE with new BE contract from eli-eric/eli-panda-api#415. Built-in column ids unchanged.
- Stabilize sort cycle for `supplier` and `manufacturerUrl` — accessor now coerces undefined/null to `''` so TanStack's `getAutoSortDir` returns a stable `'asc'` across reshuffles, restoring the 3-state cycle (asc → desc → none).

Affects 3 catalogue tables that share `/catalogue/items`:
- `CatalogueItems.columns.tsx` (main listing)
- `CatalogueTableSelect.columns.tsx` (related-items modal)
- `CatalogueItemSelect.columns.tsx` (catalogue-item picker)

Closes #1082

## Hold merge until BE #415 lands in dev
Pre-BE, both old and new FE clients 500 on custom-property sort. Post-BE, unknown sort ids fall back to default sort + warning log (no 500).

## Test plan
- [ ] Sort by built-in column — request shows `sorting=[{"id":"name","desc":...}]`, unchanged
- [ ] Sort by custom property column — request shows `sorting=[{"id":"<uuid>","desc":...}]` matching `property.uid`
- [ ] Sort by `supplier` cycles 3 states (asc → desc → none) across multiple clicks; same for `manufacturerUrl`
- [ ] Existing custom-property filter still works (no change there)
- [ ] Same behaviour in related-items modal and catalogue-item picker