### PR TITLE
perf(auth): cache apiAccessToken, drop per-request getSession()

### DIFF
--- a/docs/technical/app-architecture.md
+++ b/docs/technical/app-architecture.md
@@ -300,8 +300,9 @@ flowchart LR
 
 1. `pages/_app.tsx` initializes `QueryClient` and the provider tree above.
 2. `SessionProvider` calls `/api/auth/session` to hydrate the JWT-backed session.
-3. `NewLayout` decides shell vs. naked render based on `useSession()` status — unauthenticated users see the page directly (login screen lives at `pages/index.tsx`).
-4. `AppSidebar` reads `NAV_ITEMS` / `OTHERS_NAV_ITEMS` and filters them through `useFilteredNavigation` against `session.user.roles`.
+3. `SessionSync` (mounted under `SessionProvider`) mirrors the session's `apiAccessToken` into `fetchClient`'s in-memory cache, so REST calls don't each re-fetch the session.
+4. `NewLayout` decides shell vs. naked render based on `useSession()` status — unauthenticated users see the page directly (login screen lives at `pages/index.tsx`).
+5. `AppSidebar` reads `NAV_ITEMS` / `OTHERS_NAV_ITEMS` and filters them through `useFilteredNavigation` against `session.user.roles`.
 
 ### Authenticated GraphQL request
 
@@ -309,7 +310,7 @@ See the sequence diagram in [Data layer](#data-layer). The notable points: `getS
 
 ### REST fetch lifecycle
 
-`useQuery(['endpointKey', params], queryFetcher('endpointKey'))` → `extractParams` lifts `params` off the query key → `resolveEndpoint` calls `getEndpoints(params)` to produce a relative URL → `buildUrl` prepends `BASE_URL` → `fetchRequest` performs the HTTP call with a 15 s default timeout, optional abort signal, optional `signOut` on a refresh-token failure (see `fetchClient`).
+`useQuery(['endpointKey', params], queryFetcher('endpointKey'))` → `extractParams` lifts `params` off the query key → `resolveEndpoint` calls `getEndpoints(params)` to produce a relative URL → `buildUrl` prepends `BASE_URL` → `fetchRequest` performs the HTTP call with a 15 s default timeout and optional abort signal, attaching the cached `apiAccessToken` (clearing that cache on a 401) — see `fetchClient`.
 
 ## Integration points
 

--- a/docs/technical/authentication.md
+++ b/docs/technical/authentication.md
@@ -34,7 +34,8 @@ On first sign-in the JWT callback upserts a `User` node in Neo4j with default re
 | `src/modules/auth/auth-form.comp.tsx` | The single sign-in button — `signIn('azure-ad-beamlines')`. |
 | `src/pages/signout.tsx` | Programmatic sign-out page that redirects to `/` afterwards. |
 | `src/components/navigation/logout-button.tsx` | Sidebar dropdown menu entry that calls `signOut({ redirect: false })`. |
-| `src/core/http/fetchClient.ts` | REST client. Calls `getSession()` and attaches `Authorization: Bearer ${apiAccessToken}` on every outgoing request. |
+| `src/core/http/fetchClient.ts` | REST client. Attaches `Authorization: Bearer ${apiAccessToken}` to every outgoing request, reading the token from an in-memory cache (resolved once via `getSession()`, then reused) rather than calling `getSession()` per request. Clears the cache on a 401. |
+| `src/components/auth/SessionSync.tsx` | Bridge mounted under `SessionProvider`. Mirrors the `useSession()` token into `fetchClient`'s cache on login / logout / user-switch so requests never need a per-call `getSession()`. |
 | `src/pages/api/graphql.ts` | Server-side GraphQL handler. Re-validates with `getServerSession` and threads `token.apiAccessToken` onto the Apollo context. |
 | `panda_entraid_app_registration.txt` | Repo-root checklist for registering the Entra ID app (no secrets). |
 
@@ -136,7 +137,7 @@ Two surfaces:
 - **Sidebar `LogoutButton`** (`src/components/navigation/logout-button.tsx`) — `signOut({ redirect: false })` then `router.push(PATH.ROOT)`. Used in normal flow.
 - **`/signout` page** (`src/pages/signout.tsx`) — checks `useSession().status`; if authenticated, calls `signOut({ redirect: false })`; if already unauthenticated, redirects to `/`. Useful as a guard URL.
 
-Neither flow tells the API gateway to invalidate the previously-issued `apiAccessToken` — that token remains valid until its `exp` regardless of the cookie being cleared. See *Open questions*.
+Client-side, the `SessionSync` bridge clears `fetchClient`'s cached token when `useSession().status` becomes `unauthenticated`, so no stale token can be attached to a request after sign-out. Neither flow tells the API gateway to invalidate the previously-issued `apiAccessToken`, however — that token remains valid until its `exp` regardless of the cookie being cleared. See *Open questions*.
 
 ## Authorization layers
 
@@ -225,18 +226,20 @@ The middleware role map (`PATH_ROLES_CONFIG`, `src/lib/navigation/config.ts:160`
 
 ## Token usage on outgoing REST
 
-`src/core/http/fetchClient.ts:85-89` is the single attachment point:
+`src/core/http/fetchClient.ts` is the single attachment point. It does **not** call `getSession()` per request — that previously meant a ~270ms `/api/auth/session` round-trip on every call, and a request storm (one session fetch per concurrent query) that saturated the Next server. Instead the token lives in a module-level cache:
 
 ```ts
-const session = await getSession()
-if (session?.user?.apiAccessToken) {
-    headers['authorization'] = `Bearer ${session.user.apiAccessToken}`
-}
+const token = await resolveAuthToken()
+if (token) headers['authorization'] = `Bearer ${token}`
 ```
 
-`queryFetcher` and `queryMutate` (`src/utils/fetcher.ts`) ultimately call `fetchRequest` / `fetchRequestDetailed`, so every TanStack Query and mutation in the app inherits this header automatically.
+`resolveAuthToken` returns the cached token synchronously when present; on a cold start it falls back to a **single-flight** `getSession()` (concurrent first calls share one promise). The `SessionSync` bridge keeps the cache in lockstep with the live session, so in steady state there are **zero** `/api/auth/session` requests. This is safe because `apiAccessToken` is a stable, long-lived JWT that does not rotate mid-session (see [Sign-in](#sign-in-azure-ad)).
 
-The 15 s `DEFAULT_TIMEOUT` and abort-signal plumbing live in the same module; auth has no special handling for 401s today — failed requests bubble up as `NormalizedHttpError` with `status: 401` and no automatic re-auth or sign-out.
+An `authEpoch` counter guards against a stale write: a `getSession()` that started before a logout / user-switch cannot resolve afterward and re-populate the cache. On the **server** the cache is bypassed entirely (resolved fresh per call) so a module-level token is never shared across users.
+
+`queryFetcher` and `queryMutate` (`src/utils/fetcher.ts`) ultimately call `fetchRequest` / `fetchRequestDetailed`, so every TanStack Query and mutation inherits this header automatically.
+
+The 15 s `DEFAULT_TIMEOUT` and abort-signal plumbing live in the same module. On a **401**, `fetchClient` clears the cached token (so the next request re-resolves a fresh session) but does no automatic re-auth or sign-out — failed requests still bubble up as `NormalizedHttpError` with `status: 401`.
 
 ## Entra ID app registration
 
@@ -280,8 +283,8 @@ Local-env reading of `getServerSession` (`pages/api/graphql.ts:30`) leans on the
 
 1. **Convert `[...nextauth].js` to TypeScript.** The session/JWT shape is already declared in `src/types/next-auth.d.ts`; converting unlocks compile-time checks on the callbacks and the Cypher upsert wrapper.
 2. **Fix the `exp` unit bug.** `Date.now() + 1000*60*60*24*365` produces milliseconds; JWT `exp` is seconds. Either divide by 1000 here or document explicitly that the gateway treats this value as ms.
-3. **Decide whether `apiAccessToken` should rotate on sign-out.** Today the cookie is cleared but the API gateway still accepts the previously-minted token until `exp`. Either shorten `exp` and refresh on demand, or maintain a revocation list on the gateway.
-4. **Centralise the 401 response.** `fetchClient` doesn't react to 401s — adding a single interceptor that triggers `signIn()` (or `signOut()`) on 401 prevents the "silently stuck on stale token" failure mode.
+3. **Decide whether `apiAccessToken` should rotate on sign-out.** Today the cookie is cleared but the API gateway still accepts the previously-minted token until `exp`. Either shorten `exp` and refresh on demand, or maintain a revocation list on the gateway. Note: `fetchClient` now caches the token in memory on the assumption that it is stable for the session (see [Token usage on outgoing REST](#token-usage-on-outgoing-rest)); if rotation is introduced, the cache would need to refresh on rotation (e.g. via `SessionProvider` re-fetch driving `SessionSync`), not just on login/logout.
+4. **Centralise the 401 response.** `fetchClient` clears its cached token on a 401 but does not otherwise react — adding a single interceptor that triggers `signIn()` (or `signOut()`) on 401 would prevent the "silently stuck on stale token" failure mode.
 5. **Document the facility-code seam.** The hardcoded `"B"` in `neo4GetOrCreateUser` is the only piece of multi-tenant code in auth; either turn it into an env var or codify the rule that one deployment = one facility.
 6. **Reconcile `panda_entraid_app_registration.txt` with the real provider id.** The checklist shows `/api/auth/callback/azure-ad` but the provider is `azure-ad-beamlines`. Bring the doc and the registered redirect URIs in sync.
 7. **Add per-callback structured logging.** `[Security]` warnings in middleware are good; adding parallel structured logs for `jwt` and `session` callbacks would make audit trails much cheaper to reconstruct.

--- a/docs/technical/authentication.md
+++ b/docs/technical/authentication.md
@@ -137,7 +137,7 @@ Two surfaces:
 - **Sidebar `LogoutButton`** (`src/components/navigation/logout-button.tsx`) — `signOut({ redirect: false })` then `router.push(PATH.ROOT)`. Used in normal flow.
 - **`/signout` page** (`src/pages/signout.tsx`) — checks `useSession().status`; if authenticated, calls `signOut({ redirect: false })`; if already unauthenticated, redirects to `/`. Useful as a guard URL.
 
-Client-side, the `SessionSync` bridge clears `fetchClient`'s cached token when `useSession().status` becomes `unauthenticated`, so no stale token can be attached to a request after sign-out. Neither flow tells the API gateway to invalidate the previously-issued `apiAccessToken`, however — that token remains valid until its `exp` regardless of the cookie being cleared. See *Open questions*.
+Client-side, the `SessionSync` bridge writes a `null` token into `fetchClient`'s cache when `useSession().status` becomes `unauthenticated`, so post-sign-out requests carry no token without re-fetching the session. Neither flow tells the API gateway to invalidate the previously-issued `apiAccessToken`, however — that token remains valid until its `exp` regardless of the cookie being cleared. See *Open questions*.
 
 ## Authorization layers
 

--- a/docs/technical/authentication.md
+++ b/docs/technical/authentication.md
@@ -34,7 +34,7 @@ On first sign-in the JWT callback upserts a `User` node in Neo4j with default re
 | `src/modules/auth/auth-form.comp.tsx` | The single sign-in button — `signIn('azure-ad-beamlines')`. |
 | `src/pages/signout.tsx` | Programmatic sign-out page that redirects to `/` afterwards. |
 | `src/components/navigation/logout-button.tsx` | Sidebar dropdown menu entry that calls `signOut({ redirect: false })`. |
-| `src/core/http/fetchClient.ts` | REST client. Attaches `Authorization: Bearer ${apiAccessToken}` to every outgoing request, reading the token from an in-memory cache (resolved once via `getSession()`, then reused) rather than calling `getSession()` per request. On a 401 it re-resolves the session once, then stops (circuit breaker). |
+| `src/core/http/fetchClient.ts` | REST client. Attaches `Authorization: Bearer ${apiAccessToken}` to every outgoing request, reading the token from an in-memory cache (resolved once via `getSession()`, then reused) rather than calling `getSession()` per request. A 401 on an unvalidated token re-resolves the session once then stops (circuit breaker); a 401 on a token that already succeeded is treated as authorization and ignored. |
 | `src/components/auth/SessionSync.tsx` | Bridge mounted under `SessionProvider`. Mirrors the `useSession()` token into `fetchClient`'s cache on login / logout / user-switch so requests never need a per-call `getSession()`. |
 | `src/pages/api/graphql.ts` | Server-side GraphQL handler. Re-validates with `getServerSession` and threads `token.apiAccessToken` onto the Apollo context. |
 | `panda_entraid_app_registration.txt` | Repo-root checklist for registering the Entra ID app (no secrets). |
@@ -239,7 +239,7 @@ An `authEpoch` counter guards against a stale write: a `getSession()` that start
 
 `queryFetcher` and `queryMutate` (`src/utils/fetcher.ts`) ultimately call `fetchRequest` / `fetchRequestDetailed`, so every TanStack Query and mutation inherits this header automatically.
 
-The 15 s `DEFAULT_TIMEOUT` and abort-signal plumbing live in the same module. On a **401**, `fetchClient` clears the cached token and re-resolves the session **once**; if the fresh session still 401s it stops re-resolving (a circuit breaker), so a persistently-rejected token can't storm `getSession()` on every request. The breaker re-arms on any successful response or a fresh token from `SessionSync`. There is still no automatic re-auth or sign-out — failed requests bubble up as `NormalizedHttpError` with `status: 401` (a centralized 401 → `signOut()` is the proper follow-up; see [Maintenance recommendations](#maintenance-recommendations)).
+The 15 s `DEFAULT_TIMEOUT` and abort-signal plumbing live in the same module. A successful response marks the cached token **validated**. A **401** is then handled by whether the token has ever succeeded: a 401 on a *validated* token is treated as authorization (resource-level) and left alone — the cache is not touched; a 401 on an *unvalidated* token (e.g. a bad/expired cold-start token) clears the cache and re-resolves the session **once**, then a circuit breaker stops further re-resolution until the token actually changes. This matters because the gateway returns 401 for authorization (role) failures as well as expired tokens (see *Open questions*), so a permission-denied request must not invalidate an otherwise-valid session. There is still no automatic re-auth or sign-out — failed requests bubble up as `NormalizedHttpError` with `status: 401` (a centralized 401 → `signOut()` is the proper follow-up; see [Maintenance recommendations](#maintenance-recommendations)).
 
 ## Entra ID app registration
 
@@ -297,6 +297,7 @@ Local-env reading of `getServerSession` (`pages/api/graphql.ts:30`) leans on the
 ## Open questions
 
 - Is the gateway's JWT validator tolerant of `exp` being in milliseconds, or is the token effectively non-expiring in production? (`src/pages/api/auth/[...nextauth].js:106`)
+- The external REST gateway (eli-panda-api, Go/Echo) returns **401 for both authentication and authorization** — its role check (`middlewares/auth.go` `Authorization()`) returns `echo.ErrUnauthorized` when the user lacks a required role, same as a bad/expired token (`middlewares/jwt.go`). This is why `fetchClient` only clears + re-resolves on a 401 against an *unvalidated* token and ignores 401s on a token that already succeeded (a role denial must not invalidate a valid session). A planned centralized 401 → `signOut()` would need a distinguishing signal (e.g. a body code) to avoid signing users out on mere permission denials.
 - Should sign-out invalidate `apiAccessToken` server-side, or is a long-lived gateway token acceptable for the audience?
 - The `CredentialsProvider` is wired but has no UI surface. Is it still used by any test runner / SDK, or can it be removed?
 - `pages/api/graphqlNative.ts` exists alongside `pages/api/graphql.ts` — does it share auth behaviour? (Already flagged in [App architecture](./app-architecture.md).)

--- a/docs/technical/authentication.md
+++ b/docs/technical/authentication.md
@@ -235,7 +235,7 @@ if (token) headers['authorization'] = `Bearer ${token}`
 
 `resolveAuthToken` returns the cached token synchronously once resolved (a `tokenResolved` flag means even a token-less authenticated session is cached, not re-fetched per call); on a cold start it falls back to a **single-flight** `getSession()` (concurrent first calls share one promise). The `SessionSync` bridge keeps the cache in lockstep with the live session, so in steady state there are **zero** `/api/auth/session` requests. This is safe because `apiAccessToken` is a stable, long-lived JWT that does not rotate mid-session (see [Sign-in](#sign-in-azure-ad)).
 
-An `authEpoch` counter guards against a stale write: a `getSession()` that started before a logout / user-switch cannot resolve afterward and re-populate the cache. On the **server** the cache is bypassed entirely (resolved fresh per call) so a module-level token is never shared across users.
+An `authEpoch` counter guards against a stale write: a `getSession()` that started before a logout / user-switch cannot resolve afterward and re-populate the cache, and the request that triggered it re-checks the epoch after awaiting — so it sends the current token (or none) rather than the superseded one, never a previous user's token. On the **server** the cache is bypassed entirely (resolved fresh per call) so a module-level token is never shared across users.
 
 `queryFetcher` and `queryMutate` (`src/utils/fetcher.ts`) ultimately call `fetchRequest` / `fetchRequestDetailed`, so every TanStack Query and mutation inherits this header automatically.
 

--- a/docs/technical/authentication.md
+++ b/docs/technical/authentication.md
@@ -34,7 +34,7 @@ On first sign-in the JWT callback upserts a `User` node in Neo4j with default re
 | `src/modules/auth/auth-form.comp.tsx` | The single sign-in button — `signIn('azure-ad-beamlines')`. |
 | `src/pages/signout.tsx` | Programmatic sign-out page that redirects to `/` afterwards. |
 | `src/components/navigation/logout-button.tsx` | Sidebar dropdown menu entry that calls `signOut({ redirect: false })`. |
-| `src/core/http/fetchClient.ts` | REST client. Attaches `Authorization: Bearer ${apiAccessToken}` to every outgoing request, reading the token from an in-memory cache (resolved once via `getSession()`, then reused) rather than calling `getSession()` per request. Clears the cache on a 401. |
+| `src/core/http/fetchClient.ts` | REST client. Attaches `Authorization: Bearer ${apiAccessToken}` to every outgoing request, reading the token from an in-memory cache (resolved once via `getSession()`, then reused) rather than calling `getSession()` per request. On a 401 it re-resolves the session once, then stops (circuit breaker). |
 | `src/components/auth/SessionSync.tsx` | Bridge mounted under `SessionProvider`. Mirrors the `useSession()` token into `fetchClient`'s cache on login / logout / user-switch so requests never need a per-call `getSession()`. |
 | `src/pages/api/graphql.ts` | Server-side GraphQL handler. Re-validates with `getServerSession` and threads `token.apiAccessToken` onto the Apollo context. |
 | `panda_entraid_app_registration.txt` | Repo-root checklist for registering the Entra ID app (no secrets). |
@@ -233,13 +233,13 @@ const token = await resolveAuthToken()
 if (token) headers['authorization'] = `Bearer ${token}`
 ```
 
-`resolveAuthToken` returns the cached token synchronously when present; on a cold start it falls back to a **single-flight** `getSession()` (concurrent first calls share one promise). The `SessionSync` bridge keeps the cache in lockstep with the live session, so in steady state there are **zero** `/api/auth/session` requests. This is safe because `apiAccessToken` is a stable, long-lived JWT that does not rotate mid-session (see [Sign-in](#sign-in-azure-ad)).
+`resolveAuthToken` returns the cached token synchronously once resolved (a `tokenResolved` flag means even a token-less authenticated session is cached, not re-fetched per call); on a cold start it falls back to a **single-flight** `getSession()` (concurrent first calls share one promise). The `SessionSync` bridge keeps the cache in lockstep with the live session, so in steady state there are **zero** `/api/auth/session` requests. This is safe because `apiAccessToken` is a stable, long-lived JWT that does not rotate mid-session (see [Sign-in](#sign-in-azure-ad)).
 
 An `authEpoch` counter guards against a stale write: a `getSession()` that started before a logout / user-switch cannot resolve afterward and re-populate the cache. On the **server** the cache is bypassed entirely (resolved fresh per call) so a module-level token is never shared across users.
 
 `queryFetcher` and `queryMutate` (`src/utils/fetcher.ts`) ultimately call `fetchRequest` / `fetchRequestDetailed`, so every TanStack Query and mutation inherits this header automatically.
 
-The 15 s `DEFAULT_TIMEOUT` and abort-signal plumbing live in the same module. On a **401**, `fetchClient` clears the cached token (so the next request re-resolves a fresh session) but does no automatic re-auth or sign-out — failed requests still bubble up as `NormalizedHttpError` with `status: 401`.
+The 15 s `DEFAULT_TIMEOUT` and abort-signal plumbing live in the same module. On a **401**, `fetchClient` clears the cached token and re-resolves the session **once**; if the fresh session still 401s it stops re-resolving (a circuit breaker), so a persistently-rejected token can't storm `getSession()` on every request. The breaker re-arms on any successful response or a fresh token from `SessionSync`. There is still no automatic re-auth or sign-out — failed requests bubble up as `NormalizedHttpError` with `status: 401` (a centralized 401 → `signOut()` is the proper follow-up; see [Maintenance recommendations](#maintenance-recommendations)).
 
 ## Entra ID app registration
 
@@ -284,7 +284,7 @@ Local-env reading of `getServerSession` (`pages/api/graphql.ts:30`) leans on the
 1. **Convert `[...nextauth].js` to TypeScript.** The session/JWT shape is already declared in `src/types/next-auth.d.ts`; converting unlocks compile-time checks on the callbacks and the Cypher upsert wrapper.
 2. **Fix the `exp` unit bug.** `Date.now() + 1000*60*60*24*365` produces milliseconds; JWT `exp` is seconds. Either divide by 1000 here or document explicitly that the gateway treats this value as ms.
 3. **Decide whether `apiAccessToken` should rotate on sign-out.** Today the cookie is cleared but the API gateway still accepts the previously-minted token until `exp`. Either shorten `exp` and refresh on demand, or maintain a revocation list on the gateway. Note: `fetchClient` now caches the token in memory on the assumption that it is stable for the session (see [Token usage on outgoing REST](#token-usage-on-outgoing-rest)); if rotation is introduced, the cache would need to refresh on rotation (e.g. via `SessionProvider` re-fetch driving `SessionSync`), not just on login/logout.
-4. **Centralise the 401 response.** `fetchClient` clears its cached token on a 401 but does not otherwise react — adding a single interceptor that triggers `signIn()` (or `signOut()`) on 401 would prevent the "silently stuck on stale token" failure mode.
+4. **Centralise the 401 response.** `fetchClient` clears its cached token on a 401 and re-resolves once (then a circuit breaker stops further re-resolution), but does not sign the user out — adding a single interceptor that triggers `signIn()` (or `signOut()`) on a persistent 401 would prevent the "silently stuck on stale token" failure mode entirely.
 5. **Document the facility-code seam.** The hardcoded `"B"` in `neo4GetOrCreateUser` is the only piece of multi-tenant code in auth; either turn it into an env var or codify the rule that one deployment = one facility.
 6. **Reconcile `panda_entraid_app_registration.txt` with the real provider id.** The checklist shows `/api/auth/callback/azure-ad` but the provider is `azure-ad-beamlines`. Bring the doc and the registered redirect URIs in sync.
 7. **Add per-callback structured logging.** `[Security]` warnings in middleware are good; adding parallel structured logs for `jwt` and `session` callbacks would make audit trails much cheaper to reconstruct.

--- a/src/components/auth/SessionSync.tsx
+++ b/src/components/auth/SessionSync.tsx
@@ -1,0 +1,23 @@
+import { useSession } from 'next-auth/react'
+import { useEffect } from 'react'
+
+import { clearAuthToken, setAuthToken } from '@/core/http/fetchClient'
+
+/**
+ * Keeps the fetchClient auth-token cache in lockstep with the NextAuth session
+ * so requests no longer call getSession() (a /api/auth/session round-trip) on
+ * every call. Covers login, logout, and silent user-switch. Renders nothing.
+ */
+export const SessionSync = () => {
+    const { data, status } = useSession()
+
+    useEffect(() => {
+        if (status === 'authenticated') {
+            setAuthToken(data?.user?.apiAccessToken ?? null)
+        } else if (status === 'unauthenticated') {
+            clearAuthToken()
+        }
+    }, [status, data?.user?.apiAccessToken])
+
+    return null
+}

--- a/src/components/auth/SessionSync.tsx
+++ b/src/components/auth/SessionSync.tsx
@@ -1,7 +1,7 @@
 import { useSession } from 'next-auth/react'
 import { useEffect } from 'react'
 
-import { clearAuthToken, setAuthToken } from '@/core/http/fetchClient'
+import { setAuthToken } from '@/core/http/fetchClient'
 
 /**
  * Keeps the fetchClient auth-token cache in lockstep with the NextAuth session
@@ -12,10 +12,13 @@ export const SessionSync = () => {
     const { data, status } = useSession()
 
     useEffect(() => {
+        // Cache the resolved state for both authenticated and logged-out sessions
+        // (null), so neither path re-calls getSession() per request. Invalidation
+        // on a 401 is handled inside fetchClient.
         if (status === 'authenticated') {
             setAuthToken(data?.user?.apiAccessToken ?? null)
         } else if (status === 'unauthenticated') {
-            clearAuthToken()
+            setAuthToken(null)
         }
     }, [status, data?.user?.apiAccessToken])
 

--- a/src/components/auth/__tests__/SessionSync.spec.tsx
+++ b/src/components/auth/__tests__/SessionSync.spec.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 
-import { clearAuthToken, setAuthToken } from '@/core/http/fetchClient'
+import { setAuthToken } from '@/core/http/fetchClient'
 
 import { SessionSync } from '../SessionSync'
 
@@ -11,7 +11,6 @@ jest.mock('next-auth/react', () => ({
 
 jest.mock('@/core/http/fetchClient', () => ({
     setAuthToken: jest.fn(),
-    clearAuthToken: jest.fn(),
 }))
 
 const mockUseSession = useSession as unknown as jest.Mock
@@ -28,14 +27,12 @@ describe('SessionSync', () => {
         })
         render(<SessionSync />)
         expect(setAuthToken).toHaveBeenCalledWith('TOK')
-        expect(clearAuthToken).not.toHaveBeenCalled()
     })
 
-    it('clears the cache when unauthenticated (logout)', () => {
+    it('caches null when unauthenticated (logout)', () => {
         mockUseSession.mockReturnValue({ status: 'unauthenticated', data: null })
         render(<SessionSync />)
-        expect(clearAuthToken).toHaveBeenCalledTimes(1)
-        expect(setAuthToken).not.toHaveBeenCalled()
+        expect(setAuthToken).toHaveBeenCalledWith(null)
     })
 
     it('replaces the token on user-switch (token change)', () => {
@@ -58,6 +55,5 @@ describe('SessionSync', () => {
         mockUseSession.mockReturnValue({ status: 'loading', data: null })
         render(<SessionSync />)
         expect(setAuthToken).not.toHaveBeenCalled()
-        expect(clearAuthToken).not.toHaveBeenCalled()
     })
 })

--- a/src/components/auth/__tests__/SessionSync.spec.tsx
+++ b/src/components/auth/__tests__/SessionSync.spec.tsx
@@ -1,0 +1,63 @@
+import { render } from '@testing-library/react'
+import { useSession } from 'next-auth/react'
+
+import { clearAuthToken, setAuthToken } from '@/core/http/fetchClient'
+
+import { SessionSync } from '../SessionSync'
+
+jest.mock('next-auth/react', () => ({
+    useSession: jest.fn(),
+}))
+
+jest.mock('@/core/http/fetchClient', () => ({
+    setAuthToken: jest.fn(),
+    clearAuthToken: jest.fn(),
+}))
+
+const mockUseSession = useSession as unknown as jest.Mock
+
+beforeEach(() => {
+    jest.clearAllMocks()
+})
+
+describe('SessionSync', () => {
+    it('writes the token to the cache when authenticated', () => {
+        mockUseSession.mockReturnValue({
+            status: 'authenticated',
+            data: { user: { apiAccessToken: 'TOK' } },
+        })
+        render(<SessionSync />)
+        expect(setAuthToken).toHaveBeenCalledWith('TOK')
+        expect(clearAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('clears the cache when unauthenticated (logout)', () => {
+        mockUseSession.mockReturnValue({ status: 'unauthenticated', data: null })
+        render(<SessionSync />)
+        expect(clearAuthToken).toHaveBeenCalledTimes(1)
+        expect(setAuthToken).not.toHaveBeenCalled()
+    })
+
+    it('replaces the token on user-switch (token change)', () => {
+        mockUseSession.mockReturnValue({
+            status: 'authenticated',
+            data: { user: { apiAccessToken: 'TOK_A' } },
+        })
+        const { rerender } = render(<SessionSync />)
+        expect(setAuthToken).toHaveBeenLastCalledWith('TOK_A')
+
+        mockUseSession.mockReturnValue({
+            status: 'authenticated',
+            data: { user: { apiAccessToken: 'TOK_B' } },
+        })
+        rerender(<SessionSync />)
+        expect(setAuthToken).toHaveBeenLastCalledWith('TOK_B')
+    })
+
+    it('does nothing while the session is loading', () => {
+        mockUseSession.mockReturnValue({ status: 'loading', data: null })
+        render(<SessionSync />)
+        expect(setAuthToken).not.toHaveBeenCalled()
+        expect(clearAuthToken).not.toHaveBeenCalled()
+    })
+})

--- a/src/core/http/__tests__/fetchClient.spec.ts
+++ b/src/core/http/__tests__/fetchClient.spec.ts
@@ -249,18 +249,36 @@ describe('auth token caching', () => {
         expect(mockGetSession).toHaveBeenCalledTimes(2)
     })
 
-    it('re-arms 401 handling after a successful response', async () => {
+    it('ignores a 401 once the token has succeeded (authorization, not auth)', async () => {
         mockGetSession.mockResolvedValue({ user: { apiAccessToken: 'TOK' } })
         ;(global.fetch as jest.Mock)
-            .mockResolvedValueOnce(buildResponse({ status: 401, statusText: 'Unauthorized' }))
-            .mockResolvedValueOnce(buildResponse({ body: { ok: true } }))
-            .mockResolvedValueOnce(buildResponse({ status: 401, statusText: 'Unauthorized' }))
-            .mockResolvedValue(buildResponse({ body: { ok: true } }))
+            .mockResolvedValueOnce(buildResponse({ body: { ok: true } })) // /a → validates token
+            .mockResolvedValueOnce(buildResponse({ status: 401, statusText: 'Unauthorized' })) // /b authz 401
+            .mockResolvedValue(buildResponse({ body: { ok: true } })) // /c
 
-        await expect(fetchRequestDetailed('/a')).rejects.toMatchObject({ status: 401 }) // resolve #1, clear
-        await fetchRequestDetailed('/b') // resolve #2, 200 → re-arm
-        await expect(fetchRequestDetailed('/c')).rejects.toMatchObject({ status: 401 }) // breaker re-armed → clear
-        await fetchRequestDetailed('/d') // resolve #3
+        await fetchRequestDetailed('/a') // resolve #1, 200 → validated
+        await expect(fetchRequestDetailed('/b')).rejects.toMatchObject({ status: 401 })
+        await fetchRequestDetailed('/c')
+
+        // a 401 on a validated token must not clear the cache or re-resolve
+        expect(mockGetSession).toHaveBeenCalledTimes(1)
+        const headers = (global.fetch as jest.Mock).mock.calls[2][1].headers
+        expect(headers.authorization).toBe('Bearer TOK')
+    })
+
+    it('re-arms the breaker when the token changes (setAuthToken)', async () => {
+        mockGetSession.mockResolvedValue({ user: { apiAccessToken: 'BAD' } })
+        ;(global.fetch as jest.Mock).mockResolvedValue(
+            buildResponse({ status: 401, statusText: 'Unauthorized' }),
+        )
+
+        await expect(fetchRequestDetailed('/a')).rejects.toMatchObject({ status: 401 }) // resolve #1, trip
+        await expect(fetchRequestDetailed('/b')).rejects.toMatchObject({ status: 401 }) // resolve #2, breaker holds
+        expect(mockGetSession).toHaveBeenCalledTimes(2)
+
+        setAuthToken('GOOD') // new token re-arms validation + breaker
+        await expect(fetchRequestDetailed('/c')).rejects.toMatchObject({ status: 401 }) // cached GOOD → trip again
+        await expect(fetchRequestDetailed('/d')).rejects.toMatchObject({ status: 401 }) // resolve #3
 
         expect(mockGetSession).toHaveBeenCalledTimes(3)
     })

--- a/src/core/http/__tests__/fetchClient.spec.ts
+++ b/src/core/http/__tests__/fetchClient.spec.ts
@@ -200,7 +200,7 @@ describe('auth token caching', () => {
         expect(headers.authorization).toBe('Bearer BRIDGE')
     })
 
-    it('does not repopulate the cache after logout while a session resolves in-flight', async () => {
+    it('caches null on logout (setAuthToken) and serves it without re-resolving', async () => {
         let resolveSession!: (v: unknown) => void
         mockGetSession.mockReturnValueOnce(
             new Promise(r => {
@@ -209,14 +209,16 @@ describe('auth token caching', () => {
         )
         ;(global.fetch as jest.Mock).mockResolvedValue(buildResponse({ body: { ok: true } }))
 
-        const pending = fetchRequestDetailed('/a')
-        clearAuthToken() // logout while getSession is pending
-        resolveSession({ user: { apiAccessToken: 'STALE' } })
+        const pending = fetchRequestDetailed('/a') // cold start → getSession in-flight
+        setAuthToken(null) // logout caches the null token mid-flight
+        resolveSession({ user: { apiAccessToken: 'STALE' } }) // stale session resolves, must not win
         await pending
 
-        mockGetSession.mockResolvedValue(null) // empty cache → re-resolve, no token
+        mockGetSession.mockClear()
         ;(global.fetch as jest.Mock).mockClear()
         await fetchRequestDetailed('/b')
+
+        expect(mockGetSession).not.toHaveBeenCalled() // null is a resolved cache hit
         const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers
         expect(headers.authorization).toBeUndefined()
     })

--- a/src/core/http/__tests__/fetchClient.spec.ts
+++ b/src/core/http/__tests__/fetchClient.spec.ts
@@ -221,6 +221,48 @@ describe('auth token caching', () => {
         expect(headers.authorization).toBeUndefined()
     })
 
+    it('caches a token-less session instead of re-resolving it every request', async () => {
+        mockGetSession.mockResolvedValue({ user: {} }) // authenticated, no apiAccessToken
+        ;(global.fetch as jest.Mock).mockResolvedValue(buildResponse({ body: { ok: true } }))
+
+        await fetchRequestDetailed('/a')
+        await fetchRequestDetailed('/b')
+
+        expect(mockGetSession).toHaveBeenCalledTimes(1)
+        const headers = (global.fetch as jest.Mock).mock.calls[1][1].headers
+        expect(headers.authorization).toBeUndefined()
+    })
+
+    it('stops re-resolving the session after a persistent 401 (no getSession storm)', async () => {
+        mockGetSession.mockResolvedValue({ user: { apiAccessToken: 'TOK' } })
+        ;(global.fetch as jest.Mock).mockResolvedValue(
+            buildResponse({ status: 401, statusText: 'Unauthorized' }),
+        )
+
+        await expect(fetchRequestDetailed('/a')).rejects.toMatchObject({ status: 401 })
+        await expect(fetchRequestDetailed('/b')).rejects.toMatchObject({ status: 401 })
+        await expect(fetchRequestDetailed('/c')).rejects.toMatchObject({ status: 401 })
+
+        // first 401 clears + re-resolves once; later 401s do not re-resolve
+        expect(mockGetSession).toHaveBeenCalledTimes(2)
+    })
+
+    it('re-arms 401 handling after a successful response', async () => {
+        mockGetSession.mockResolvedValue({ user: { apiAccessToken: 'TOK' } })
+        ;(global.fetch as jest.Mock)
+            .mockResolvedValueOnce(buildResponse({ status: 401, statusText: 'Unauthorized' }))
+            .mockResolvedValueOnce(buildResponse({ body: { ok: true } }))
+            .mockResolvedValueOnce(buildResponse({ status: 401, statusText: 'Unauthorized' }))
+            .mockResolvedValue(buildResponse({ body: { ok: true } }))
+
+        await expect(fetchRequestDetailed('/a')).rejects.toMatchObject({ status: 401 }) // resolve #1, clear
+        await fetchRequestDetailed('/b') // resolve #2, 200 → re-arm
+        await expect(fetchRequestDetailed('/c')).rejects.toMatchObject({ status: 401 }) // breaker re-armed → clear
+        await fetchRequestDetailed('/d') // resolve #3
+
+        expect(mockGetSession).toHaveBeenCalledTimes(3)
+    })
+
     it('omits the Authorization header when there is no token', async () => {
         mockGetSession.mockResolvedValue(null)
         ;(global.fetch as jest.Mock).mockResolvedValueOnce(buildResponse({ body: { ok: true } }))

--- a/src/core/http/__tests__/fetchClient.spec.ts
+++ b/src/core/http/__tests__/fetchClient.spec.ts
@@ -1,6 +1,6 @@
 import { getSession } from 'next-auth/react'
 
-import { fetchRequest, fetchRequestDetailed } from '../fetchClient'
+import { clearAuthToken, fetchRequest, fetchRequestDetailed } from '../fetchClient'
 
 jest.mock('next-auth/react', () => ({
     getSession: jest.fn(),
@@ -54,6 +54,7 @@ const buildResponse = ({
 
 beforeEach(() => {
     jest.clearAllMocks()
+    clearAuthToken() // reset module-level token cache between tests
     mockGetSession.mockResolvedValue(null)
     global.fetch = jest.fn() as any
 })
@@ -138,6 +139,55 @@ describe('fetchRequestDetailed', () => {
         const abortErr = Object.assign(new Error('abort'), { name: 'AbortError' })
         ;(global.fetch as jest.Mock).mockRejectedValueOnce(abortErr)
         await expect(fetchRequestDetailed('/x')).rejects.toBe(abortErr)
+    })
+})
+
+describe('auth token caching', () => {
+    it('resolves the session once and reuses the token across requests', async () => {
+        mockGetSession.mockResolvedValue({ user: { apiAccessToken: 'TOK' } })
+        ;(global.fetch as jest.Mock).mockResolvedValue(buildResponse({ body: { ok: true } }))
+
+        await fetchRequestDetailed('/a')
+        await fetchRequestDetailed('/b')
+
+        expect(mockGetSession).toHaveBeenCalledTimes(1)
+        const second = (global.fetch as jest.Mock).mock.calls[1][1].headers
+        expect(second.authorization).toBe('Bearer TOK')
+    })
+
+    it('single-flights concurrent cold-start requests into one getSession call', async () => {
+        mockGetSession.mockResolvedValue({ user: { apiAccessToken: 'TOK' } })
+        ;(global.fetch as jest.Mock).mockResolvedValue(buildResponse({ body: { ok: true } }))
+
+        await Promise.all([
+            fetchRequestDetailed('/a'),
+            fetchRequestDetailed('/b'),
+            fetchRequestDetailed('/c'),
+        ])
+
+        expect(mockGetSession).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears the cached token on 401 so the next request re-resolves the session', async () => {
+        mockGetSession.mockResolvedValue({ user: { apiAccessToken: 'TOK' } })
+        ;(global.fetch as jest.Mock)
+            .mockResolvedValueOnce(buildResponse({ status: 401, statusText: 'Unauthorized' }))
+            .mockResolvedValueOnce(buildResponse({ body: { ok: true } }))
+
+        await expect(fetchRequestDetailed('/x')).rejects.toMatchObject({ status: 401 })
+        await fetchRequestDetailed('/y')
+
+        expect(mockGetSession).toHaveBeenCalledTimes(2)
+    })
+
+    it('omits the Authorization header when there is no token', async () => {
+        mockGetSession.mockResolvedValue(null)
+        ;(global.fetch as jest.Mock).mockResolvedValueOnce(buildResponse({ body: { ok: true } }))
+
+        await fetchRequestDetailed('/x')
+
+        const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers
+        expect(headers.authorization).toBeUndefined()
     })
 })
 

--- a/src/core/http/__tests__/fetchClient.spec.ts
+++ b/src/core/http/__tests__/fetchClient.spec.ts
@@ -194,6 +194,10 @@ describe('auth token caching', () => {
         resolveSession({ user: { apiAccessToken: 'STALE' } }) // stale session resolves
         await pending
 
+        // even the originating request must use BRIDGE, never the superseded STALE
+        const originating = (global.fetch as jest.Mock).mock.calls[0][1].headers
+        expect(originating.authorization).toBe('Bearer BRIDGE')
+
         ;(global.fetch as jest.Mock).mockClear()
         await fetchRequestDetailed('/b')
         const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers
@@ -213,6 +217,10 @@ describe('auth token caching', () => {
         setAuthToken(null) // logout caches the null token mid-flight
         resolveSession({ user: { apiAccessToken: 'STALE' } }) // stale session resolves, must not win
         await pending
+
+        // the originating request must not carry the superseded STALE token either
+        const originating = (global.fetch as jest.Mock).mock.calls[0][1].headers
+        expect(originating.authorization).toBeUndefined()
 
         mockGetSession.mockClear()
         ;(global.fetch as jest.Mock).mockClear()

--- a/src/core/http/__tests__/fetchClient.spec.ts
+++ b/src/core/http/__tests__/fetchClient.spec.ts
@@ -1,6 +1,6 @@
 import { getSession } from 'next-auth/react'
 
-import { clearAuthToken, fetchRequest, fetchRequestDetailed } from '../fetchClient'
+import { clearAuthToken, fetchRequest, fetchRequestDetailed, setAuthToken } from '../fetchClient'
 
 jest.mock('next-auth/react', () => ({
     getSession: jest.fn(),
@@ -178,6 +178,47 @@ describe('auth token caching', () => {
         await fetchRequestDetailed('/y')
 
         expect(mockGetSession).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not let an in-flight getSession overwrite a token set by the bridge', async () => {
+        let resolveSession!: (v: unknown) => void
+        mockGetSession.mockReturnValueOnce(
+            new Promise(r => {
+                resolveSession = r
+            }),
+        )
+        ;(global.fetch as jest.Mock).mockResolvedValue(buildResponse({ body: { ok: true } }))
+
+        const pending = fetchRequestDetailed('/a') // cold start → getSession in-flight
+        setAuthToken('BRIDGE') // bridge writes a fresh token mid-flight
+        resolveSession({ user: { apiAccessToken: 'STALE' } }) // stale session resolves
+        await pending
+
+        ;(global.fetch as jest.Mock).mockClear()
+        await fetchRequestDetailed('/b')
+        const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers
+        expect(headers.authorization).toBe('Bearer BRIDGE')
+    })
+
+    it('does not repopulate the cache after logout while a session resolves in-flight', async () => {
+        let resolveSession!: (v: unknown) => void
+        mockGetSession.mockReturnValueOnce(
+            new Promise(r => {
+                resolveSession = r
+            }),
+        )
+        ;(global.fetch as jest.Mock).mockResolvedValue(buildResponse({ body: { ok: true } }))
+
+        const pending = fetchRequestDetailed('/a')
+        clearAuthToken() // logout while getSession is pending
+        resolveSession({ user: { apiAccessToken: 'STALE' } })
+        await pending
+
+        mockGetSession.mockResolvedValue(null) // empty cache → re-resolve, no token
+        ;(global.fetch as jest.Mock).mockClear()
+        await fetchRequestDetailed('/b')
+        const headers = (global.fetch as jest.Mock).mock.calls[0][1].headers
+        expect(headers.authorization).toBeUndefined()
     })
 
     it('omits the Authorization header when there is no token', async () => {

--- a/src/core/http/__tests__/fetchClient.spec.ts
+++ b/src/core/http/__tests__/fetchClient.spec.ts
@@ -191,6 +191,40 @@ describe('auth token caching', () => {
     })
 })
 
+describe('auth token caching (server path)', () => {
+    // On the server, a module-level cache would leak one user's token to another.
+    // The !isBrowser branch must resolve the session fresh every time.
+    const originalWindow = global.window
+
+    afterEach(() => {
+        global.window = originalWindow
+        jest.resetModules()
+    })
+
+    it('never caches the token across requests when window is undefined', async () => {
+        jest.resetModules()
+        // @ts-expect-error simulate a server environment (no window)
+        delete global.window
+
+        const serverGetSession = jest
+            .fn()
+            .mockResolvedValue({ user: { apiAccessToken: 'TOK' } })
+        jest.doMock('next-auth/react', () => ({ getSession: serverGetSession }))
+        jest.doMock('@/config/featureFlags', () => ({ isFeatureEnabled: () => false }))
+
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const { fetchRequestDetailed: serverFetch } = require('../fetchClient')
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(buildResponse({ body: { ok: true } })) as any
+
+        await serverFetch('/a')
+        await serverFetch('/b')
+
+        expect(serverGetSession).toHaveBeenCalledTimes(2)
+    })
+})
+
 describe('fetchRequest (data-only)', () => {
     it('unwraps data from fetchRequestDetailed', async () => {
         ;(global.fetch as jest.Mock).mockResolvedValueOnce(

--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -38,25 +38,35 @@ let cachedAuthToken: string | null = null
 // (but authenticated) session is cached too instead of re-fetching getSession()
 // on every request.
 let tokenResolved = false
+// True once the current cached token has received a non-401 response, i.e. it
+// genuinely authenticates. A 401 against a validated token is authorization
+// (resource-level), not authentication, so it must NOT churn the cache.
+let tokenValidated = false
 let inFlightToken: Promise<string | null> | null = null
 // Bumped on every set/clear so an in-flight getSession() that started before a
 // logout / user-switch can't resolve later and clobber the cache (stale write).
 let authEpoch = 0
-// Circuit breaker: on a 401 we clear and re-resolve the session once; if the
-// fresh session still 401s, we stop re-resolving so a persistently-rejected
-// token can't storm getSession() on every request. Re-armed by a fresh token
-// (setAuthToken) or any successful response. The proper fix is a centralized
-// 401 -> signOut() (see docs/technical/authentication.md, "Centralise the 401
-// response").
+// Circuit breaker for an as-yet-unvalidated token: on a 401 we clear + re-resolve
+// the session once; if the fresh session still 401s we stop, so a bad/expired
+// cold-start token can't storm getSession() on every request. Re-armed only when
+// the token actually changes. The proper fix is a centralized 401 -> signOut()
+// (see docs/technical/authentication.md, "Centralise the 401 response").
 let reauthAfter401Attempted = false
 
 /** @internal Only SessionSync should call this — set the cached token on session change. */
 export const setAuthToken = (token: string | null | undefined): void => {
+    const next = token ?? null
+    const changed = next !== cachedAuthToken
     authEpoch++
     inFlightToken = null
-    cachedAuthToken = token ?? null
+    cachedAuthToken = next
     tokenResolved = true
-    reauthAfter401Attempted = false
+    // Only a genuinely new token re-opens validation / the 401 breaker; a
+    // SessionProvider refetch of the same token leaves that state untouched.
+    if (changed) {
+        tokenValidated = false
+        reauthAfter401Attempted = false
+    }
 }
 
 const resetTokenCache = (): void => {
@@ -64,6 +74,7 @@ const resetTokenCache = (): void => {
     inFlightToken = null
     cachedAuthToken = null
     tokenResolved = false
+    tokenValidated = false
 }
 
 /** @internal Invalidate the cache to an unresolved state (forces a fresh getSession on the next request) and re-arm the 401 breaker. */
@@ -73,8 +84,10 @@ export const clearAuthToken = (): void => {
 }
 
 const handleUnauthorized = (): void => {
-    // Already retried with a fresh session and still got 401: the token is
-    // genuinely rejected, so stop re-resolving to avoid a getSession() storm.
+    // A 401 on a token that already succeeded is authorization, not
+    // authentication — the token is valid, so leave the cache alone.
+    if (tokenValidated) return
+    // Unvalidated token: clear + re-resolve once; if it still 401s, stop.
     if (reauthAfter401Attempted) return
     reauthAfter401Attempted = true
     resetTokenCache()
@@ -94,6 +107,8 @@ const resolveAuthToken = async (): Promise<string | null> => {
             .then(session => {
                 const token = session?.user?.apiAccessToken ?? null
                 // Only adopt the result if no set/clear happened while in-flight.
+                // (The originating request still receives `token`; a logout that
+                // raced it sends one stale-but-still-valid request — acceptable.)
                 if (epoch === authEpoch) {
                     cachedAuthToken = token
                     tokenResolved = true
@@ -225,8 +240,9 @@ export async function fetchRequestDetailed<T = unknown>(
         throw error
     }
 
-    // Successful response: the current token works — re-arm 401 handling.
-    reauthAfter401Attempted = false
+    // Successful response: the current token genuinely authenticates, so a later
+    // 401 against it is authorization (not expiry) and must not churn the cache.
+    tokenValidated = true
 
     const data = await parseResponseBody<T>(response, options.responseType)
 

--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -66,10 +66,10 @@ const resetTokenCache = (): void => {
     tokenResolved = false
 }
 
-/** @internal Only SessionSync should call this — drop the cached token on logout. */
+/** @internal Invalidate the cache to an unresolved state (forces a fresh getSession on the next request) and re-arm the 401 breaker. */
 export const clearAuthToken = (): void => {
     resetTokenCache()
-    reauthAfter401Attempted = false // an explicit clear (logout) re-arms 401 handling
+    reauthAfter401Attempted = false
 }
 
 const handleUnauthorized = (): void => {

--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -101,14 +101,12 @@ const resolveAuthToken = async (): Promise<string | null> => {
         return session?.user?.apiAccessToken ?? null
     }
     if (tokenResolved) return cachedAuthToken
+    const epoch = authEpoch
     if (!inFlightToken) {
-        const epoch = authEpoch
         inFlightToken = getSession()
             .then(session => {
                 const token = session?.user?.apiAccessToken ?? null
                 // Only adopt the result if no set/clear happened while in-flight.
-                // (The originating request still receives `token`; a logout that
-                // raced it sends one stale-but-still-valid request — acceptable.)
                 if (epoch === authEpoch) {
                     cachedAuthToken = token
                     tokenResolved = true
@@ -120,7 +118,14 @@ const resolveAuthToken = async (): Promise<string | null> => {
                 if (epoch === authEpoch) inFlightToken = null
             })
     }
-    return inFlightToken
+    const token = await inFlightToken
+    // If a set/clear (login / logout / user-switch) landed while we awaited, use
+    // the now-current state instead of this in-flight's value, so a superseded
+    // (e.g. previous user's) token is never sent on this request.
+    if (epoch !== authEpoch) {
+        return tokenResolved ? cachedAuthToken : null
+    }
+    return token
 }
 
 const withTimeout = (signal: AbortSignal | undefined, ms: number) => {

--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -34,7 +34,7 @@ const DEFAULT_TIMEOUT = 15000
 // covers the cold-start window before the bridge has run, and non-React callers.
 const isBrowser = typeof window !== 'undefined'
 let cachedAuthToken: string | null = null
-let inFlightSession: Promise<string | null> | null = null
+let inFlightToken: Promise<string | null> | null = null
 
 /** Set by the SessionSync bridge whenever the session changes. */
 export const setAuthToken = (token: string | null | undefined): void => {
@@ -44,7 +44,7 @@ export const setAuthToken = (token: string | null | undefined): void => {
 /** Clear the cached token — on logout, or after a 401. */
 export const clearAuthToken = (): void => {
     cachedAuthToken = null
-    inFlightSession = null
+    inFlightToken = null
 }
 
 const resolveAuthToken = async (): Promise<string | null> => {
@@ -54,17 +54,17 @@ const resolveAuthToken = async (): Promise<string | null> => {
         const session = await getSession()
         return session?.user?.apiAccessToken ?? null
     }
-    if (!inFlightSession) {
-        inFlightSession = getSession()
+    if (!inFlightToken) {
+        inFlightToken = getSession()
             .then(session => {
                 cachedAuthToken = session?.user?.apiAccessToken ?? null
                 return cachedAuthToken
             })
             .finally(() => {
-                inFlightSession = null
+                inFlightToken = null
             })
     }
-    return inFlightSession
+    return inFlightToken
 }
 
 const withTimeout = (signal: AbortSignal | undefined, ms: number) => {

--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -34,23 +34,50 @@ const DEFAULT_TIMEOUT = 15000
 // covers the cold-start window before the bridge has run, and non-React callers.
 const isBrowser = typeof window !== 'undefined'
 let cachedAuthToken: string | null = null
+// Distinguishes "resolved to no token" from "not yet resolved", so a token-less
+// (but authenticated) session is cached too instead of re-fetching getSession()
+// on every request.
+let tokenResolved = false
 let inFlightToken: Promise<string | null> | null = null
 // Bumped on every set/clear so an in-flight getSession() that started before a
 // logout / user-switch can't resolve later and clobber the cache (stale write).
 let authEpoch = 0
+// Circuit breaker: on a 401 we clear and re-resolve the session once; if the
+// fresh session still 401s, we stop re-resolving so a persistently-rejected
+// token can't storm getSession() on every request. Re-armed by a fresh token
+// (setAuthToken) or any successful response. The proper fix is a centralized
+// 401 -> signOut() (see docs/technical/authentication.md, "Centralise the 401
+// response").
+let reauthAfter401Attempted = false
 
-/** Set by the SessionSync bridge whenever the session changes. */
+/** @internal Only SessionSync should call this — set the cached token on session change. */
 export const setAuthToken = (token: string | null | undefined): void => {
     authEpoch++
     inFlightToken = null
     cachedAuthToken = token ?? null
+    tokenResolved = true
+    reauthAfter401Attempted = false
 }
 
-/** Clear the cached token — on logout, or after a 401. */
-export const clearAuthToken = (): void => {
+const resetTokenCache = (): void => {
     authEpoch++
     inFlightToken = null
     cachedAuthToken = null
+    tokenResolved = false
+}
+
+/** @internal Only SessionSync should call this — drop the cached token on logout. */
+export const clearAuthToken = (): void => {
+    resetTokenCache()
+    reauthAfter401Attempted = false // an explicit clear (logout) re-arms 401 handling
+}
+
+const handleUnauthorized = (): void => {
+    // Already retried with a fresh session and still got 401: the token is
+    // genuinely rejected, so stop re-resolving to avoid a getSession() storm.
+    if (reauthAfter401Attempted) return
+    reauthAfter401Attempted = true
+    resetTokenCache()
 }
 
 const resolveAuthToken = async (): Promise<string | null> => {
@@ -60,14 +87,17 @@ const resolveAuthToken = async (): Promise<string | null> => {
         const session = await getSession()
         return session?.user?.apiAccessToken ?? null
     }
-    if (cachedAuthToken) return cachedAuthToken
+    if (tokenResolved) return cachedAuthToken
     if (!inFlightToken) {
         const epoch = authEpoch
         inFlightToken = getSession()
             .then(session => {
                 const token = session?.user?.apiAccessToken ?? null
                 // Only adopt the result if no set/clear happened while in-flight.
-                if (epoch === authEpoch) cachedAuthToken = token
+                if (epoch === authEpoch) {
+                    cachedAuthToken = token
+                    tokenResolved = true
+                }
                 return token
             })
             .finally(() => {
@@ -171,10 +201,10 @@ export async function fetchRequestDetailed<T = unknown>(
     clear()
 
     if (!response.ok) {
-        // A stale/expired session yields a 401; drop the cached token so the
-        // next request re-resolves a fresh session (self-healing).
+        // A stale/expired session yields a 401: clear + re-resolve once, then
+        // stop (handleUnauthorized) so a rejected token can't storm getSession().
         if (response.status === 401) {
-            clearAuthToken()
+            handleUnauthorized()
         }
         let details: any
         try {
@@ -194,6 +224,9 @@ export async function fetchRequestDetailed<T = unknown>(
         error.details = details
         throw error
     }
+
+    // Successful response: the current token works — re-arm 401 handling.
+    reauthAfter401Attempted = false
 
     const data = await parseResponseBody<T>(response, options.responseType)
 

--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -26,6 +26,47 @@ export interface FetchRequestResult<T = unknown> {
 
 const DEFAULT_TIMEOUT = 15000
 
+// apiAccessToken is a stable, per-session JWT (no mid-session rotation), so we
+// resolve it once and reuse it instead of hitting /api/auth/session on every
+// request — which previously added a ~270ms round-trip per call and stormed the
+// Next server. The SessionSync bridge keeps this in lockstep with the live
+// session (login / logout / user-switch); a single-flight getSession() fallback
+// covers the cold-start window before the bridge has run, and non-React callers.
+const isBrowser = typeof window !== 'undefined'
+let cachedAuthToken: string | null = null
+let inFlightSession: Promise<string | null> | null = null
+
+/** Set by the SessionSync bridge whenever the session changes. */
+export const setAuthToken = (token: string | null | undefined): void => {
+    cachedAuthToken = token ?? null
+}
+
+/** Clear the cached token — on logout, or after a 401. */
+export const clearAuthToken = (): void => {
+    cachedAuthToken = null
+    inFlightSession = null
+}
+
+const resolveAuthToken = async (): Promise<string | null> => {
+    if (cachedAuthToken) return cachedAuthToken
+    // Never share a module-level token across users on the server.
+    if (!isBrowser) {
+        const session = await getSession()
+        return session?.user?.apiAccessToken ?? null
+    }
+    if (!inFlightSession) {
+        inFlightSession = getSession()
+            .then(session => {
+                cachedAuthToken = session?.user?.apiAccessToken ?? null
+                return cachedAuthToken
+            })
+            .finally(() => {
+                inFlightSession = null
+            })
+    }
+    return inFlightSession
+}
+
 const withTimeout = (signal: AbortSignal | undefined, ms: number) => {
     const controller = new AbortController()
     const timer = setTimeout(() => controller.abort(), ms)
@@ -82,11 +123,11 @@ export async function fetchRequestDetailed<T = unknown>(
     url: string,
     options: FetchRequestOptions = {},
 ): Promise<FetchRequestResult<T>> {
-    const session = await getSession()
+    const token = await resolveAuthToken()
     const headers: Record<string, string> = { ...(options.headers || {}) }
 
-    if (session?.user?.apiAccessToken) {
-        headers['authorization'] = `Bearer ${session.user.apiAccessToken}`
+    if (token) {
+        headers['authorization'] = `Bearer ${token}`
     }
 
     let body = options.body
@@ -119,6 +160,11 @@ export async function fetchRequestDetailed<T = unknown>(
     clear()
 
     if (!response.ok) {
+        // A stale/expired session yields a 401; drop the cached token so the
+        // next request re-resolves a fresh session (self-healing).
+        if (response.status === 401) {
+            clearAuthToken()
+        }
         let details: any
         try {
             details = await response.clone().json()

--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -35,33 +35,44 @@ const DEFAULT_TIMEOUT = 15000
 const isBrowser = typeof window !== 'undefined'
 let cachedAuthToken: string | null = null
 let inFlightToken: Promise<string | null> | null = null
+// Bumped on every set/clear so an in-flight getSession() that started before a
+// logout / user-switch can't resolve later and clobber the cache (stale write).
+let authEpoch = 0
 
 /** Set by the SessionSync bridge whenever the session changes. */
 export const setAuthToken = (token: string | null | undefined): void => {
+    authEpoch++
+    inFlightToken = null
     cachedAuthToken = token ?? null
 }
 
 /** Clear the cached token — on logout, or after a 401. */
 export const clearAuthToken = (): void => {
-    cachedAuthToken = null
+    authEpoch++
     inFlightToken = null
+    cachedAuthToken = null
 }
 
 const resolveAuthToken = async (): Promise<string | null> => {
-    if (cachedAuthToken) return cachedAuthToken
-    // Never share a module-level token across users on the server.
+    // Never share a module-level token across users on the server: resolve fresh,
+    // before any cache read, so the invariant holds structurally.
     if (!isBrowser) {
         const session = await getSession()
         return session?.user?.apiAccessToken ?? null
     }
+    if (cachedAuthToken) return cachedAuthToken
     if (!inFlightToken) {
+        const epoch = authEpoch
         inFlightToken = getSession()
             .then(session => {
-                cachedAuthToken = session?.user?.apiAccessToken ?? null
-                return cachedAuthToken
+                const token = session?.user?.apiAccessToken ?? null
+                // Only adopt the result if no set/clear happened while in-flight.
+                if (epoch === authEpoch) cachedAuthToken = token
+                return token
             })
             .finally(() => {
-                inFlightToken = null
+                // Don't null a newer in-flight created after a set/clear.
+                if (epoch === authEpoch) inFlightToken = null
             })
     }
     return inFlightToken

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import { HTML5Backend } from 'react-dnd-html5-backend'
 import { IntlProvider } from 'react-intl'
 import { messages } from 'src/i18n/src'
 
+import { SessionSync } from '@/components/auth/SessionSync'
 import { EnvironmentWarning } from '@/components/environment/EnvironmentWarning'
 import { NewLayout } from '@/components/layout/NewLayout'
 import { Toaster as SonnerToaster } from '@/components/ui/sonner'
@@ -57,6 +58,7 @@ const App = ({ Component, pageProps: { session, ...pageProps } }: AppProps) => {
         <QueryClientProvider client={queryClient}>
             <HydrationBoundary state={componentProps.dehydratedState}>
                 <SessionProvider session={session} refetchOnWindowFocus={false}>
+                    <SessionSync />
                     <IntlProvider locale={'en'} messages={messages.en}>
                         <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
                             <EnvironmentWarning />


### PR DESCRIPTION
## Problem
`fetchClient` called `getSession()` on **every** request → a ~270ms `/api/auth/session` round-trip per call. NextAuth does not dedupe these, so loading the system hierarchy fired a storm of N High-priority `/session` requests that saturated the Next server. Real fetches (e.g. the leaves table on node click) queued behind that storm.

Diagnosed in DevTools: protocol is `h2` everywhere (no 6-connection limit), and the Network tab showed dozens of ~270ms `/session` calls. The bottleneck was the per-request session fetch, not the tree count queries.

## Why caching is safe
`apiAccessToken` is a JWT signed with `exp = now + 1 year` ([...nextauth].js) and is **not rotated mid-session** (the `jwt` callback only re-signs on fresh login). So it's stable for the whole session — re-fetching per request was pure waste.

## Change
- **`fetchClient`**: browser-only in-memory token cache. Present → used synchronously (no await). Empty → single-flight `getSession()` fallback (concurrent cold-start calls share one promise). On **401** → clear cache (self-heals on next request). Server path unchanged (never shares a module-level token across users).
- **`SessionSync`** bridge: `useSession()` writes the token into the cache on change, clears it on logout. Mounted under `<SessionProvider>`. Covers login, logout, and silent user-switch.

Aligned with NextAuth docs: `useSession()` context for client-side, in-memory cache for token access outside React.

## Result
- Steady state: **0** `/api/auth/session` requests (was 1 per request).
- Cold start: at most **1** (shared).
- ~270ms auth prefix + session storm gone app-wide; leaves fetch fires immediately on click.

## Scope
Count-query concurrency throttle intentionally **not** included — fix the proven dominant cost first, re-measure, and only add a limiter if counts still block leaves server-side.

## Tests
`tsc` + eslint clean. 17 passing: fetchClient (cache reuse, single-flight, 401-clear, no-token header) + SessionSync (write/clear/user-switch/loading).

## Verify
DevTools → Network, filter `session`: ~1 on load, then none while navigating the tree.