### PR TITLE
feat(hierarchy): right-click delete system in tree, table & graph

### DIFF
--- a/docs/technical/systems-family/system-hierarchy.md
+++ b/docs/technical/systems-family/system-hierarchy.md
@@ -95,6 +95,7 @@ The leaves panel toggles between **Tree View** (the default `LeavesTable`) and *
 | `useItemFieldUpdate` | PATCH a single field on the attached `Item` (serial, usage, condition, notes). Takes `(systemUid, currentItem)`. Records the `WAS_UPDATED_BY` edge on the **owning System node** (not the Item) — same as `systemItem` — so item edits surface in the system's History tab. Builds change entries via `utils/fieldChangeBuilder` and passes them as `updatedByResolver(changes)`; on success invalidates `SYSTEM_DETAIL_QUERY_KEY` + `['history']`. |
 | `useSystemCopy` | Calls REST endpoint `system/<uid>/copy` — server orchestrates the recursive copy |
 | `useCreateSubsystem` | `mutation CreateSystems` via `useGraphQLMutation`. Payload assembled by the pure `utils/buildCreateSubsystemPayload`, including `parentSystem.connect`, parent-inherited `responsible/location/zone`, and the required `updatedBy.connect[edge.action=Insert]` so `updatedByResolver` writes a history edge. On success seeds `[SYSTEM_DETAIL_QUERY_KEY, newUid]` with the full SystemDetail fragment returned by the server, then invalidates `HIERARCHY`, `LEAVES`, `LEAVES_COUNT`, and `RELATIONSHIP_GRAPH` keys. |
+| `useDeleteSystem` | `queryMutate('system', 'delete', { uid })` — REST `DELETE /system/{uid}` (soft + recursive: `deleted=true` on the system and every subsystem). `onSuccess` stays **synchronous** so the delete resolves immediately: fires an instant invalidate of `HIERARCHY`, `LEAVES`, `LEAVES_COUNT`, `RELATIONSHIP_GRAPH`, then a background `recalculateSpareParts` POST that triggers a **second** invalidate on success (`.catch` swallows recalc failure so it can't mask the delete). UX orchestration (confirm, toast, 409, selection reset) lives in `useDeleteSystemAction` — see [Delete System](#delete-system). |
 | `useSystemCodeGenerate` | Generate a code based on type + level + ancestry |
 | `useSystemCodeClear` | Clear a previously generated code |
 | `useDeleteRelationship` | Remove one of the 8 engineering edges. Always invalidates `RELATIONSHIP_GRAPH_QUERY_KEY`; on `IS_SPARE_FOR` disconnect additionally invalidates via `matchesSpareAffectedQuery([currentSystemUid, relatedSystemUid])` — see [Cache invalidation for spare flows](#cache-invalidation-for-spare-flows). |
@@ -195,7 +196,22 @@ The dialog reads the parent via `useSystemDetail(parentUid)` to surface the inhe
 
 After the mutation resolves, the dialog calls `selectLeaf(newUid)` **without** an optimistic hint — the mutation hook has already written the full `SystemDetail` fragment into the system-detail query cache, so the detail page renders every field on first navigation (a minimal hint would otherwise stick because `primeSystemDetailCache`'s background `fetchQuery` is a no-op under the 60 s `staleTime`).
 
-`TreeNode` also takes a `canEdit` prop and a `onCreateSubsystem(parentUid, parentName, parentLevel)` callback. Permission gating is now uniform — Copy, Paste, and Create System are **always rendered** and `disabled` based on `canEdit` (plus their per-action rule: `!canPaste` for paste, `!canCreateUnder(level)` for create). The previous "hide handlers when no edit permission" behaviour in `SystemTree.cont` was dropped in favour of always-render-disabled for better discoverability.
+`TreeNode` also takes a `canEdit` prop and a `onCreateSubsystem(parentUid, parentName, parentLevel)` callback. Permission gating is now uniform — Copy, Paste, Create System, and Delete System are **always rendered** and `disabled` based on `canEdit` (plus their per-action rule: `!canPaste` for paste, `!canCreateUnder(level)` for create). The previous "hide handlers when no edit permission" behaviour in `SystemTree.cont` was dropped in favour of always-render-disabled for better discoverability.
+
+## Delete System
+
+User-facing companion: [Deleting systems](../../user-guide/systemHierarchy/workflows/deleting-systems.md).
+
+Right-click **Delete System** is available on all three system surfaces — tree node (`TreeNode`), leaves table row (`LeavesTable`), and graph node (`SystemNode`). All three call a single orchestrator, `hooks/useDeleteSystemAction.ts`, layered on the `useDeleteSystem` mutation. It returns `{ canEdit, handleDeleteSystem, isPending }`:
+
+- **Permission** — `usePermission([ROLE.SYSTEM_EDIT])`. `handleDeleteSystem` also re-checks `!canEdit || isPending` so an in-flight delete can't be re-fired. The guard is per hook-instance — only one context menu is open at a time, so that's the only reachable double-fire path.
+- **Confirm** — wraps the mutation in `useWarningModal` with recursive wording (`systemHierarchy.delete.confirm` — "…and all its sub-systems"). The backend delete is recursive + soft, so the wording holds even for childless rows.
+- **Feedback** — `toast.promise` (loading / success / error). On HTTP **409** the backend returns the blocking physical items as a bare `SystemPhysicalItemInfo[]` (read from `err.response.data`); the toast lists up to `MAX_LISTED_ITEMS = 3` item names with a locale-neutral `(+N)` overflow, and falls back to a generic message when the body is empty/unparseable.
+- **Selection reset** — on success, `isOpenOrAncestor(uid)` decides whether to call `clearSelection()` (new `useHierarchyNavigation` action that drops `parent`/`leaf`/`tab` from the URL). It returns true when the deleted uid is the open leaf or selected parent, an **ancestor of the open leaf** (via `useSystemDetail(selectedLeafUid).parentPath` — the leaf can be opened with a stale `parent`), or an **ancestor of the selected parent** (via `findHierarchyPath(nodes, selectedParentUid)`). This stops the detail panel pointing at a node the recursive delete just removed.
+
+Gating convention matches Copy/Paste/Create: tree + table **render the item `disabled`** when `!canEdit`; the graph **omits** it (`useRelationshipGraphContainerState` passes `onDeleteSystem` only when `canEdit`). The graph callback is threaded node-ward through `useRelationshipGraphFlow` → `utils/graphTransformers`, the same path as `onCopySystem`.
+
+`LeavesTable` wraps its content in a Radix `ContextMenu` **only when `onDeleteSystem` is provided** (otherwise the trigger would suppress the native right-click menu with nothing to show). The right-clicked row is captured by a capture-phase reset on the wrapper (clears the target) plus a bubble-phase `onContextMenu` per row (re-sets it) — so right-clicking empty table area leaves the item disabled.
 
 ## Copy / Paste
 
@@ -272,8 +288,9 @@ Unit coverage under `__tests__/` is heaviest in:
 - `types/__tests__/` — schema parsing.
 - `utils/__tests__/` — tree search, graph layout, filter predicates, change-builder, **parent→child level rules** (`systemLevelRules.spec.ts`), **create-subsystem payload builder** (`buildCreateSubsystemPayload.spec.ts` — locks the `updatedBy[Insert]` audit edge).
 - `hooks/queries/__tests__/` — `primeSystemDetailCache.test.ts` (the contract above), `useSystemLeaves.test.ts`, `useSystemLeavesCount.test.ts`.
-- `hooks/mutations/__tests__/` — `useSystemFieldUpdate.spec.ts`, `useItemFieldUpdate.spec.ts` (locks the System-node `WAS_UPDATED_BY` edge + change entries for item edits).
-- `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden).
+- `hooks/mutations/__tests__/` — `useSystemFieldUpdate.spec.ts`, `useItemFieldUpdate.spec.ts` (locks the System-node `WAS_UPDATED_BY` edge + change entries for item edits), `useDeleteSystem.spec.ts` (immediate invalidate + background recalc → second invalidate; recalc failure keeps only the immediate round).
+- `hooks/__tests__/useDeleteSystemAction.spec.tsx` — permission gate, in-flight re-entry guard, recursive confirm, 409 item-list + `(+N)` overflow + generic fallback, and selection reset for both open-leaf-ancestor and selected-parent-ancestor.
+- `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden); the Delete context item is covered in `tree/TreeNode.test.tsx`, `graph/SystemNode.test.tsx`, and `leaves/LeavesTable.test.tsx` (the last stubs the virtualized `PandaTableV2` to exercise the capture/bubble row capture, disabled-on-empty-area, and no-handler short-circuit).
 
 ## Deprecated / legacy
 
@@ -300,4 +317,4 @@ Unit coverage under `__tests__/` is heaviest in:
 
 > 🔧 *Engineer-only; stripped from the wiki.*
 >
-> Relevant schema: `System`, `SystemInterface`, `ParentPathItem` (`src/server/apollo/schema.graphql:266-369`). Relationship registry: `src/modules/systemHierarchy/types/graph.ts` (`RELATIONSHIP_DEFINITIONS`). Endpoint keys consumed: `systemsHierarchy`, `systemSubsystems`, `systemDetail`, `systemRelationships`, `system/<uid>/copy`.
+> Relevant schema: `System`, `SystemInterface`, `ParentPathItem` (`src/server/apollo/schema.graphql:266-369`). Relationship registry: `src/modules/systemHierarchy/types/graph.ts` (`RELATIONSHIP_DEFINITIONS`). Endpoint keys consumed: `systemsHierarchy`, `systemSubsystems`, `systemDetail`, `systemRelationships`, `system/<uid>/copy`, `system` (`DELETE /system/{uid}`, soft+recursive, 409 → `SystemPhysicalItemInfo[]`), `recalculateSpareParts`.

--- a/docs/user-guide/systemHierarchy/README.md
+++ b/docs/user-guide/systemHierarchy/README.md
@@ -15,7 +15,7 @@ The System Hierarchy module is the central place to browse, organize, and inspec
 | Persona | Role(s) | Can do |
 |---|---|---|
 | 👁️ **Viewer** | `systems-view` | Browse the tree, view details, view relationships, search and filter, view change history |
-| ✏️ **Editor / Admin** | `systems-edit` or `admin` | Everything in Viewer + edit fields, manage persons, manage relationships, **use and remove spare parts** (feature-flag gated in production), **create subsystems**, copy systems, assign and move physical items |
+| ✏️ **Editor / Admin** | `systems-edit` or `admin` | Everything in Viewer + edit fields, manage persons, manage relationships, **use and remove spare parts** (feature-flag gated in production), **create subsystems**, copy systems, **delete systems**, assign and move physical items |
 
 > 🔮 **Coming soon — Phase 1: split between Editor and Admin**
 > - **Admin** will have exclusive edit on systems at `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels (the strategic top of the tree).
@@ -67,6 +67,7 @@ When a system is selected for full detail view, a tabbed area replaces the leave
 - [Viewing change history](./workflows/viewing-change-history.md) — the *History* tab timeline and its filters.
 - [Creating systems](./workflows/creating-systems.md) — right-click a parent in the tree to create a new subsystem. Two-field dialog (name + level), inherits responsible/location/zone from the parent.
 - [Copying systems](./workflows/copying-systems.md) — copy/paste a system (and optionally its subtree) under a different parent.
+- [Deleting systems](./workflows/deleting-systems.md) — right-click → Delete System in the tree, table, or graph. Recursive (removes the whole subtree), confirmed, blocked when physical items are attached.
 - [Managing physical items](./workflows/managing-physical-items.md) — viewing the item's fields and catalogue properties (with service-modified values flagged), and assigning or moving the physical item attached to a system.
 
 For moving a system to a different parent, see the **Systems Moving** module — drag-and-drop rearrangement of the hierarchy lives there. See the [user guide index](../README.md).

--- a/docs/user-guide/systemHierarchy/workflows/deleting-systems.md
+++ b/docs/user-guide/systemHierarchy/workflows/deleting-systems.md
@@ -1,0 +1,74 @@
+# Deleting systems
+
+## What this is for
+
+Remove a system from the hierarchy when it no longer belongs there. Deletion is **recursive** — deleting a system also deletes every subsystem beneath it — so it is the right tool for retiring a whole branch, not just a single node. If you only want to move a system elsewhere, use the **Systems Moving** module instead; if you want to set a node aside without removing it, move it under the `TRASH` level (see [Editing system details](./editing-system-details.md)).
+
+Deletion is a soft removal: the systems are flagged as deleted and disappear from the hierarchy, and the action is recorded against your user in the change history.
+
+## Who can do this
+
+✏️ **Editor / Admin** — requires the `systems-edit` role.
+
+> 🔮 *Coming soon — Phase 1:* the delete action will be scoped by system level. Editors will be able to delete systems at `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, and `TRASH` levels only; deleting systems at `SYSTEM_DOMAIN` or `TECHNOLOGY_UNIT` will be admin-only.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean. Viewers see the **Delete System** menu item greyed out (disabled).
+
+## Prerequisites
+
+- You are looking at the System Hierarchy module.
+- You know which system you want to delete, and you understand that **all of its subsystems will be deleted with it**.
+- The system (and every subsystem under it) must have **no physical item attached** — otherwise the delete is blocked (see [Limitations](#limitations)).
+- See [Key concepts](../README.md#key-concepts) for terminology (system, subsystem, physical item).
+
+## Steps
+
+The action is available in three surfaces — the left **tree**, the **leaves table** (middle panel in table view), and the **Leaves Panel Graph** (middle panel in graph view). The interactions are identical in all three.
+
+1. **Right-click the system you want to delete.**
+   A context menu opens. **Delete System** is at the bottom, shown in red.
+
+   `[SCREENSHOT PLACEHOLDER: tree node right-clicked, context menu open with "Delete System" highlighted in red at the bottom, below Create/Copy/Paste entries]`
+
+2. **Click *Delete System*.**
+   A **Warning** dialog opens asking *"Are you sure you want to delete "&lt;name&gt;" and all its sub-systems?"*
+
+   `[SCREENSHOT PLACEHOLDER: Warning dialog with the recursive-delete confirmation question, Cancel and Continue buttons]`
+
+3. **Confirm with *Continue*** (or back out with *Cancel*).
+   On confirm, a toast tracks the operation: *Deleting system…* → *System "&lt;name&gt;" deleted*.
+
+4. **The view refreshes.** The deleted system and its subtree disappear from the tree, table, and graph. If you were viewing the deleted system (or one of its ancestors) in the detail panel, the selection clears so you are not left looking at a removed node.
+
+`[VIDEO PLACEHOLDER: 20s — right-click a subsystem in the tree → Delete System → confirm in the Warning dialog → watch the node and its children disappear and the success toast appear]`
+
+## What gets deleted
+
+**✅ Removed by the delete:**
+- The selected system.
+- **Every subsystem beneath it**, to any depth.
+
+**❌ Not removed:**
+- **Parent and sibling systems** — only the selected node and its descendants go.
+- **Physical items** — items are never deleted by this action; in fact their presence blocks the delete (see below).
+
+## Limitations
+
+- **Blocked by attached physical items.** If the system, or any subsystem under it, still has a physical item attached, the delete is refused and you get a toast: *Cannot delete "&lt;name&gt;": it still has attached physical items (…)*. The message lists the blocking items (up to three names, then a `(+N)` count). Detach or move those items first, then retry. See [Managing physical items](./managing-physical-items.md).
+- **Recursive and not selective.** You cannot delete a parent while keeping its children — the whole subtree goes together. To preserve some children, move them to another parent first (Systems Moving module).
+- **No bulk delete.** You delete one system (with its subtree) at a time.
+
+## Tips & gotchas
+
+- **The action is recursive — double-check the node.** The confirmation always names the system and warns about sub-systems. On a deep branch, deleting near the top removes a lot at once.
+- **Childless rows still say "and all its sub-systems".** The wording is the same everywhere because the system *could* have children; for a true leaf it simply means "this one system".
+- **Clear blocking items first.** The fastest path past a blocked delete is to open each system the toast names and detach or move its physical item.
+- **Deleted, not destroyed.** Deletion is a soft removal recorded in history; if something was deleted in error, raise it with an administrator rather than recreating it by hand.
+
+## Related
+
+- [Navigating the tree](./navigating-the-tree.md)
+- [Editing system details](./editing-system-details.md) — using the `TRASH` level to set a system aside instead of deleting it.
+- [Managing physical items](./managing-physical-items.md) — detaching the items that can block a delete.
+- [Copying systems](./copying-systems.md)
+- Moving a system to a different parent → see the `systemsMoving` module documentation in the [user guide index](../../README.md).

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1537,6 +1537,15 @@ export const messages = {
                 nameRequired: 'Name is required',
             },
         },
+        delete: {
+            menuItem: 'Delete System',
+            confirm: 'Are you sure you want to delete "{name}" and all its sub-systems?',
+            deleting: 'Deleting system...',
+            success: 'System "{name}" deleted',
+            conflict: 'Cannot delete "{name}": it still has attached physical items ({items}).',
+            conflictGeneric: 'Cannot delete "{name}" — it still has attached physical items.',
+            error: 'Failed to delete system "{name}".',
+        },
         systemLevels: {
             SYSTEM_DOMAIN: 'System domain',
             TECHNOLOGY_UNIT: 'Technology unit',

--- a/src/modules/systemHierarchy/components/graph/SystemNode.comp.tsx
+++ b/src/modules/systemHierarchy/components/graph/SystemNode.comp.tsx
@@ -27,6 +27,7 @@ interface SystemNodeData {
     onContextMenuChange?: (open: boolean) => void
     onCopySystem?: (uid: string) => void
     onPasteSystem?: (uid: string) => void
+    onDeleteSystem?: (uid: string, name: string) => void
     copiedSystemUid?: string | null
     hiddenRelationshipsCount?: number
     [key: string]: unknown
@@ -48,6 +49,7 @@ const SystemNodeComponent = ({ id, data }: NodeProps) => {
         onContextMenuChange,
         onCopySystem,
         onPasteSystem,
+        onDeleteSystem,
         copiedSystemUid,
         hiddenRelationshipsCount,
     } = data as unknown as SystemNodeData
@@ -138,6 +140,18 @@ const SystemNodeComponent = ({ id, data }: NodeProps) => {
                     >
                         {fm({ id: message.systemHierarchy.copy.pasteSystem })}
                     </ContextMenuItem>
+                )}
+                {onDeleteSystem && (
+                    <>
+                        <ContextMenuSeparator />
+                        <ContextMenuItem
+                            onSelect={() => onDeleteSystem(id, name)}
+                            className="text-destructive focus:text-destructive"
+                            data-testid="context-delete-system"
+                        >
+                            {fm({ id: message.systemHierarchy.delete.menuItem })}
+                        </ContextMenuItem>
+                    </>
                 )}
             </ContextMenuContent>
         </ContextMenu>

--- a/src/modules/systemHierarchy/components/graph/__tests__/SystemNode.test.tsx
+++ b/src/modules/systemHierarchy/components/graph/__tests__/SystemNode.test.tsx
@@ -35,6 +35,7 @@ const renderNode = (props = defaultProps) =>
                 'systemHierarchy.graph.actions.loadMore': 'Load 10 More',
                 'systemHierarchy.copy.copySystem': 'Copy System',
                 'systemHierarchy.copy.pasteSystem': 'Paste System',
+                'systemHierarchy.delete.menuItem': 'Delete System',
             }}
         >
             <ReactFlowProvider>
@@ -207,5 +208,23 @@ describe('SystemNode', () => {
         fireEvent.contextMenu(screen.getByTestId('system-node'))
         const pasteItem = screen.getByTestId('context-paste-system')
         expect(pasteItem).not.toHaveAttribute('data-disabled')
+    })
+
+    it('omits Delete System when onDeleteSystem is not provided', () => {
+        renderNode()
+        fireEvent.contextMenu(screen.getByTestId('system-node'))
+        expect(screen.queryByTestId('context-delete-system')).not.toBeInTheDocument()
+    })
+
+    it('calls onDeleteSystem with node id and name when Delete System clicked', () => {
+        const onDeleteSystem = jest.fn()
+        const props = {
+            ...defaultProps,
+            data: { ...defaultProps.data, onDeleteSystem },
+        }
+        renderNode(props)
+        fireEvent.contextMenu(screen.getByTestId('system-node'))
+        fireEvent.click(screen.getByText('Delete System'))
+        expect(onDeleteSystem).toHaveBeenCalledWith('n1', 'Pump A')
     })
 })

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -11,6 +11,7 @@ import useTableStateStore from '@/store/useTableStateStore'
 
 import { useSystemDetail } from '../../hooks/queries/useSystemDetail'
 import { useSystemLeaves } from '../../hooks/queries/useSystemLeaves'
+import { useDeleteSystemAction } from '../../hooks/useDeleteSystemAction'
 import { useHierarchyNavigation } from '../../hooks/useHierarchyNavigation'
 import { HIERARCHY_VIEWS, LEAVES_TABLE_ID } from '../../types/constants'
 import { SystemDetailViewContainer } from '../detail/SystemDetailView.cont'
@@ -34,6 +35,7 @@ export const LeavesPanelContainer: FC = () => {
     const { leaves, totalCount, isLoading, isInitialLoad } = useSystemLeaves(selectedParentUid)
 
     const { columns } = useLeavesColumns()
+    const { canEdit, handleDeleteSystem } = useDeleteSystemAction()
 
     const table = usePandaTable({
         tableId: LEAVES_TABLE_ID,
@@ -173,6 +175,8 @@ export const LeavesPanelContainer: FC = () => {
                     table={table}
                     toolbar={toolbar}
                     emptyState={emptyState}
+                    canEdit={canEdit}
+                    onDeleteSystem={handleDeleteSystem}
                 />
             </div>
         </div>

--- a/src/modules/systemHierarchy/components/leaves/LeavesTable.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesTable.comp.tsx
@@ -1,7 +1,15 @@
 import type { Table } from '@tanstack/react-table'
 import type { FC, ReactNode } from 'react'
-import { useCallback, useRef } from 'react'
+import { useCallback, useRef, useState } from 'react'
+import { useIntl } from 'react-intl'
 
+import {
+    ContextMenu,
+    ContextMenuContent,
+    ContextMenuItem,
+    ContextMenuTrigger,
+} from '@/components/ui/context-menu'
+import { message } from '@/i18n/src/messages'
 import { PaginationV2 as Pagination } from '@/modules/shared/table/PaginationV2'
 import {
     PandaTableV2,
@@ -20,6 +28,8 @@ interface LeavesTableProps {
     table: Table<SystemLeaf>
     toolbar?: ReactNode
     emptyState?: ReactNode
+    canEdit?: boolean
+    onDeleteSystem?: (uid: string, name: string) => void
 }
 
 export const LeavesTableComponent: FC<LeavesTableProps> = ({
@@ -31,48 +41,81 @@ export const LeavesTableComponent: FC<LeavesTableProps> = ({
     table,
     toolbar,
     emptyState,
+    canEdit = false,
+    onDeleteSystem,
 }) => {
+    const { formatMessage: fm } = useIntl()
     const tableRef = useRef<PandaTableV2Handle>(null)
+    const [contextSystem, setContextSystem] = useState<SystemLeaf | null>(null)
 
     const handlePageChange = useCallback(() => {
         tableRef.current?.scrollToTop()
     }, [])
 
     return (
-        <div className="flex flex-col h-full" data-testid="system-hierarchy-leaves-table">
-            <div className="flex-1 min-h-0 flex flex-col">
-                <PandaTableV2
-                    ref={tableRef}
-                    data={isInitialLoad ? undefined : data}
-                    table={table}
-                    loading={isLoading}
-                    tableId={LEAVES_TABLE_ID}
-                    skeletonRowCount={25}
-                    getRowProps={({ original: { uid } }) => ({
-                        onClick: () => onRowClick(uid),
-                        className: 'cursor-pointer hover:text-primary hover:bg-primary/10',
-                    })}
-                    settings={{
-                        enableSorting: true,
-                        enableColumnHiding: true,
-                        enableColumnReordering: false,
-                    }}
-                    toolbar={toolbar}
-                    emptyState={emptyState}
-                    className="flex-1 min-h-0"
-                />
-            </div>
-            <div className="shrink-0">
-                <Pagination
-                    tableId={LEAVES_TABLE_ID}
-                    settings={{
-                        enableQueryURL: true,
-                        pageSizeDefault: 25,
-                        total: totalCount,
-                    }}
-                    onPageChange={handlePageChange}
-                />
-            </div>
-        </div>
+        <ContextMenu
+            onOpenChange={open => {
+                if (!open) setContextSystem(null)
+            }}
+        >
+            <ContextMenuTrigger asChild>
+                <div
+                    className="flex flex-col h-full"
+                    data-testid="system-hierarchy-leaves-table"
+                    onContextMenuCapture={() => setContextSystem(null)}
+                >
+                    <div className="flex-1 min-h-0 flex flex-col">
+                        <PandaTableV2
+                            ref={tableRef}
+                            data={isInitialLoad ? undefined : data}
+                            table={table}
+                            loading={isLoading}
+                            tableId={LEAVES_TABLE_ID}
+                            skeletonRowCount={25}
+                            getRowProps={({ original }) => ({
+                                onClick: () => onRowClick(original.uid),
+                                onContextMenu: () => setContextSystem(original),
+                                className:
+                                    'cursor-pointer hover:text-primary hover:bg-primary/10',
+                            })}
+                            settings={{
+                                enableSorting: true,
+                                enableColumnHiding: true,
+                                enableColumnReordering: false,
+                            }}
+                            toolbar={toolbar}
+                            emptyState={emptyState}
+                            className="flex-1 min-h-0"
+                        />
+                    </div>
+                    <div className="shrink-0">
+                        <Pagination
+                            tableId={LEAVES_TABLE_ID}
+                            settings={{
+                                enableQueryURL: true,
+                                pageSizeDefault: 25,
+                                total: totalCount,
+                            }}
+                            onPageChange={handlePageChange}
+                        />
+                    </div>
+                </div>
+            </ContextMenuTrigger>
+            {onDeleteSystem && (
+                <ContextMenuContent>
+                    <ContextMenuItem
+                        disabled={!canEdit || !contextSystem}
+                        className="text-destructive focus:text-destructive"
+                        data-testid="context-delete-system"
+                        onSelect={() =>
+                            contextSystem &&
+                            onDeleteSystem(contextSystem.uid, contextSystem.name)
+                        }
+                    >
+                        {fm({ id: message.systemHierarchy.delete.menuItem })}
+                    </ContextMenuItem>
+                </ContextMenuContent>
+            )}
+        </ContextMenu>
     )
 }

--- a/src/modules/systemHierarchy/components/leaves/LeavesTable.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesTable.comp.tsx
@@ -52,70 +52,74 @@ export const LeavesTableComponent: FC<LeavesTableProps> = ({
         tableRef.current?.scrollToTop()
     }, [])
 
+    const tableContent = (
+        <div
+            className="flex flex-col h-full"
+            data-testid="system-hierarchy-leaves-table"
+            onContextMenuCapture={onDeleteSystem ? () => setContextSystem(null) : undefined}
+        >
+            <div className="flex-1 min-h-0 flex flex-col">
+                <PandaTableV2
+                    ref={tableRef}
+                    data={isInitialLoad ? undefined : data}
+                    table={table}
+                    loading={isLoading}
+                    tableId={LEAVES_TABLE_ID}
+                    skeletonRowCount={25}
+                    getRowProps={({ original }) => ({
+                        onClick: () => onRowClick(original.uid),
+                        onContextMenu: onDeleteSystem
+                            ? () => setContextSystem(original)
+                            : undefined,
+                        className: 'cursor-pointer hover:text-primary hover:bg-primary/10',
+                    })}
+                    settings={{
+                        enableSorting: true,
+                        enableColumnHiding: true,
+                        enableColumnReordering: false,
+                    }}
+                    toolbar={toolbar}
+                    emptyState={emptyState}
+                    className="flex-1 min-h-0"
+                />
+            </div>
+            <div className="shrink-0">
+                <Pagination
+                    tableId={LEAVES_TABLE_ID}
+                    settings={{
+                        enableQueryURL: true,
+                        pageSizeDefault: 25,
+                        total: totalCount,
+                    }}
+                    onPageChange={handlePageChange}
+                />
+            </div>
+        </div>
+    )
+
+    // Only wrap in a context menu when there's an action — otherwise the trigger
+    // would suppress the native right-click menu without offering anything.
+    if (!onDeleteSystem) return tableContent
+
     return (
         <ContextMenu
             onOpenChange={open => {
                 if (!open) setContextSystem(null)
             }}
         >
-            <ContextMenuTrigger asChild>
-                <div
-                    className="flex flex-col h-full"
-                    data-testid="system-hierarchy-leaves-table"
-                    onContextMenuCapture={() => setContextSystem(null)}
+            <ContextMenuTrigger asChild>{tableContent}</ContextMenuTrigger>
+            <ContextMenuContent>
+                <ContextMenuItem
+                    disabled={!canEdit || !contextSystem}
+                    className="text-destructive focus:text-destructive"
+                    data-testid="context-delete-system"
+                    onSelect={() =>
+                        contextSystem && onDeleteSystem(contextSystem.uid, contextSystem.name)
+                    }
                 >
-                    <div className="flex-1 min-h-0 flex flex-col">
-                        <PandaTableV2
-                            ref={tableRef}
-                            data={isInitialLoad ? undefined : data}
-                            table={table}
-                            loading={isLoading}
-                            tableId={LEAVES_TABLE_ID}
-                            skeletonRowCount={25}
-                            getRowProps={({ original }) => ({
-                                onClick: () => onRowClick(original.uid),
-                                onContextMenu: () => setContextSystem(original),
-                                className:
-                                    'cursor-pointer hover:text-primary hover:bg-primary/10',
-                            })}
-                            settings={{
-                                enableSorting: true,
-                                enableColumnHiding: true,
-                                enableColumnReordering: false,
-                            }}
-                            toolbar={toolbar}
-                            emptyState={emptyState}
-                            className="flex-1 min-h-0"
-                        />
-                    </div>
-                    <div className="shrink-0">
-                        <Pagination
-                            tableId={LEAVES_TABLE_ID}
-                            settings={{
-                                enableQueryURL: true,
-                                pageSizeDefault: 25,
-                                total: totalCount,
-                            }}
-                            onPageChange={handlePageChange}
-                        />
-                    </div>
-                </div>
-            </ContextMenuTrigger>
-            {onDeleteSystem && (
-                <ContextMenuContent>
-                    <ContextMenuItem
-                        disabled={!canEdit || !contextSystem}
-                        className="text-destructive focus:text-destructive"
-                        data-testid="context-delete-system"
-                        onSelect={() =>
-                            contextSystem &&
-                            onDeleteSystem(contextSystem.uid, contextSystem.name)
-                        }
-                    >
-                        {fm({ id: message.systemHierarchy.delete.menuItem })}
-                    </ContextMenuItem>
-                </ContextMenuContent>
-            )}
+                    {fm({ id: message.systemHierarchy.delete.menuItem })}
+                </ContextMenuItem>
+            </ContextMenuContent>
         </ContextMenu>
     )
 }

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesTable.test.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesTable.test.tsx
@@ -1,0 +1,88 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+
+import { LeavesTableComponent } from '../LeavesTable.comp'
+
+// PandaTableV2 is virtualized and renders nothing in jsdom — stub it with a
+// plain table that drives getRowProps so the context-menu wiring is what's tested.
+jest.mock('@/modules/shared/table/pandaTableV2/PandaTableV2', () => ({
+    PandaTableV2: ({ data, getRowProps }: any) => (
+        <table>
+            <tbody>
+                {(data ?? []).map((original: any) => {
+                    const { onClick, onContextMenu } = getRowProps({ original })
+                    return (
+                        <tr
+                            key={original.uid}
+                            data-testid={`row-${original.uid}`}
+                            onClick={onClick}
+                            onContextMenu={onContextMenu}
+                        >
+                            <td>{original.name}</td>
+                        </tr>
+                    )
+                })}
+            </tbody>
+        </table>
+    ),
+}))
+
+jest.mock('@/modules/shared/table/PaginationV2', () => ({ PaginationV2: () => null }))
+
+const leaves = [
+    { uid: 'leaf-1', name: 'Pump A' },
+    { uid: 'leaf-2', name: 'Valve B' },
+]
+
+const renderTable = (props: Partial<React.ComponentProps<typeof LeavesTableComponent>> = {}) =>
+    render(
+        <IntlProvider locale="en" messages={{ 'systemHierarchy.delete.menuItem': 'Delete System' }}>
+            <LeavesTableComponent
+                data={leaves as never}
+                totalCount={leaves.length}
+                isLoading={false}
+                isInitialLoad={false}
+                onRowClick={jest.fn()}
+                table={{} as never}
+                canEdit
+                onDeleteSystem={jest.fn()}
+                {...props}
+            />
+        </IntlProvider>,
+    )
+
+describe('LeavesTableComponent context menu', () => {
+    it('enables Delete and calls handler with the right-clicked row uid and name', () => {
+        const onDeleteSystem = jest.fn()
+        renderTable({ onDeleteSystem })
+
+        fireEvent.contextMenu(screen.getByTestId('row-leaf-2'))
+        const deleteItem = screen.getByTestId('context-delete-system')
+        expect(deleteItem).not.toHaveAttribute('data-disabled')
+
+        fireEvent.click(deleteItem)
+        expect(onDeleteSystem).toHaveBeenCalledWith('leaf-2', 'Valve B')
+    })
+
+    it('disables Delete when right-clicking outside a row (no row captured)', () => {
+        renderTable()
+
+        fireEvent.contextMenu(screen.getByTestId('system-hierarchy-leaves-table'))
+        expect(screen.getByTestId('context-delete-system')).toHaveAttribute('data-disabled')
+    })
+
+    it('disables Delete when the user cannot edit', () => {
+        renderTable({ canEdit: false })
+
+        fireEvent.contextMenu(screen.getByTestId('row-leaf-1'))
+        expect(screen.getByTestId('context-delete-system')).toHaveAttribute('data-disabled')
+    })
+
+    it('does not wrap in a context menu when no delete handler is provided', () => {
+        renderTable({ onDeleteSystem: undefined })
+
+        fireEvent.contextMenu(screen.getByTestId('row-leaf-1'))
+        expect(screen.queryByTestId('context-delete-system')).not.toBeInTheDocument()
+    })
+})

--- a/src/modules/systemHierarchy/components/tree/SystemTree.comp.tsx
+++ b/src/modules/systemHierarchy/components/tree/SystemTree.comp.tsx
@@ -18,6 +18,7 @@ interface SystemTreeComponentProps {
     onCopySystem?: (uid: string) => void
     onPasteSystem?: (uid: string) => void
     onCreateSubsystem?: (parentUid: string, parentName: string, parentLevel: SystemLevel) => void
+    onDeleteSystem?: (uid: string, name: string) => void
 }
 
 export const SystemTreeComponent: FC<SystemTreeComponentProps> = ({
@@ -32,6 +33,7 @@ export const SystemTreeComponent: FC<SystemTreeComponentProps> = ({
     onCopySystem,
     onPasteSystem,
     onCreateSubsystem,
+    onDeleteSystem,
 }) => {
     const renderNode = useCallback(
         (node: HierarchyNode, depth: number) => {
@@ -53,6 +55,7 @@ export const SystemTreeComponent: FC<SystemTreeComponentProps> = ({
                     onCopySystem={onCopySystem}
                     onPasteSystem={onPasteSystem}
                     onCreateSubsystem={onCreateSubsystem}
+                    onDeleteSystem={onDeleteSystem}
                 >
                     {isExpanded && node.children.map(child => renderNode(child, depth + 1))}
                 </TreeNode>
@@ -69,6 +72,7 @@ export const SystemTreeComponent: FC<SystemTreeComponentProps> = ({
             onCopySystem,
             onPasteSystem,
             onCreateSubsystem,
+            onDeleteSystem,
         ],
     )
 

--- a/src/modules/systemHierarchy/components/tree/SystemTree.cont.tsx
+++ b/src/modules/systemHierarchy/components/tree/SystemTree.cont.tsx
@@ -10,6 +10,7 @@ import { message } from '@/i18n/src/messages'
 
 import { useSystemHierarchy } from '../../hooks/queries/useSystemHierarchy'
 import { useCreateSubsystemAction } from '../../hooks/useCreateSubsystemAction'
+import { useDeleteSystemAction } from '../../hooks/useDeleteSystemAction'
 import { useHierarchyNavigation } from '../../hooks/useHierarchyNavigation'
 import { useSystemCopyPaste } from '../../hooks/useSystemCopyPaste'
 import { useHierarchyStore } from '../../store/useHierarchyStore'
@@ -26,6 +27,7 @@ export const SystemTreeContainer: FC = () => {
         useHierarchyStore()
     const { copiedSystemUid, canEdit, handleCopySystem, handlePasteSystem } = useSystemCopyPaste()
     const { handleCreateSubsystem } = useCreateSubsystemAction()
+    const { handleDeleteSystem } = useDeleteSystemAction()
 
     const [searchInput, setSearchInput] = useState('')
     const [search, setSearch] = useState('')
@@ -127,6 +129,7 @@ export const SystemTreeContainer: FC = () => {
                         onCopySystem={handleCopySystem}
                         onPasteSystem={handlePasteSystem}
                         onCreateSubsystem={handleCreateSubsystem}
+                        onDeleteSystem={handleDeleteSystem}
                     />
                 )}
             </div>

--- a/src/modules/systemHierarchy/components/tree/TreeNode.comp.tsx
+++ b/src/modules/systemHierarchy/components/tree/TreeNode.comp.tsx
@@ -7,6 +7,7 @@ import {
     ContextMenu,
     ContextMenuContent,
     ContextMenuItem,
+    ContextMenuSeparator,
     ContextMenuTrigger,
 } from '@/components/ui/context-menu'
 import { message } from '@/i18n/src/messages'
@@ -33,6 +34,7 @@ interface TreeNodeProps {
     onCopySystem?: (uid: string) => void
     onPasteSystem?: (uid: string) => void
     onCreateSubsystem?: (parentUid: string, parentName: string, parentLevel: SystemLevel) => void
+    onDeleteSystem?: (uid: string, name: string) => void
 }
 
 export const TreeNode: FC<TreeNodeProps> = ({
@@ -49,6 +51,7 @@ export const TreeNode: FC<TreeNodeProps> = ({
     onCopySystem,
     onPasteSystem,
     onCreateSubsystem,
+    onDeleteSystem,
 }) => {
     const { formatMessage: fm } = useIntl()
     const hasChildren = node.children.length > 0
@@ -70,7 +73,8 @@ export const TreeNode: FC<TreeNodeProps> = ({
 
     const canPaste = !!copiedSystemUid && copiedSystemUid !== node.uid
     const canCreate = canCreateUnder(node.systemLevel)
-    const hasContextMenu = !!onCopySystem || !!onPasteSystem || !!onCreateSubsystem
+    const hasContextMenu =
+        !!onCopySystem || !!onPasteSystem || !!onCreateSubsystem || !!onDeleteSystem
 
     const nodeContent = (
         <div
@@ -137,6 +141,19 @@ export const TreeNode: FC<TreeNodeProps> = ({
                             >
                                 {fm({ id: message.systemHierarchy.copy.pasteSystem })}
                             </ContextMenuItem>
+                        )}
+                        {onDeleteSystem && (
+                            <>
+                                <ContextMenuSeparator />
+                                <ContextMenuItem
+                                    onSelect={() => onDeleteSystem(node.uid, node.name)}
+                                    disabled={!canEdit}
+                                    className="text-destructive focus:text-destructive"
+                                    data-testid="context-delete-system"
+                                >
+                                    {fm({ id: message.systemHierarchy.delete.menuItem })}
+                                </ContextMenuItem>
+                            </>
                         )}
                     </ContextMenuContent>
                 </ContextMenu>

--- a/src/modules/systemHierarchy/components/tree/__tests__/TreeNode.test.tsx
+++ b/src/modules/systemHierarchy/components/tree/__tests__/TreeNode.test.tsx
@@ -29,6 +29,7 @@ const messages = {
     'systemHierarchy.copy.copySystem': 'Copy System',
     'systemHierarchy.copy.pasteSystem': 'Paste System',
     'systemHierarchy.create.menuItem': 'Create System',
+    'systemHierarchy.delete.menuItem': 'Delete System',
 }
 
 const renderTreeNode = (props: Partial<React.ComponentProps<typeof TreeNode>> = {}) =>
@@ -158,6 +159,30 @@ describe('TreeNode', () => {
 
             fireEvent.contextMenu(screen.getByTestId('tree-node-node-1').firstChild!)
             expect(screen.queryByText('Copy System')).not.toBeInTheDocument()
+        })
+
+        it('shows Delete System and calls handler with uid and name', () => {
+            const onDeleteSystem = jest.fn()
+            renderTreeNode({ onDeleteSystem, canEdit: true })
+
+            fireEvent.contextMenu(screen.getByTestId('tree-node-node-1').firstChild!)
+            const deleteItem = screen.getByTestId('context-delete-system')
+            expect(deleteItem).not.toHaveAttribute('data-disabled')
+
+            fireEvent.click(deleteItem)
+            expect(onDeleteSystem).toHaveBeenCalledWith('node-1', 'Node 1')
+        })
+
+        it('disables Delete System and does not fire handler when canEdit is false', () => {
+            const onDeleteSystem = jest.fn()
+            renderTreeNode({ onDeleteSystem, canEdit: false })
+
+            fireEvent.contextMenu(screen.getByTestId('tree-node-node-1').firstChild!)
+            const deleteItem = screen.getByTestId('context-delete-system')
+            expect(deleteItem).toHaveAttribute('data-disabled')
+
+            fireEvent.click(deleteItem)
+            expect(onDeleteSystem).not.toHaveBeenCalled()
         })
 
         it('enables Create System when canEdit and parent level allows children, calls handler on click', () => {

--- a/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
@@ -151,6 +151,25 @@ describe('useDeleteSystemAction', () => {
         expect(message).toBe('systemHierarchy.delete.conflict|Pump A|Item A, Item B')
     })
 
+    it('caps the listed items and appends a locale-neutral overflow count', () => {
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        const message = getToastHandlers().error({
+            response: {
+                status: 409,
+                data: [
+                    { itemName: 'Item A' },
+                    { itemName: 'Item B' },
+                    { itemName: 'Item C' },
+                    { itemName: 'Item D' },
+                ],
+            },
+        })
+
+        expect(message).toBe('systemHierarchy.delete.conflict|Pump A|Item A, Item B, Item C (+1)')
+    })
+
     it('uses the generic conflict message when the 409 body is empty', () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 

--- a/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
@@ -82,6 +82,16 @@ describe('useDeleteSystemAction', () => {
         expect(mutateAsync).not.toHaveBeenCalled()
     })
 
+    it('ignores re-entry while a delete is already in flight', () => {
+        mockUseDeleteSystem.mockReturnValue({ mutateAsync, isPending: true })
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+
+        expect(mockToastPromise).not.toHaveBeenCalled()
+        expect(mutateAsync).not.toHaveBeenCalled()
+    })
+
     it('confirms with recursive wording then deletes via the mutation', () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 

--- a/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
@@ -1,0 +1,161 @@
+import { act, renderHook } from '@testing-library/react'
+import { toast } from 'sonner'
+
+import { usePermission } from '@/hooks/usePermission'
+import useWarningModal from '@/hooks/useWarningModal'
+
+import { useDeleteSystem } from '../mutations/useDeleteSystem'
+import { useSystemHierarchy } from '../queries/useSystemHierarchy'
+import { useDeleteSystemAction } from '../useDeleteSystemAction'
+import { useHierarchyNavigation } from '../useHierarchyNavigation'
+
+jest.mock('@/hooks/usePermission', () => ({ usePermission: jest.fn() }))
+jest.mock('@/hooks/useWarningModal', () => ({ __esModule: true, default: jest.fn() }))
+jest.mock('../mutations/useDeleteSystem', () => ({ useDeleteSystem: jest.fn() }))
+jest.mock('../queries/useSystemHierarchy', () => ({ useSystemHierarchy: jest.fn() }))
+jest.mock('../useHierarchyNavigation', () => ({ useHierarchyNavigation: jest.fn() }))
+jest.mock('sonner', () => ({ toast: { promise: jest.fn() } }))
+jest.mock('react-intl', () => ({
+    useIntl: () => ({
+        formatMessage: ({ id }: { id: string }, values?: Record<string, unknown>) =>
+            [id, values?.name, values?.items].filter(v => v != null).join('|'),
+    }),
+}))
+
+const mockUsePermission = usePermission as jest.Mock
+const mockUseWarningModal = useWarningModal as unknown as jest.Mock
+const mockUseDeleteSystem = useDeleteSystem as jest.Mock
+const mockUseSystemHierarchy = useSystemHierarchy as jest.Mock
+const mockUseHierarchyNavigation = useHierarchyNavigation as jest.Mock
+const mockToastPromise = toast.promise as jest.Mock
+
+let mutateAsync: jest.Mock
+let clearSelection: jest.Mock
+let lastConfirmMessage: string | undefined
+
+const setNavigation = (overrides: Record<string, unknown> = {}) => {
+    mockUseHierarchyNavigation.mockReturnValue({
+        selectedParentUid: null,
+        selectedLeafUid: null,
+        clearSelection,
+        ...overrides,
+    })
+}
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mutateAsync = jest.fn().mockResolvedValue({})
+    clearSelection = jest.fn()
+    lastConfirmMessage = undefined
+
+    mockUsePermission.mockReturnValue(true)
+    // withWarningModal(cb, msg) → trigger that runs cb immediately (simulating confirm)
+    mockUseWarningModal.mockReturnValue(
+        (cb: (...args: unknown[]) => void, msg?: string) =>
+            (...args: unknown[]) => {
+                lastConfirmMessage = msg
+                cb(...args)
+            },
+    )
+    mockUseDeleteSystem.mockReturnValue({ mutateAsync, isPending: false })
+    mockUseSystemHierarchy.mockReturnValue({ nodes: [] })
+    setNavigation()
+})
+
+const getToastHandlers = () => {
+    const [, handlers] = mockToastPromise.mock.calls[0]
+    return handlers as {
+        loading: string
+        success: () => string
+        error: (error: unknown) => string
+    }
+}
+
+describe('useDeleteSystemAction', () => {
+    it('does nothing when the user lacks edit permission', () => {
+        mockUsePermission.mockReturnValue(false)
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+
+        expect(mockToastPromise).not.toHaveBeenCalled()
+        expect(mutateAsync).not.toHaveBeenCalled()
+    })
+
+    it('confirms with recursive wording then deletes via the mutation', () => {
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+
+        expect(lastConfirmMessage).toBe('systemHierarchy.delete.confirm|Pump A')
+        expect(mutateAsync).toHaveBeenCalledWith({ uid: 'sys-1' })
+        expect(mockToastPromise).toHaveBeenCalledTimes(1)
+    })
+
+    it('resets selection on success when the deleted system is currently open', () => {
+        setNavigation({ selectedLeafUid: 'sys-1' })
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        const { success } = getToastHandlers()
+        const successMessage = success()
+
+        expect(clearSelection).toHaveBeenCalledTimes(1)
+        expect(successMessage).toBe('systemHierarchy.delete.success|Pump A')
+    })
+
+    it('resets selection when the deleted system is an ancestor of the open node', () => {
+        mockUseSystemHierarchy.mockReturnValue({
+            nodes: [{ uid: 'root', children: [{ uid: 'child', children: [] }] }],
+        })
+        setNavigation({ selectedParentUid: 'child' })
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('root', 'Root'))
+        getToastHandlers().success()
+
+        expect(clearSelection).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not reset selection when an unrelated system is deleted', () => {
+        setNavigation({ selectedParentUid: 'other', selectedLeafUid: 'other' })
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        getToastHandlers().success()
+
+        expect(clearSelection).not.toHaveBeenCalled()
+    })
+
+    it('lists the blocking physical items on a 409 conflict', () => {
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        const message = getToastHandlers().error({
+            response: {
+                status: 409,
+                data: [{ itemName: 'Item A' }, { itemName: 'Item B' }],
+            },
+        })
+
+        expect(message).toBe('systemHierarchy.delete.conflict|Pump A|Item A, Item B')
+    })
+
+    it('uses the generic conflict message when the 409 body is empty', () => {
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        const message = getToastHandlers().error({ response: { status: 409, data: [] } })
+
+        expect(message).toBe('systemHierarchy.delete.conflictGeneric|Pump A')
+    })
+
+    it('uses the generic error message for non-409 failures', () => {
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        const message = getToastHandlers().error({ response: { status: 500 } })
+
+        expect(message).toBe('systemHierarchy.delete.error|Pump A')
+    })
+})

--- a/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
@@ -5,6 +5,7 @@ import { usePermission } from '@/hooks/usePermission'
 import useWarningModal from '@/hooks/useWarningModal'
 
 import { useDeleteSystem } from '../mutations/useDeleteSystem'
+import { useSystemDetail } from '../queries/useSystemDetail'
 import { useSystemHierarchy } from '../queries/useSystemHierarchy'
 import { useDeleteSystemAction } from '../useDeleteSystemAction'
 import { useHierarchyNavigation } from '../useHierarchyNavigation'
@@ -12,6 +13,7 @@ import { useHierarchyNavigation } from '../useHierarchyNavigation'
 jest.mock('@/hooks/usePermission', () => ({ usePermission: jest.fn() }))
 jest.mock('@/hooks/useWarningModal', () => ({ __esModule: true, default: jest.fn() }))
 jest.mock('../mutations/useDeleteSystem', () => ({ useDeleteSystem: jest.fn() }))
+jest.mock('../queries/useSystemDetail', () => ({ useSystemDetail: jest.fn() }))
 jest.mock('../queries/useSystemHierarchy', () => ({ useSystemHierarchy: jest.fn() }))
 jest.mock('../useHierarchyNavigation', () => ({ useHierarchyNavigation: jest.fn() }))
 jest.mock('sonner', () => ({ toast: { promise: jest.fn() } }))
@@ -25,6 +27,7 @@ jest.mock('react-intl', () => ({
 const mockUsePermission = usePermission as jest.Mock
 const mockUseWarningModal = useWarningModal as unknown as jest.Mock
 const mockUseDeleteSystem = useDeleteSystem as jest.Mock
+const mockUseSystemDetail = useSystemDetail as jest.Mock
 const mockUseSystemHierarchy = useSystemHierarchy as jest.Mock
 const mockUseHierarchyNavigation = useHierarchyNavigation as jest.Mock
 const mockToastPromise = toast.promise as jest.Mock
@@ -58,6 +61,7 @@ beforeEach(() => {
             },
     )
     mockUseDeleteSystem.mockReturnValue({ mutateAsync, isPending: false })
+    mockUseSystemDetail.mockReturnValue({ system: null })
     mockUseSystemHierarchy.mockReturnValue({ nodes: [] })
     setNavigation()
 })
@@ -122,6 +126,21 @@ describe('useDeleteSystemAction', () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 
         act(() => result.current.handleDeleteSystem('root', 'Root'))
+        getToastHandlers().success()
+
+        expect(clearSelection).toHaveBeenCalledTimes(1)
+    })
+
+    it('resets selection when the deleted system is an ancestor of the open detail leaf', () => {
+        // Leaf opened via selectLeaf — parent stays on an unrelated root.
+        mockUseSystemDetail.mockReturnValue({
+            system: { parentPath: [{ uid: 'root' }, { uid: 'mid' }] },
+        })
+        mockUseSystemHierarchy.mockReturnValue({ nodes: [] })
+        setNavigation({ selectedLeafUid: 'leaf-x', selectedParentUid: 'unrelated-root' })
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        act(() => result.current.handleDeleteSystem('mid', 'Mid'))
         getToastHandlers().success()
 
         expect(clearSelection).toHaveBeenCalledTimes(1)

--- a/src/modules/systemHierarchy/hooks/mutations/__tests__/useDeleteSystem.spec.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/__tests__/useDeleteSystem.spec.ts
@@ -1,0 +1,68 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook, waitFor } from '@testing-library/react'
+import React from 'react'
+
+import { queryMutate } from '@/utils/fetcher'
+
+import { useDeleteSystem } from '../useDeleteSystem'
+
+jest.mock('@/utils/fetcher', () => ({ queryMutate: jest.fn() }))
+
+const mockQueryMutate = queryMutate as jest.Mock
+
+describe('useDeleteSystem', () => {
+    let queryClient: QueryClient
+    let invalidateSpy: jest.SpyInstance
+    const deleteFn = jest.fn()
+    const recalcFn = jest.fn()
+
+    const createWrapper = () => {
+        queryClient = new QueryClient({
+            defaultOptions: { mutations: { retry: false } },
+        })
+        invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries')
+        const Wrapper = ({ children }: { children: React.ReactNode }) =>
+            React.createElement(QueryClientProvider, { client: queryClient }, children)
+        Wrapper.displayName = 'TestWrapper'
+        return Wrapper
+    }
+
+    beforeEach(() => {
+        jest.clearAllMocks()
+        deleteFn.mockResolvedValue({})
+        recalcFn.mockResolvedValue({})
+        mockQueryMutate.mockImplementation((endpoint: string) =>
+            endpoint === 'system' ? deleteFn : recalcFn,
+        )
+    })
+
+    it('deletes, recalculates spare parts, then invalidates all hierarchy keys', async () => {
+        const { result } = renderHook(() => useDeleteSystem(), { wrapper: createWrapper() })
+
+        await result.current.mutateAsync({ uid: 'sys-1' })
+
+        expect(mockQueryMutate).toHaveBeenCalledWith('system', 'delete', { uid: 'sys-1' })
+        expect(deleteFn).toHaveBeenCalled()
+        expect(mockQueryMutate).toHaveBeenCalledWith('recalculateSpareParts', 'post')
+        expect(recalcFn).toHaveBeenCalled()
+
+        await waitFor(() => {
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemsHierarchy'] })
+        })
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemLeaves'] })
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemLeavesCount'] })
+        expect(invalidateSpy).toHaveBeenCalledTimes(4)
+    })
+
+    it('still invalidates when the recalc call fails', async () => {
+        recalcFn.mockRejectedValue(new Error('recalc boom'))
+        const { result } = renderHook(() => useDeleteSystem(), { wrapper: createWrapper() })
+
+        await result.current.mutateAsync({ uid: 'sys-1' })
+
+        await waitFor(() => {
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemsHierarchy'] })
+        })
+        expect(invalidateSpy).toHaveBeenCalledTimes(4)
+    })
+})

--- a/src/modules/systemHierarchy/hooks/mutations/__tests__/useDeleteSystem.spec.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/__tests__/useDeleteSystem.spec.ts
@@ -36,7 +36,7 @@ describe('useDeleteSystem', () => {
         )
     })
 
-    it('deletes, recalculates spare parts, then invalidates all hierarchy keys', async () => {
+    it('refreshes immediately on delete, then recalculates and refreshes again', async () => {
         const { result } = renderHook(() => useDeleteSystem(), { wrapper: createWrapper() })
 
         await result.current.mutateAsync({ uid: 'sys-1' })
@@ -46,15 +46,14 @@ describe('useDeleteSystem', () => {
         expect(mockQueryMutate).toHaveBeenCalledWith('recalculateSpareParts', 'post')
         expect(recalcFn).toHaveBeenCalled()
 
-        await waitFor(() => {
-            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemsHierarchy'] })
-        })
+        expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemsHierarchy'] })
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemLeaves'] })
         expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemLeavesCount'] })
-        expect(invalidateSpy).toHaveBeenCalledTimes(4)
+        // Two refresh rounds: immediate (on delete) + after the background recalc.
+        await waitFor(() => expect(invalidateSpy).toHaveBeenCalledTimes(8))
     })
 
-    it('still invalidates when the recalc call fails', async () => {
+    it('keeps the immediate refresh and skips the second round when recalc fails', async () => {
         recalcFn.mockRejectedValue(new Error('recalc boom'))
         const { result } = renderHook(() => useDeleteSystem(), { wrapper: createWrapper() })
 
@@ -63,6 +62,7 @@ describe('useDeleteSystem', () => {
         await waitFor(() => {
             expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['systemsHierarchy'] })
         })
+        // Only the immediate round; the failed recalc must not trigger a second one.
         expect(invalidateSpy).toHaveBeenCalledTimes(4)
     })
 })

--- a/src/modules/systemHierarchy/hooks/mutations/useDeleteSystem.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useDeleteSystem.ts
@@ -32,6 +32,9 @@ export const useDeleteSystem = () => {
             // Immediate refresh so the deleted node disappears promptly.
             invalidateHierarchy()
             // Deleting a system can shift spare-parts coverage of related systems.
+            // Run unconditionally: a recursive delete may remove subsystems with
+            // spare relations we can't cheaply detect client-side, and a stale
+            // coverage number is worse than one extra request (matches legacy delete).
             // Recompute in the background, then refresh again so coverage stats
             // catch up. A recalc failure must not mask the successful delete.
             void queryMutate('recalculateSpareParts', 'post')(undefined)

--- a/src/modules/systemHierarchy/hooks/mutations/useDeleteSystem.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useDeleteSystem.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+
+import type { AxiosError } from '@/types/http'
+import { queryMutate } from '@/utils/fetcher'
+
+import {
+    HIERARCHY_QUERY_KEY,
+    LEAVES_COUNT_QUERY_KEY,
+    LEAVES_QUERY_KEY,
+    RELATIONSHIP_GRAPH_QUERY_KEY,
+} from '../../types/constants'
+
+type DeleteSystemVariables = { uid: string }
+
+export const useDeleteSystem = () => {
+    const queryClient = useQueryClient()
+
+    return useMutation<unknown, AxiosError, DeleteSystemVariables>({
+        mutationFn: ({ uid }) => queryMutate('system', 'delete', { uid })(undefined),
+        onSuccess: async () => {
+            // Deleting a system can shift spare-parts coverage of related systems.
+            // Mirror the legacy delete by recomputing before refetching; a recalc
+            // failure must not mask the successful delete.
+            try {
+                await queryMutate('recalculateSpareParts', 'post')(null)
+            } catch {
+                // ignore — invalidation below still refreshes from source of truth
+            }
+            queryClient.invalidateQueries({ queryKey: [HIERARCHY_QUERY_KEY] })
+            queryClient.invalidateQueries({ queryKey: [LEAVES_QUERY_KEY] })
+            queryClient.invalidateQueries({ queryKey: [LEAVES_COUNT_QUERY_KEY] })
+            queryClient.invalidateQueries({ queryKey: [RELATIONSHIP_GRAPH_QUERY_KEY] })
+        },
+    })
+}

--- a/src/modules/systemHierarchy/hooks/mutations/useDeleteSystem.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useDeleteSystem.ts
@@ -15,21 +15,30 @@ type DeleteSystemVariables = { uid: string }
 export const useDeleteSystem = () => {
     const queryClient = useQueryClient()
 
+    // Refresh the hierarchy/leaves/graph views. Fire-and-forget on purpose —
+    // TanStack handles the refetch; we never need to await it here.
+    const invalidateHierarchy = () => {
+        queryClient.invalidateQueries({ queryKey: [HIERARCHY_QUERY_KEY] })
+        queryClient.invalidateQueries({ queryKey: [LEAVES_QUERY_KEY] })
+        queryClient.invalidateQueries({ queryKey: [LEAVES_COUNT_QUERY_KEY] })
+        queryClient.invalidateQueries({ queryKey: [RELATIONSHIP_GRAPH_QUERY_KEY] })
+    }
+
     return useMutation<unknown, AxiosError, DeleteSystemVariables>({
         mutationFn: ({ uid }) => queryMutate('system', 'delete', { uid })(undefined),
-        onSuccess: async () => {
+        // Keep onSuccess synchronous so the delete (and its toast) resolves as soon
+        // as the system is gone — without waiting on the slower recalc.
+        onSuccess: () => {
+            // Immediate refresh so the deleted node disappears promptly.
+            invalidateHierarchy()
             // Deleting a system can shift spare-parts coverage of related systems.
-            // Mirror the legacy delete by recomputing before refetching; a recalc
-            // failure must not mask the successful delete.
-            try {
-                await queryMutate('recalculateSpareParts', 'post')(null)
-            } catch {
-                // ignore — invalidation below still refreshes from source of truth
-            }
-            queryClient.invalidateQueries({ queryKey: [HIERARCHY_QUERY_KEY] })
-            queryClient.invalidateQueries({ queryKey: [LEAVES_QUERY_KEY] })
-            queryClient.invalidateQueries({ queryKey: [LEAVES_COUNT_QUERY_KEY] })
-            queryClient.invalidateQueries({ queryKey: [RELATIONSHIP_GRAPH_QUERY_KEY] })
+            // Recompute in the background, then refresh again so coverage stats
+            // catch up. A recalc failure must not mask the successful delete.
+            void queryMutate('recalculateSpareParts', 'post')(undefined)
+                .then(() => invalidateHierarchy())
+                .catch(() => {
+                    // ignore — the immediate refresh above already reflects the delete
+                })
         },
     })
 }

--- a/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
+++ b/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
@@ -59,7 +59,7 @@ export const useDeleteSystemAction = () => {
 
     const handleDeleteSystem = useCallback(
         (uid: string, name: string) => {
-            if (!canEdit) return
+            if (!canEdit || isPending) return
 
             const runDelete = () => {
                 toast.promise(mutateAsync({ uid }), {
@@ -80,7 +80,16 @@ export const useDeleteSystemAction = () => {
             const confirm = fm({ id: messages.confirm }, createMessageValues({ name }))
             withWarningModal(runDelete, confirm)()
         },
-        [canEdit, withWarningModal, fm, mutateAsync, isOpenOrAncestor, clearSelection, buildConflictMessage],
+        [
+            canEdit,
+            isPending,
+            withWarningModal,
+            fm,
+            mutateAsync,
+            isOpenOrAncestor,
+            clearSelection,
+            buildConflictMessage,
+        ],
     )
 
     return { canEdit, handleDeleteSystem, isPending }

--- a/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
+++ b/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
@@ -1,0 +1,87 @@
+import { useCallback } from 'react'
+import { useIntl } from 'react-intl'
+import { toast } from 'sonner'
+
+import { usePermission } from '@/hooks/usePermission'
+import useWarningModal from '@/hooks/useWarningModal'
+import { message } from '@/i18n/src/messages'
+import { ROLE } from '@/types/constants/roles'
+import type { AxiosError } from '@/types/http'
+import { createMessageValues } from '@/utils/formatters'
+
+import { findHierarchyPath } from '../utils/treePath'
+import { useDeleteSystem } from './mutations/useDeleteSystem'
+import { useSystemHierarchy } from './queries/useSystemHierarchy'
+import { useHierarchyNavigation } from './useHierarchyNavigation'
+
+const messages = message.systemHierarchy.delete
+
+const MAX_LISTED_ITEMS = 3
+
+type PhysicalItemConflict = {
+    systemUid: string
+    systemName: string
+    itemUid: string
+    itemName: string
+}
+
+export const useDeleteSystemAction = () => {
+    const { formatMessage: fm } = useIntl()
+    const canEdit = usePermission([ROLE.SYSTEM_EDIT])
+    const withWarningModal = useWarningModal()
+    const { nodes } = useSystemHierarchy()
+    const { selectedParentUid, selectedLeafUid, clearSelection } = useHierarchyNavigation()
+    const { mutateAsync, isPending } = useDeleteSystem()
+
+    const isOpenOrAncestor = useCallback(
+        (uid: string) => {
+            if (uid === selectedLeafUid || uid === selectedParentUid) return true
+            if (!selectedParentUid) return false
+            return findHierarchyPath(nodes, selectedParentUid).some(node => node.uid === uid)
+        },
+        [nodes, selectedParentUid, selectedLeafUid],
+    )
+
+    const buildConflictMessage = useCallback(
+        (name: string, data: unknown) => {
+            const conflicts = Array.isArray(data) ? (data as PhysicalItemConflict[]) : []
+            const itemNames = conflicts.map(conflict => conflict.itemName).filter(Boolean)
+            if (itemNames.length === 0) {
+                return fm({ id: messages.conflictGeneric }, createMessageValues({ name }))
+            }
+            const shown = itemNames.slice(0, MAX_LISTED_ITEMS).join(', ')
+            const remaining = itemNames.length - MAX_LISTED_ITEMS
+            const items = remaining > 0 ? `${shown} +${remaining} more` : shown
+            return fm({ id: messages.conflict }, createMessageValues({ name, items }))
+        },
+        [fm],
+    )
+
+    const handleDeleteSystem = useCallback(
+        (uid: string, name: string) => {
+            if (!canEdit) return
+
+            const runDelete = () => {
+                toast.promise(mutateAsync({ uid }), {
+                    loading: fm({ id: messages.deleting }),
+                    success: () => {
+                        if (isOpenOrAncestor(uid)) clearSelection()
+                        return fm({ id: messages.success }, createMessageValues({ name }))
+                    },
+                    error: (error: AxiosError) => {
+                        if (error?.response?.status === 409) {
+                            return buildConflictMessage(name, error.response.data)
+                        }
+                        return fm({ id: messages.error }, createMessageValues({ name }))
+                    },
+                })
+            }
+
+            const confirm = fm({ id: messages.confirm }, createMessageValues({ name }))
+            withWarningModal(runDelete, confirm)()
+        },
+        [canEdit, withWarningModal, fm, mutateAsync, isOpenOrAncestor, clearSelection, buildConflictMessage],
+    )
+
+    return { canEdit, handleDeleteSystem, isPending }
+}

--- a/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
+++ b/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
@@ -51,7 +51,8 @@ export const useDeleteSystemAction = () => {
             }
             const shown = itemNames.slice(0, MAX_LISTED_ITEMS).join(', ')
             const remaining = itemNames.length - MAX_LISTED_ITEMS
-            const items = remaining > 0 ? `${shown} +${remaining} more` : shown
+            // Locale-neutral overflow suffix — avoids embedding an untranslated word.
+            const items = remaining > 0 ? `${shown} (+${remaining})` : shown
             return fm({ id: messages.conflict }, createMessageValues({ name, items }))
         },
         [fm],

--- a/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
+++ b/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
@@ -11,6 +11,7 @@ import { createMessageValues } from '@/utils/formatters'
 
 import { findHierarchyPath } from '../utils/treePath'
 import { useDeleteSystem } from './mutations/useDeleteSystem'
+import { useSystemDetail } from './queries/useSystemDetail'
 import { useSystemHierarchy } from './queries/useSystemHierarchy'
 import { useHierarchyNavigation } from './useHierarchyNavigation'
 
@@ -31,15 +32,23 @@ export const useDeleteSystemAction = () => {
     const withWarningModal = useWarningModal()
     const { nodes } = useSystemHierarchy()
     const { selectedParentUid, selectedLeafUid, clearSelection } = useHierarchyNavigation()
+    const { system: openLeaf } = useSystemDetail(selectedLeafUid)
     const { mutateAsync, isPending } = useDeleteSystem()
 
     const isOpenOrAncestor = useCallback(
         (uid: string) => {
+            // The open node itself — detail leaf or selected tree parent.
             if (uid === selectedLeafUid || uid === selectedParentUid) return true
-            if (!selectedParentUid) return false
-            return findHierarchyPath(nodes, selectedParentUid).some(node => node.uid === uid)
+            // An ancestor of the open detail leaf (its breadcrumb path). The leaf may
+            // be opened via selectLeaf with a stale `parent`, so check it directly.
+            if (openLeaf?.parentPath?.some(ancestor => ancestor.uid === uid)) return true
+            // An ancestor of the selected tree parent.
+            return (
+                !!selectedParentUid &&
+                findHierarchyPath(nodes, selectedParentUid).some(node => node.uid === uid)
+            )
         },
-        [nodes, selectedParentUid, selectedLeafUid],
+        [nodes, selectedParentUid, selectedLeafUid, openLeaf],
     )
 
     const buildConflictMessage = useCallback(

--- a/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
+++ b/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
@@ -19,6 +19,12 @@ const messages = message.systemHierarchy.delete
 
 const MAX_LISTED_ITEMS = 3
 
+// 409 body contract: the backend returns a BARE array of these at
+// `err.response.data` (echo `c.JSON(409, itemsInfo)` where `itemsInfo` is
+// `[]models.SystemPhysicalItemInfo` — eli-panda-api
+// services/systems-service/systems-handlers.go DeleteSystemRecursive +
+// models/model_system.go SystemPhysicalItemInfo). If that shape ever changes,
+// buildConflictMessage falls back to the generic message instead of listing items.
 type PhysicalItemConflict = {
     systemUid: string
     systemName: string

--- a/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
@@ -68,6 +68,10 @@ export const useHierarchyNavigation = () => {
         updateQuery({ leaf: undefined, tab: undefined })
     }, [updateQuery])
 
+    const clearSelection = useCallback(() => {
+        updateQuery({ parent: undefined, leaf: undefined, tab: undefined })
+    }, [updateQuery])
+
     const setActiveView = useCallback(
         (view: HierarchyView) => {
             updateQuery({ view: view === HIERARCHY_VIEWS.TREE ? undefined : view })
@@ -86,6 +90,7 @@ export const useHierarchyNavigation = () => {
             setActiveTab,
             setActiveView,
             goBackToLeaves,
+            clearSelection,
         }),
         [
             selectedParentUid,
@@ -97,6 +102,7 @@ export const useHierarchyNavigation = () => {
             setActiveTab,
             setActiveView,
             goBackToLeaves,
+            clearSelection,
         ],
     )
 }

--- a/src/modules/systemHierarchy/hooks/useRelationshipGraphContainerState.ts
+++ b/src/modules/systemHierarchy/hooks/useRelationshipGraphContainerState.ts
@@ -6,6 +6,7 @@ import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 import type { GraphLayoutMode, RelationshipGraphEdge, RelationshipGraphNode } from '../types/graph'
 import { isNodeScopeKey, toGraphScopeKey } from '../utils/graphScope'
 import { useRelationshipGraph } from './queries/useRelationshipGraph'
+import { useDeleteSystemAction } from './useDeleteSystemAction'
 import type { GraphFiltersApi } from './useGraphFilters'
 import { useHierarchyNavigation } from './useHierarchyNavigation'
 import { useRelationshipGraphApiQuery } from './useRelationshipGraphApiQuery'
@@ -149,6 +150,7 @@ export const useRelationshipGraphContainerState = ({
     const { copiedSystemUid, canEdit, handleCopySystem, handlePasteSystem } = useSystemCopyPaste({
         onExpandNode: handleExpand,
     })
+    const { handleDeleteSystem } = useDeleteSystemAction()
 
     const { layoutMode, systemLevels, rfNodes, rfEdges, handleLayoutChange } =
         useRelationshipGraphFlow({
@@ -163,6 +165,7 @@ export const useRelationshipGraphContainerState = ({
             onContextMenuChange: handleContextMenuChange,
             onCopySystem: canEdit ? handleCopySystem : undefined,
             onPasteSystem: canEdit ? handlePasteSystem : undefined,
+            onDeleteSystem: canEdit ? handleDeleteSystem : undefined,
             copiedSystemUid,
             onGraphChanged,
         })

--- a/src/modules/systemHierarchy/hooks/useRelationshipGraphFlow.ts
+++ b/src/modules/systemHierarchy/hooks/useRelationshipGraphFlow.ts
@@ -19,6 +19,7 @@ interface UseRelationshipGraphFlowParams {
     onContextMenuChange: (open: boolean) => void
     onCopySystem?: (uid: string) => void
     onPasteSystem?: (uid: string) => void
+    onDeleteSystem?: (uid: string, name: string) => void
     copiedSystemUid?: string | null
     onGraphChanged: () => void
 }
@@ -43,6 +44,7 @@ export const useRelationshipGraphFlow = ({
     onContextMenuChange,
     onCopySystem,
     onPasteSystem,
+    onDeleteSystem,
     copiedSystemUid,
     onGraphChanged,
 }: UseRelationshipGraphFlowParams): UseRelationshipGraphFlowResult => {
@@ -60,6 +62,7 @@ export const useRelationshipGraphFlow = ({
                 onContextMenuChange,
                 onCopySystem,
                 onPasteSystem,
+                onDeleteSystem,
                 copiedSystemUid,
                 hiddenRelationshipsByNodeUid,
             }),
@@ -72,6 +75,7 @@ export const useRelationshipGraphFlow = ({
             onContextMenuChange,
             onCopySystem,
             onPasteSystem,
+            onDeleteSystem,
             copiedSystemUid,
             hiddenRelationshipsByNodeUid,
         ],

--- a/src/modules/systemHierarchy/utils/graphTransformers.ts
+++ b/src/modules/systemHierarchy/utils/graphTransformers.ts
@@ -25,6 +25,7 @@ interface ToReactFlowNodesOptions {
     onContextMenuChange?: (open: boolean) => void
     onCopySystem?: (uid: string) => void
     onPasteSystem?: (uid: string) => void
+    onDeleteSystem?: (uid: string, name: string) => void
     copiedSystemUid?: string | null
     hiddenRelationshipsByNodeUid?: Record<string, number>
 }
@@ -53,6 +54,7 @@ export const toReactFlowNodes = (
             onContextMenuChange: options?.onContextMenuChange,
             onCopySystem: options?.onCopySystem,
             onPasteSystem: options?.onPasteSystem,
+            onDeleteSystem: options?.onDeleteSystem,
             copiedSystemUid: options?.copiedSystemUid,
             hiddenRelationshipsCount: options?.hiddenRelationshipsByNodeUid?.[node.uid] ?? 0,
         },


### PR DESCRIPTION
## What

Adds **right-click → Delete System** to the System Hierarchy module across all three views: the tree (left panel), the leaves table, and the relationship graph. Previously delete only existed in the legacy systems overview.

## How

- **`useDeleteSystem`** (new mutation hook) — `DELETE /system/{uid}` → raw `recalculateSpareParts` POST (in try/catch so a recalc failure can't mask the successful delete) → invalidate `systemsHierarchy` / `systemLeaves` / `systemLeavesCount` / relationship-graph keys.
- **`useDeleteSystemAction`** (new) — `usePermission(SYSTEM_EDIT)` gate, `useWarningModal` confirm (recursive wording), `toast.promise` loading/success/error.
  - On **409** parses the blocking physical-items array and names them in the error toast (generic fallback when empty).
  - Resets navigation (`clearSelection`) when the deleted system is the open node or an ancestor of it.
- **Context menus**: `TreeNode`, `LeavesTable` (single Radix `ContextMenu` wrapper, row captured via `getRowProps.onContextMenu` with capture-phase reset), and `SystemNode` (threaded through `useRelationshipGraphContainerState` → `useRelationshipGraphFlow` → `graphTransformers`).
- i18n `systemHierarchy.delete.*` added.

**Gating convention (matches existing copy/paste per view):** tree + table render the item `disabled` when `!canEdit`; graph omits it.

> Note: backend delete is recursive **and soft** (`deleted=true` on the system + all subsystems) — the confirm wording reflects that.

## Tests

- Extended `TreeNode.test` + `SystemNode.test` for the delete item (show / call with uid+name / disabled / omitted).
- New `useDeleteSystem.spec` (delete → recalc → invalidate; still invalidates on recalc failure) and `useDeleteSystemAction.spec` (confirm gate, 409 item-list, generic fallbacks, reset-on-ancestor).
- 40 tests pass; `tsc --noEmit` clean; ESLint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)