### PR TITLE
fix(fetchClient): fall back to raw text when response body is not JSON

### DIFF
--- a/src/core/http/fetchClient.ts
+++ b/src/core/http/fetchClient.ts
@@ -64,17 +64,14 @@ const parseResponseBody = async <T>(
         })
     }
 
+    if (rawText === '') return undefined as T
+
     try {
         return JSON.parse(rawText) as T
-    } catch (error) {
-        if (isFeatureEnabled('enableHttpLogging')) {
-            //eslint-disable-next-line
-            console.error('[fetchClient] JSON parse error:', {
-                error,
-                rawText: rawText.substring(0, 500),
-            })
-        }
-        throw error
+    } catch {
+        // Endpoint returned a non-JSON body (e.g. a plain string like "DM04-001").
+        // Fall back to the raw text instead of failing the whole request.
+        return rawText as T
     }
 }
 


### PR DESCRIPTION
Plain-string endpoints (e.g. system code generate returning `DM04-001`) threw 'not valid JSON' and surfaced as error toasts on the UI. Now returns raw text on parse failure, empty body as undefined.

Fixes error toast on system code generation in both `systemItem` and `systemHierarchy` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)