### PR TITLE
chore(ci,docs): bump Node 20 → 22 in workflows + setup docs

### DIFF
--- a/.github/workflows/build-upload-run-azure-dev.yml
+++ b/.github/workflows/build-upload-run-azure-dev.yml
@@ -44,7 +44,7 @@ jobs:
               uses: actions/checkout@v4
             - uses: actions/setup-node@v4
               with:
-                  node-version: 20
+                  node-version: 22
             - name: Install Yarn
               run: npm install -g yarn
             - name: Install dependencies

--- a/.github/workflows/compose-up-dev-on-push.yml
+++ b/.github/workflows/compose-up-dev-on-push.yml
@@ -34,7 +34,7 @@ jobs:
               uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 22
             - name: Install Yarn
               run: npm install -g yarn
             - name: Install dependencies

--- a/.github/workflows/compose-up-frontend-main-ui.yml
+++ b/.github/workflows/compose-up-frontend-main-ui.yml
@@ -18,7 +18,7 @@ jobs:
               uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 22
             - name: Install Yarn
               run: npm install -g yarn
             - name: Install dependencies

--- a/.github/workflows/compose-up-production-on-push.yml
+++ b/.github/workflows/compose-up-production-on-push.yml
@@ -26,7 +26,7 @@ jobs:
               uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 22
             - name: Install Yarn
               run: npm install -g yarn
             - name: Install dependencies

--- a/.github/workflows/compose-up-test-on-push.yml
+++ b/.github/workflows/compose-up-test-on-push.yml
@@ -26,7 +26,7 @@ jobs:
               uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 20
+                  node-version: 22
             - name: Install Yarn
               run: npm install -g yarn
             - name: Install dependencies

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -31,7 +31,7 @@ jobs:
             - name: Setup Node
               uses: actions/setup-node@v4
               with:
-                  node-version: '20'
+                  node-version: '22'
 
             - name: Run sync script
               working-directory: main

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains the main frontend web application built with [Next.js](
 
 ## Prerequisites
 
-- Node.js 20+
+- Node.js 22+ (see `.nvmrc`)
 - Yarn (npm/pnpm are blocked by the `preinstall` check)
 
 ## Getting Started

--- a/docs/technical/deployment-runbook.md
+++ b/docs/technical/deployment-runbook.md
@@ -18,7 +18,7 @@ All pushes additionally run unit tests (`yarn test`) and Playwright E2E tests (v
 
 | Layer | Choice |
 |---|---|
-| Runtime image | `node:20-alpine` multi-stage build → Next.js `output: 'standalone'` |
+| Runtime image | `node:22-alpine` multi-stage build → Next.js `output: 'standalone'` |
 | Build | Yarn 1.x `--frozen-lockfile` (enforced by `scripts/enforce-package-manager.cjs`) |
 | Deploy A | Azure Container Apps + Azure Container Registry (ACR) |
 | Deploy B | Self-hosted Docker on the `czechia-server` runner via `docker compose` |
@@ -68,7 +68,7 @@ All app Dockerfiles share the same three-stage pattern (`deps` → `builder` →
 
 Build invariants:
 
-- **Image base**: `node:20-alpine` for app images; `node:20-bookworm` only for `Dockerfile.e2e` (Playwright system deps need glibc).
+- **Image base**: `node:22-alpine` for app images; `node:22-bookworm` only for `Dockerfile.e2e` (Playwright system deps need glibc).
 - **Final command**: `CMD ["node", "server.js"]` — Next.js standalone entry, no `yarn start`.
 - **Port**: `5001` (`EXPOSE 5001`, `ENV PORT=5001`).
 - **`sharp`** is reinstalled in the runner stage with platform-correct binaries (`yarn add sharp --ignore-scripts --prefer-offline`).
@@ -328,7 +328,7 @@ Schema migrations are out of scope for this repo (`SchemaMigration` exists in th
 
 1. **Add `/api/health`.** A no-op `pages/api/health.ts` returning `{ status: 'ok', version: process.env.GIT_SHA }` lets monitoring poll a real endpoint and provides a non-auth path to verify the process is alive. Wire `GIT_SHA` from the build env.
 2. **Promote test and prod to Azure Container Apps.** Today only dev uses ACR + Container Apps. Bringing test and prod onto the same surface eliminates the Czechia host SPOF and gives revision-based rollback for free.
-3. **Pin `node:20-alpine` to a specific digest.** All Dockerfiles use the floating tag. Pin to `node:20.<minor>-alpine@sha256:…` to make builds reproducible.
+3. **Pin `node:22-alpine` to a specific digest.** All Dockerfiles use the floating tag. Pin to `node:22.<minor>-alpine@sha256:…` to make builds reproducible.
 4. **Single Dockerfile + build-args.** `Dockerfile`, `Dockerfile.devenv`, `Dockerfile.testenv`, `Dockerfile.azure-dev` are nearly identical. Consolidate into one file with environment-driven build args (the `Dockerfile.azure-dev` already shows the pattern).
 5. **Externalise per-env URLs.** API gateway, MinIO endpoint, Neo4j URI are baked into Dockerfile `ENV` lines. Moving them to compose / Container App env vars allows the same image to deploy to any env.
 6. **Centralise secret rotation playbook.** Add a `docs/technical/runbook-rotations.md` covering `NEXTAUTH_SECRET`, `AZURE_AD_BEAMLINES_CLIENT_SECRET` (730-day expiry), Neo4j password, MinIO keys. Today it's tribal knowledge.

--- a/docs/technical/local-development.md
+++ b/docs/technical/local-development.md
@@ -6,7 +6,7 @@ Everything you need to get the app running locally, plus the conventions every c
 
 | Tool | Version | Notes |
 |---|---|---|
-| Node.js | 20.x | `node:20-alpine` is the production base — match locally. |
+| Node.js | 22.x | `node:22-alpine` is the production base — match locally. Pinned in `.nvmrc` and `engines.node` in `package.json`. |
 | Yarn | 1.x (classic) | Enforced — `npm` / `pnpm` are rejected by `scripts/enforce-package-manager.cjs`. |
 | Docker + Compose v2 | recent | Only needed for local MinIO or running compose images. |
 | Neo4j 5.x | running | Either local install, or SSH-tunnel to a shared instance (see `env-example`). |


### PR DESCRIPTION
Companion to #1115 (Next 16 + Node 22 upgrade).

#1115's CI is currently failing because GitHub Actions still pins Node 20 via `actions/setup-node`, but the package.json on that branch declares `engines.node >=22.0.0`. Yarn refuses install in CI:

\`\`\`
error ui-main-app@2.1.0: The engine "node" is incompatible with this module. Expected version ">=22.0.0". Got "20.20.0"
\`\`\`

## Summary

- **6 workflows** — bump `actions/setup-node` `node-version: 20` → `22`:
  - `build-upload-run-azure-dev.yml`
  - `compose-up-dev-on-push.yml`
  - `compose-up-frontend-main-ui.yml`
  - `compose-up-production-on-push.yml`
  - `compose-up-test-on-push.yml`
  - `sync-wiki.yml`
- **README.md** — Prerequisites: Node 20+ → Node 22+ with `.nvmrc` pointer
- **docs/technical/local-development.md** — Node 20.x row → 22.x, `node:20-alpine` → `node:22-alpine`
- **docs/technical/deployment-runbook.md** — all `node:20-alpine` / `node:20-bookworm` references → `node:22-*`

## Merge order

This PR should land before #1115, or simultaneously. After it merges, #1115 needs a rebase on `dev` to pick up the workflow bumps so its CI passes.

## Test plan

- [ ] CI runs use Node 22 across all jobs after merge
- [ ] After #1115 rebased on dev: `yarn install` succeeds in CI