### PR TITLE
feat(systemHierarchy): deprecate systemItem, relink system links to hierarchy

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -31,7 +31,7 @@ When you sharpen a term during a design conversation, update both this file and 
 
 - **System** — facility item with hierarchy and relations. See [`systems-family/systems-overview.md`](./technical/systems-family/systems-overview.md).
 - **System hierarchy** — parent/child tree of systems. See [`systems-family/system-hierarchy.md`](./technical/systems-family/system-hierarchy.md).
-- **System item** — leaf attached to a system. See [`systems-family/system-item.md`](./technical/systems-family/system-item.md).
+- **System item** — leaf attached to a system. The `systemItem` module / `/system/<uid>` page is **deprecated** — detail now lives in the hierarchy explorer (`/systems/hierarchy?leaf=<uid>`). See [`systems-family/system-item.md`](./technical/systems-family/system-item.md).
 - **System type** — schema/template that drives a system's editable fields. See [`systems-family/system-type-edit.md`](./technical/systems-family/system-type-edit.md).
 - **Moving flow / Multi-move** — bulk re-parenting of systems. See [`systems-family/moving.md`](./technical/systems-family/moving.md).
 - **Relations / Spares** — non-hierarchical links between systems. See [`systems-family/relations-and-spares.md`](./technical/systems-family/relations-and-spares.md).

--- a/docs/technical/systems-family/README.md
+++ b/docs/technical/systems-family/README.md
@@ -10,7 +10,7 @@ The systems family covers every module that reads or writes the `System` graph �
 |---|---|---|
 | [System Hierarchy](./system-hierarchy.md) | `src/modules/systemHierarchy/` | `/systems/hierarchy` — tree explorer, leaves panel, tabbed detail, relationship graph |
 | [Systems overview](./systems-overview.md) | `src/modules/systems/` | `/systems/overview` — flat table |
-| [System item (detail)](./system-item.md) | `src/modules/systemItem/` | `/system/[uid]` — detail page, sub-systems, spares, relations |
+| [System item (detail)](./system-item.md) — **deprecated** | `src/modules/systemItem/` | `/system/[uid]` — now a thin redirect to `/systems/hierarchy?leaf=<uid>`; module kept for shared utils until extracted |
 | [Relations & spares](./relations-and-spares.md) | `src/modules/systemsRelations/` | `/systems/relations` — engineering relations + spare-for tables |
 | [Moving systems](./moving.md) | `src/modules/systemsMoving/`, `src/modules/systems-multi-move/` | `/systems/moving`, `/systems/multi-move` |
 | [System type editor](./system-type-edit.md) | `src/modules/system-type-edit/` | `/system/type-edit` |
@@ -127,7 +127,7 @@ flowchart LR
     subgraph Pages["src/pages/"]
         P1["/systems/hierarchy"]
         P2["/systems/overview"]
-        P3["/system/[uid]"]
+        P3["/system/[uid] — redirect"]
         P4["/systems/relations"]
         P5["/systems/moving"]
         P6["/systems/multi-move"]
@@ -167,7 +167,7 @@ flowchart LR
     M3 --> R3
 ```
 
-`src/pages/system/alias/[alias].tsx` resolves a human-readable alias to a `uid` and reuses the `systemItem` module; `src/pages/system/item/[itemUid].tsx` opens a system from a physical-item reference.
+`src/pages/system/[uid].tsx` is a thin redirect to `/systems/hierarchy?leaf=<uid>` (see [System Hierarchy → Deep links](./system-hierarchy.md#deep-links--url-contract)). `src/pages/system/alias/[alias].tsx` resolves a human-readable alias to a `uid`, `src/pages/system/item/[itemUid].tsx` resolves a physical-item reference to a `uid` (QR codes) — both still use `systemItem`'s `useSystemDetail` for the lookup, then redirect to the hierarchy deep link.
 
 ## Cross-module flows
 
@@ -186,9 +186,9 @@ sequenceDiagram
     Hier->>GQL: systemsHierarchy + systemLeaves
     GQL-->>Hier: tree + leaves
     U->>Hier: click leaf
-    Hier->>Item: navigate /system/[uid]
-    Item->>GQL: systems(where:{uid}) — SystemDetail fragment
-    Item->>Rel: open Relations tab
+    Hier->>Hier: ?leaf=<uid> — in-page detail view (tabs)
+    Hier->>GQL: systems(where:{uid}) — SystemDetail fragment
+    Hier->>Rel: open Relations tab
     Rel->>GQL: read all 9 engineering edges
     U->>Mov: open /systems/moving
     Mov->>GQL: mutation moveSystem(systemUid, newParentUid, oldParentUid)

--- a/docs/technical/systems-family/system-hierarchy.md
+++ b/docs/technical/systems-family/system-hierarchy.md
@@ -41,6 +41,7 @@ Entry point (`SystemHierarchyExplorer.cont.tsx`):
 const SystemHierarchyExplorerContainer: FC = () => {
     const { selectedLeafUid } = useHierarchyNavigation()
     const { system } = useSystemDetail(selectedLeafUid)
+    useHierarchyDeepLinkResolver()
 
     return (
         <HierarchyLayoutContainer
@@ -213,6 +214,22 @@ Gating convention matches Copy/Paste/Create: tree + table **render the item `dis
 
 `LeavesTable` wraps its content in a Radix `ContextMenu` **only when `onDeleteSystem` is provided** (otherwise the trigger would suppress the native right-click menu with nothing to show). The right-clicked row is captured by a capture-phase reset on the wrapper (clears the target) plus a bubble-phase `onContextMenu` per row (re-sets it) — so right-clicking empty table area leaves the item disabled.
 
+## Deep links & URL contract
+
+The explorer's URL is its source of truth (`useHierarchyNavigation`): `?parent=<uid>` (tree selection), `?leaf=<uid>` (detail view), `?tab=` (defaults to `detail`), `?view=` (`tree`/`graph`), plus table `page`/`filter`. All in-page updates are shallow `router.push`; `updateQuery` accepts `{ replace: true }` for history-neutral updates.
+
+**`getSystemHierarchyDetailPath(uid)`** (`utils/hierarchyLinks.ts`) is the canonical builder for cross-module links into the explorer: `/systems/hierarchy?leaf=<uid>`. It deliberately omits `parent` — **`useHierarchyDeepLinkResolver`** (`hooks/useHierarchyDeepLinkResolver.ts`, mounted once in `SystemHierarchyExplorer.cont.tsx`) fills it in client-side:
+
+- When `leaf` is set and `parent` is missing, it reads `useSystemDetail(leaf).parentPath`, expands the ancestor nodes (`useHierarchyStore.expandNodes`, merge-only), and `router.replace`s `parent=<immediate parent>` (no history entry — back leaves the page in one step).
+- Root systems (empty `parentPath`) resolve to `parent === leaf`, an already-legitimate state (`selectParent` produces it in detail mode).
+- Guards: `system.uid === leaf` (rejects `keepPreviousData` leftovers), a per-leaf ref (replace is async; prevents double-fire), reset once `parent` is present so a later leaf-only link to the same uid re-resolves.
+
+Consumers: global search (`getRedirectPath`), systems overview action buttons, order lines, control-systems code tables, move wizard, the `/system/[uid]` / `/system/alias/[alias]` / `/system/item/[itemUid]` redirect pages (see [System item](./system-item.md) — that module is deprecated), and `SystemHistoryFeed`'s system links.
+
+An unknown/deleted `leaf` renders a **not-found state** in `SystemDetailView.cont.tsx` (message + *Back to hierarchy* via `clearSelection`) instead of an endless skeleton.
+
+History/field-change types (`HISTORY_TYPE`, `FieldChangeEntry`, `HistoryResponse`, …) live in `types/history.ts` — moved here from `systemItem`, which re-exports them for back-compat. The module no longer imports anything from `systemItem`.
+
 ## Copy / Paste
 
 The copy-paste flow lives in `components/copy/`. Buffer: `useHierarchyStore.copiedSystemUid`. The right-click context menu on a tree node or graph node offers **Copy System** (sets the buffer) and **Paste System** (opens the dialog).
@@ -289,6 +306,7 @@ Unit coverage under `__tests__/` is heaviest in:
 - `utils/__tests__/` — tree search, graph layout, filter predicates, change-builder, **parent→child level rules** (`systemLevelRules.spec.ts`), **create-subsystem payload builder** (`buildCreateSubsystemPayload.spec.ts` — locks the `updatedBy[Insert]` audit edge).
 - `hooks/queries/__tests__/` — `primeSystemDetailCache.test.ts` (the contract above), `useSystemLeaves.test.ts`, `useSystemLeavesCount.test.ts`.
 - `hooks/mutations/__tests__/` — `useSystemFieldUpdate.spec.ts`, `useItemFieldUpdate.spec.ts` (locks the System-node `WAS_UPDATED_BY` edge + change entries for item edits), `useDeleteSystem.spec.ts` (immediate invalidate + background recalc → second invalidate; recalc failure keeps only the immediate round).
+- `hooks/__tests__/useHierarchyDeepLinkResolver.spec.tsx` — parent resolution from `parentPath`, root parent==leaf case, stale-uid guard, single-replace idempotency, re-resolution after the URL settles; `utils/__tests__/hierarchyLinks.spec.ts` — deep-link shape + encoding; `components/detail/__tests__/SystemDetailView.spec.tsx` — skeleton / not-found / loaded states.
 - `hooks/__tests__/useDeleteSystemAction.spec.tsx` — permission gate, in-flight re-entry guard, recursive confirm, 409 item-list + `(+N)` overflow + generic fallback, and selection reset for both open-leaf-ancestor and selected-parent-ancestor.
 - `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden); the Delete context item is covered in `tree/TreeNode.test.tsx`, `graph/SystemNode.test.tsx`, and `leaves/LeavesTable.test.tsx` (the last stubs the virtualized `PandaTableV2` to exercise the capture/bubble row capture, disabled-on-empty-area, and no-handler short-circuit).
 
@@ -309,7 +327,6 @@ Unit coverage under `__tests__/` is heaviest in:
 
 - Should the Copy / Paste buffer survive a hard reload? Today it does (persisted) — but the user has no UI indicator that something is buffered.
 - The Graph tab's force-layout iteration count is hardcoded in `utils/graphLayout.ts`. Configurable per-system?
-- The right sidebar (`HierarchyDetailSidebar`) and the `SystemForm.cont` (in `systemItem`) both edit the same `System` shape but with different UI affordances. Are both needed long-term, or is the sidebar the modern surface?
 
 ---
 

--- a/docs/technical/systems-family/system-item.md
+++ b/docs/technical/systems-family/system-item.md
@@ -1,6 +1,8 @@
-# System item (detail)
+# System item (detail) — DEPRECATED
 
-The `/system/[uid]` route — the canonical *detail page* for a single system. Hosts the edit form, sub-systems table, spare-parts widgets, and relationships. Also surfaces as `/system/alias/[alias]` (alias→uid lookup) and `/system/item/[itemUid]` (open from a physical item).
+> ⚠️ **Deprecated (2026-06).** System detail now lives in [System Hierarchy](./system-hierarchy.md) — `/systems/hierarchy?leaf=<uid>` (built via `getSystemHierarchyDetailPath`). `/system/[uid]` is a thin client redirect to that deep link; `/system/alias/[alias]` and `/system/item/[itemUid]` still resolve alias/item → uid (via this module's `useSystemDetail`) and then redirect to the hierarchy. The module is **not deleted**: several utils/hooks are still consumed by active modules. See `src/modules/systemItem/DEPRECATED.md` for the allowed-imports list and removal criteria.
+
+The former `/system/[uid]` route — the *detail page* for a single system. Hosted the edit form, sub-systems table, spare-parts widgets, and relationships. Also surfaced as `/system/alias/[alias]` (alias→uid lookup) and `/system/item/[itemUid]` (open from a physical item, e.g. QR codes).
 
 ## Module location
 
@@ -120,6 +122,7 @@ Cross-module ownership: the *graph* visualisation lives here, but the *editing* 
 
 ## Deprecated / legacy
 
+- **The whole module is deprecated** — see the banner above. `SystemItemContainer` and the page-level detail hooks carry `@deprecated` JSDoc and must not gain new consumers. History/field-change types moved to `systemHierarchy/types/history.ts` (re-exported here for back-compat).
 - `// TODO: split to update and create form` (`components/form/SystemForm.cont.tsx:49`) — single form for both modes is fragile.
 - `// TODO: add itemConditionStatus` (`components/form/SystemForm.fields.ts:98`) — the physical-item edit on this form omits a field the catalogue surface includes.
 - `useSubsystems` duplicates the `systems` module's hook of the same name with a different shape. Consolidate.

--- a/docs/technical/systems-family/systems-overview.md
+++ b/docs/technical/systems-family/systems-overview.md
@@ -59,8 +59,8 @@ flowchart LR
     EP --> GW["PANDA API gateway"]
     GW --> H
     H --> Table["PandaTableV2"]
-    Table -->|row click| Nav["router.push(/system/<uid>)"]
-    Nav --> Item["systemItem module"]
+    Table -->|action button| Nav["getSystemHierarchyDetailPath(uid)\n/systems/hierarchy?leaf=<uid>"]
+    Nav --> Item["systemHierarchy detail view"]
 ```
 
 The list comes from REST (`getEndpoints.systemsList`), **not** GraphQL. Filter, sort, and pagination are query-string round-trippable when `enableQueryURL={true}` — the URL is the source of truth.

--- a/docs/user-guide/systems/README.md
+++ b/docs/user-guide/systems/README.md
@@ -49,7 +49,7 @@ The columns shown by default are: **Name**, **System Code**, **System Type**, **
 - [Exporting systems to CSV](./workflows/exporting-csv.md) — export the currently filtered table to a CSV file.
 - [Opening a system from the overview](./workflows/opening-a-system.md) — row click navigation, expanding subsystems inline, jumping back to the [System Hierarchy](../systemHierarchy/README.md) tree for context.
 
-For working *inside* a system (editing details, managing physical items, relationships, history) — see the [System Hierarchy](../systemHierarchy/README.md) module; both the overview and the tree open the same detail page.
+For working *inside* a system (editing details, managing physical items, relationships, history) — see the [System Hierarchy](../systemHierarchy/README.md) module; both the overview and the tree open the same detail view inside the hierarchy explorer.
 
 ## Coming soon
 

--- a/docs/user-guide/systems/workflows/opening-a-system.md
+++ b/docs/user-guide/systems/workflows/opening-a-system.md
@@ -2,7 +2,7 @@
 
 ## What this is for
 
-Get from the flat list into the full detail of a single system — the same tabbed detail surface the System Hierarchy uses (Detail, Persons, Physical Item, Spare Parts, Relationships, Attachments, History). The overview is good for finding the row; the detail page is where you actually work on a system.
+Get from the flat list into the full detail of a single system — the tabbed detail view of the [System Hierarchy](../../systemHierarchy/README.md) (Detail, Persons, Physical Item, Spare Parts, Relationships, Attachments, History). The overview is good for finding the row; the hierarchy detail view is where you actually work on a system.
 
 ## Who can do this
 
@@ -23,10 +23,10 @@ See [Access & Responsibilities](../README.md#access--responsibilities) for what 
 
 2. **Open the system.** There are two paths:
 
-   - **Click the system *Name*** — opens the system detail page. The URL takes the form `/system/<uid>` and the page is bookmarkable / shareable.
+   - **Click the system *Name*** — opens the system in the System Hierarchy detail view, with the tree expanded to its location. The URL takes the form `/systems/hierarchy?leaf=<uid>` and the page is bookmarkable / shareable. Old `/system/<uid>` bookmarks and QR codes keep working — they redirect to the same view.
    - **Click the avatar / image** on the *Name* column — opens a *Device Info* overlay in place, without leaving the overview. Useful for a quick look at the system without losing your filter and scroll position. Close the overlay to return to the table exactly where you were.
 
-   `[SCREENSHOT PLACEHOLDER: system detail page open after clicking a row — tabbed area showing Detail / Persons / Physical Item / Spare Parts / Relationships / Attachments / History / Graph, breadcrumb at top]`
+   `[SCREENSHOT PLACEHOLDER: System Hierarchy open after clicking a row — tree on the left expanded to the system, detail view showing tabs Detail / Persons / Physical Item / Spare Parts / Relationships / Attachments / History / Graph, breadcrumb at top]`
 
 3. **Expand subsystems inline (alternative path).** If you want to peek at a row's children without leaving the overview, click the chevron at the start of the row. The direct children render inline as nested rows. Their own chevrons can be expanded to drill deeper.
 
@@ -34,14 +34,14 @@ See [Access & Responsibilities](../README.md#access--responsibilities) for what 
 
 5. **Return to the overview** with the browser back button. The URL state — filters, search, sort, page — is restored, so your prior view comes back exactly as you left it.
 
-`[VIDEO PLACEHOLDER: 30s — open Systems → filter to a small set → expand a row inline to peek at children → click a child's name → land on the detail page → back to the overview with state intact]`
+`[VIDEO PLACEHOLDER: 30s — open Systems → filter to a small set → expand a row inline to peek at children → click a child's name → land in the System Hierarchy detail view → back to the overview with state intact]`
 
 ## Tips & gotchas
 
 - **Avatar overlay vs. row navigation.** Click the *image avatar* in the Name column for a non-navigational preview; click the *text name* to open the full detail page. The avatar overlay is the fastest way to scan a system's basics without losing your place in the table.
 - **Subsystem expansion is per-row.** Expanding one row does not affect the others — fold a row's children back up with the same chevron.
-- **The detail page opens in the same tab.** Use middle-click or *Ctrl/Cmd+click* on the system name to open in a new tab when you are walking through many systems.
-- **Detail page is shared with the System Hierarchy.** Edits applied here surface in the tree too; both views read and write the same record. Workflow documentation for editing lives under the [System Hierarchy](../../systemHierarchy/README.md) module.
+- **The detail view opens in the same tab.** Use middle-click or *Ctrl/Cmd+click* on the system name to open in a new tab when you are walking through many systems.
+- **Detail opens inside the System Hierarchy.** You land in the full hierarchy explorer — the tree on the left shows where the system lives, and edits made in the tabs are the same as editing from the tree. Workflow documentation for editing lives under the [System Hierarchy](../../systemHierarchy/README.md) module.
 - **Back is non-destructive.** The browser back button restores your URL-encoded overview state. Bookmark a URL while filters are active to come back to that exact view later.
 
 ## Related

--- a/docs/user-guide/systemsRelations/workflows/inspecting-and-removing.md
+++ b/docs/user-guide/systemsRelations/workflows/inspecting-and-removing.md
@@ -4,7 +4,7 @@
 
 See what relationships a system already has — particularly its spares — without leaving the Systems Relations workbench, and remove a relationship when the link is no longer valid (a spare has been consumed and re-assigned elsewhere, a power source has been re-routed, a control link has been retired).
 
-Bulk *creation* is the workbench's primary purpose; bulk *removal* lives on the per-system detail page (see *Managing relationships* in the [System Hierarchy](../../systemHierarchy/README.md) module). This workflow covers the read-only inspection surfaces in the workbench and points you at the right place for deletions.
+Bulk *creation* is the workbench's primary purpose; bulk *removal* lives in the per-system detail view (see *Managing relationships* in the [System Hierarchy](../../systemHierarchy/README.md) module). This workflow covers the read-only inspection surfaces in the workbench and points you at the right place for deletions.
 
 ## Who can do this
 
@@ -42,13 +42,13 @@ See [Access & Responsibilities](../README.md#access--responsibilities) for what 
 
 For relationship types other than `IS_SPARE_FOR`, and for actual removal of any type, switch to the system's detail page:
 
-1. **Open the system detail page** — either from the workbench (click the row's name) or from the [System Hierarchy](../../systemHierarchy/README.md) module or the [Systems Overview](../../systems/README.md). The URL takes the form `/system/<uid>`.
+1. **Open the system detail view** — either from the workbench (click the row's name) or from the [System Hierarchy](../../systemHierarchy/README.md) module or the [Systems Overview](../../systems/README.md). It opens in the System Hierarchy; the URL takes the form `/systems/hierarchy?leaf=<uid>` (old `/system/<uid>` links redirect there).
 
 2. **Go to the *Relationships* tab.** It lists every relationship for that system in both directions, grouped by type, with a *Delete* affordance on each row (visible only with `systems-edit`).
 
 3. **Click *Delete* on the relationship row** you want to remove. Confirm in the modal.
 
-   `[SCREENSHOT PLACEHOLDER: Relationships tab on a system detail page, showing groups for Is Powered From / Is Spare For / Provides Data To, one row hovered with the Delete affordance visible]`
+   `[SCREENSHOT PLACEHOLDER: Relationships tab in the System Hierarchy detail view, showing groups for Is Powered From / Is Spare For / Provides Data To, one row hovered with the Delete affordance visible]`
 
 4. **Read the toast.** Success → the relationship is gone from both sides. The opposite system's *Relationships* tab updates immediately on next view.
 
@@ -70,7 +70,7 @@ For relationship types other than `IS_SPARE_FOR`, and for actual removal of any 
 
 ## Tips & gotchas
 
-- **Modals are read-only.** The *Spare Parts* and *Spare Part for Systems* modals in the workbench do not offer a delete action. Use them to verify; delete from the system detail page.
+- **Modals are read-only.** The *Spare Parts* and *Spare Part for Systems* modals in the workbench do not offer a delete action. Use them to verify; delete from the system detail view in the System Hierarchy.
 - **Mirror affordances are not symmetric in label.** *Spare Parts* lists the spares **for** this system; *Spare Part for Systems* lists the systems **this** spare covers. Confirm which side of the link you are inspecting before deleting.
 - **One link, one delete.** Each click of *Delete* removes a single directed relationship. The reverse direction does not exist as a separate link — deletion is symmetric.
 - **No undo.** Recreate the relationship via the workbench if you delete the wrong one.

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1464,6 +1464,10 @@ export const messages = {
             moveItem: 'Move Item',
             assignSpares: 'Assign Spares',
             assignItem: 'Assign Item',
+            notFoundTitle: 'System not found',
+            notFoundDescription:
+                'The system may have been deleted or the link is no longer valid.',
+            notFoundBack: 'Back to hierarchy',
         },
         tabs: {
             detail: 'Detail',

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1468,6 +1468,8 @@ export const messages = {
             notFoundDescription:
                 'The system may have been deleted or the link is no longer valid.',
             notFoundBack: 'Back to hierarchy',
+            loadErrorTitle: 'Failed to load system',
+            loadErrorDescription: 'Something went wrong while loading the system detail.',
         },
         tabs: {
             detail: 'Detail',

--- a/src/modules/control-systems/components/create/usePreviewTableColumns.tsx
+++ b/src/modules/control-systems/components/create/usePreviewTableColumns.tsx
@@ -46,7 +46,11 @@ export const usePreviewTableColumns = () => {
                     if (uid) {
                         return (
                             <Button variant="link" className="h-auto p-0" asChild>
-                                <Link href={getSystemHierarchyDetailPath(uid)} target="_blank">
+                                <Link
+                                    href={getSystemHierarchyDetailPath(uid)}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
                                     {codeElement}
                                 </Link>
                             </Button>

--- a/src/modules/control-systems/components/create/usePreviewTableColumns.tsx
+++ b/src/modules/control-systems/components/create/usePreviewTableColumns.tsx
@@ -7,7 +7,7 @@ import { Tooltip } from '@/components/Tooltip'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { message } from '@/i18n/src/messages'
-import { PATH } from '@/types/constants/paths'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 
 import type { SystemCodeResult } from '../../types'
 
@@ -46,7 +46,7 @@ export const usePreviewTableColumns = () => {
                     if (uid) {
                         return (
                             <Button variant="link" className="h-auto p-0" asChild>
-                                <Link href={`${PATH.SYSTEM}/${uid}`} target="_blank">
+                                <Link href={getSystemHierarchyDetailPath(uid)} target="_blank">
                                     {codeElement}
                                 </Link>
                             </Button>

--- a/src/modules/control-systems/components/table/useSystemCodesColumns.tsx
+++ b/src/modules/control-systems/components/table/useSystemCodesColumns.tsx
@@ -54,6 +54,7 @@ const SystemCodeCell = ({ row, queryKey }: SystemCodeCellProps) => {
                             <Link
                                 href={getSystemHierarchyDetailPath(uid)}
                                 target="_blank"
+                                rel="noopener noreferrer"
                                 className="flex items-center cursor-pointer"
                             >
                                 <Edit className="h-4 w-4 mr-2" />

--- a/src/modules/control-systems/components/table/useSystemCodesColumns.tsx
+++ b/src/modules/control-systems/components/table/useSystemCodesColumns.tsx
@@ -14,8 +14,8 @@ import {
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
 import { message } from '@/i18n/src/messages'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { useSystemDelete } from '@/modules/systems/hooks/useSystemDelete'
-import { PATH } from '@/types/constants/paths'
 import type { SystemDetail } from '@/types/responses/systems'
 import type { QueryFetcherKey } from '@/utils/fetcher'
 
@@ -52,7 +52,7 @@ const SystemCodeCell = ({ row, queryKey }: SystemCodeCellProps) => {
                     <DropdownMenuContent align="end">
                         <DropdownMenuItem asChild>
                             <Link
-                                href={`${PATH.SYSTEM}/${uid}`}
+                                href={getSystemHierarchyDetailPath(uid)}
                                 target="_blank"
                                 className="flex items-center cursor-pointer"
                             >

--- a/src/modules/orderItem/components/orderLines/components/OrderLines.columns.tsx
+++ b/src/modules/orderItem/components/orderLines/components/OrderLines.columns.tsx
@@ -206,7 +206,7 @@ const useOrderLinesColumns = () => {
                             value={getValue()?.split(' - ')[0]}
                         />
                     ) : (
-                        <span>{getValue()?.split(' - ')[0]}</span>
+                        <div className="break-words">{getValue()?.split(' - ')[0]}</div>
                     ),
             },
             {
@@ -228,7 +228,7 @@ const useOrderLinesColumns = () => {
                             value={getValue()?.split('-')[0]}
                         />
                     ) : (
-                        <span>{getValue()?.split('-')[0]}</span>
+                        <div className="break-words">{getValue()?.split('-')[0]}</div>
                     ),
             },
             {

--- a/src/modules/orderItem/components/orderLines/components/OrderLines.columns.tsx
+++ b/src/modules/orderItem/components/orderLines/components/OrderLines.columns.tsx
@@ -13,6 +13,7 @@ import { message } from '@/i18n/src/messages'
 import { useOrderLineContext } from '@/modules/orderItem/context'
 import useOrderDetail from '@/modules/orderItem/hooks/useOrderDetail'
 import type { OrderLineFormType } from '@/modules/orderItem/types/form'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { PATH } from '@/types/constants/paths'
 import { createMessageValues } from '@/utils/formatters'
 
@@ -122,8 +123,11 @@ const useOrderLinesColumns = () => {
                         original: { system },
                     },
                 }) =>
-                    system ? (
-                        <NewTabLink href={PATH.SYSTEM + '/' + system?.uid} value={getValue()} />
+                    system?.uid ? (
+                        <NewTabLink
+                            href={getSystemHierarchyDetailPath(system.uid)}
+                            value={getValue()}
+                        />
                     ) : (
                         <div className="break-words">{getValue()}</div>
                     ),
@@ -195,12 +199,15 @@ const useOrderLinesColumns = () => {
                 accessorFn: row => row.parentSystem?.name,
                 size: 240,
                 enablePinning: false,
-                cell: ({ getValue, row: { original } }) => (
-                    <NewTabLink
-                        href={PATH.SYSTEM + '/' + original.parentSystem?.uid}
-                        value={getValue()?.split(' - ')[0]}
-                    />
-                ),
+                cell: ({ getValue, row: { original } }) =>
+                    original.parentSystem?.uid ? (
+                        <NewTabLink
+                            href={getSystemHierarchyDetailPath(original.parentSystem.uid)}
+                            value={getValue()?.split(' - ')[0]}
+                        />
+                    ) : (
+                        <span>{getValue()?.split(' - ')[0]}</span>
+                    ),
             },
             {
                 header: formatMessage({ id: messages.location }),
@@ -214,12 +221,15 @@ const useOrderLinesColumns = () => {
                 accessorFn: row => row.serviceItemName,
                 enablePinning: false,
                 size: 240,
-                cell: ({ getValue, row: { original } }) => (
-                    <NewTabLink
-                        href={PATH.SYSTEM + '/' + original.parentSystem?.uid}
-                        value={getValue()?.split('-')[0]}
-                    />
-                ),
+                cell: ({ getValue, row: { original } }) =>
+                    original.parentSystem?.uid ? (
+                        <NewTabLink
+                            href={getSystemHierarchyDetailPath(original.parentSystem.uid)}
+                            value={getValue()?.split('-')[0]}
+                        />
+                    ) : (
+                        <span>{getValue()?.split('-')[0]}</span>
+                    ),
             },
             {
                 id: 'actions',

--- a/src/modules/shared/form/itemMoving/hooks/useMoveWizardSubmit.ts
+++ b/src/modules/shared/form/itemMoving/hooks/useMoveWizardSubmit.ts
@@ -3,10 +3,10 @@ import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { toast } from 'sonner'
 
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { useSystemDetail } from '@/modules/systemItem/hooks/useSystemDetail'
 import { useSystemsReload } from '@/modules/systemItem/hooks/useSystemsReload'
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
-import { PATH } from '@/types/constants/paths'
 import type { AxiosError } from '@/types/http'
 import type { CodebookType } from '@/types/responses/codebook'
 import { queryMutate } from '@/utils/fetcher'
@@ -40,8 +40,8 @@ export const useMoveWizardSubmit = () => {
         setSelectedSystem(null)
         if (moveType === MOVE_TYPE.ASSIGN) {
             router.reload()
-        } else {
-            router.push(PATH.SYSTEM + '/' + redirectUid)
+        } else if (redirectUid) {
+            router.push(getSystemHierarchyDetailPath(redirectUid))
         }
     }
 

--- a/src/modules/shared/globalSearch/__tests__/getRedirectPath.test.ts
+++ b/src/modules/shared/globalSearch/__tests__/getRedirectPath.test.ts
@@ -6,7 +6,7 @@ import { getRedirectPath } from '../utils/getRedirectPath'
 describe('getRedirectPath', () => {
     it('returns correct path for System node type', () => {
         const result = getRedirectPath('System', 'abc-123')
-        expect(result).toBe(`${PATH.SYSTEM}/abc-123`)
+        expect(result).toBe(`${PATH.SYSTEMS_HIERARCHY}?leaf=abc-123`)
     })
 
     it('returns correct path for Order node type', () => {
@@ -22,7 +22,7 @@ describe('getRedirectPath', () => {
     it('handles special characters in uid', () => {
         const uidWithSpecialChars = 'test-123_ABC@xyz'
         const result = getRedirectPath('System', uidWithSpecialChars)
-        expect(result).toBe(`${PATH.SYSTEM}/${uidWithSpecialChars}`)
+        expect(result).toBe(`${PATH.SYSTEMS_HIERARCHY}?leaf=${encodeURIComponent(uidWithSpecialChars)}`)
     })
 
     it('generates correct paths for all node types', () => {
@@ -30,7 +30,7 @@ describe('getRedirectPath', () => {
         const uid = 'test-uid'
 
         const expectedPaths = {
-            System: `${PATH.SYSTEM}/${uid}`,
+            System: `${PATH.SYSTEMS_HIERARCHY}?leaf=${uid}`,
             Order: `${PATH.ORDER}/${uid}`,
             CatalogueItem: `${PATH.CATALOGUE_ITEM}/${uid}`,
         }

--- a/src/modules/shared/globalSearch/utils/getRedirectPath.ts
+++ b/src/modules/shared/globalSearch/utils/getRedirectPath.ts
@@ -1,3 +1,4 @@
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { PATH } from '@/types/constants/paths'
 
 import type { NodeType } from '../types'
@@ -7,7 +8,7 @@ import type { NodeType } from '../types'
  */
 export const getRedirectPath = (nodeType: NodeType, uid: string): string => {
     const pathMap: Record<NodeType, string> = {
-        System: `${PATH.SYSTEM}/${uid}`,
+        System: getSystemHierarchyDetailPath(uid),
         Order: `${PATH.ORDER}/${uid}`,
         CatalogueItem: `${PATH.CATALOGUE_ITEM}/${uid}`,
     }

--- a/src/modules/shared/system/device-info-overlay/components/sections/SystemInformationSection.comp.tsx
+++ b/src/modules/shared/system/device-info-overlay/components/sections/SystemInformationSection.comp.tsx
@@ -2,8 +2,8 @@ import { type FC } from 'react'
 
 import { Disclosure } from '@/components/ui'
 import { cn } from '@/lib/utils'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { getColorBySystemLevel } from '@/modules/systemItem/utils'
-import { PATH } from '@/types/constants/paths'
 import type { SystemLevel } from '@/types/gql/graphql'
 
 import { SystemDetailParameter } from '../system-detail-parameter.comp'
@@ -36,7 +36,7 @@ export const SystemInformationSection: FC<SystemInformationSectionProps> = ({ sy
                 <SystemDetailParameter
                     title="System Name"
                     value={systemDetail.name}
-                    href={`${PATH.SYSTEM}/${systemDetail.uid}`}
+                    href={getSystemHierarchyDetailPath(systemDetail.uid)}
                 />
                 <SystemDetailParameter title="Location" value={systemDetail.location?.name} />
                 <SystemDetailParameter title="System Type" value={systemDetail.systemType?.name} />

--- a/src/modules/shared/system/device-info-overlay/components/sections/__tests__/SystemInformationSection.spec.tsx
+++ b/src/modules/shared/system/device-info-overlay/components/sections/__tests__/SystemInformationSection.spec.tsx
@@ -64,6 +64,6 @@ describe('SystemInformationSection', () => {
             />,
         )
         const nameRow = screen.getByText('System Name:N')
-        expect(nameRow.getAttribute('data-href')).toBe('/system/sys-1')
+        expect(nameRow.getAttribute('data-href')).toBe('/systems/hierarchy?leaf=sys-1')
     })
 })

--- a/src/modules/systemHierarchy/SystemHierarchyExplorer.cont.tsx
+++ b/src/modules/systemHierarchy/SystemHierarchyExplorer.cont.tsx
@@ -5,11 +5,13 @@ import { LeavesPanelContainer } from './components/leaves/LeavesPanel.cont'
 import { HierarchyDetailSidebar } from './components/sidebar/HierarchyDetailSidebar.comp'
 import { SystemTreeContainer } from './components/tree/SystemTree.cont'
 import { useSystemDetail } from './hooks/queries/useSystemDetail'
+import { useHierarchyDeepLinkResolver } from './hooks/useHierarchyDeepLinkResolver'
 import { useHierarchyNavigation } from './hooks/useHierarchyNavigation'
 
 const SystemHierarchyExplorerContainer: FC = () => {
     const { selectedLeafUid } = useHierarchyNavigation()
     const { system } = useSystemDetail(selectedLeafUid)
+    useHierarchyDeepLinkResolver()
 
     return (
         <HierarchyLayoutContainer

--- a/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
@@ -14,11 +14,11 @@ export const SystemDetailViewContainer: FC = () => {
     const { formatMessage: fm } = useIntl()
     const { selectedLeafUid, goBackToLeaves, selectParent, clearSelection } =
         useHierarchyNavigation()
-    const { system, isLoading } = useSystemDetail(selectedLeafUid)
+    const { system, isLoading, error, refetch } = useSystemDetail(selectedLeafUid)
 
     if (isLoading) {
         return (
-            <div className="flex flex-col h-full">
+            <div className="flex flex-col h-full" data-testid="system-detail-skeleton">
                 <div className="flex items-center gap-3 border-b border-border px-4 py-2">
                     <Skeleton className="h-8 w-24" />
                     <Skeleton className="h-5 flex-1" />
@@ -27,6 +27,26 @@ export const SystemDetailViewContainer: FC = () => {
                     <Skeleton className="h-9 w-64" />
                     <Skeleton className="h-40 w-full" />
                 </div>
+            </div>
+        )
+    }
+
+    // fetch failed (retry: false) — transient errors are not a missing system
+    if (error && !system) {
+        return (
+            <div
+                className="flex flex-col items-center justify-center h-full gap-2 p-4 text-center"
+                data-testid="system-detail-error"
+            >
+                <p className="text-lg font-semibold">
+                    {fm({ id: message.systemHierarchy.detail.loadErrorTitle })}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    {fm({ id: message.systemHierarchy.detail.loadErrorDescription })}
+                </p>
+                <Button variant="outline" className="mt-2" onClick={() => refetch()}>
+                    {fm({ id: message.common.buttons.retry })}
+                </Button>
             </div>
         )
     }

--- a/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
@@ -1,9 +1,9 @@
 import type { FC } from 'react'
 import { useIntl } from 'react-intl'
-import { message } from 'src/i18n/src/messages'
 
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
+import { message } from '@/i18n/src/messages'
 
 import { useSystemDetail } from '../../hooks/queries/useSystemDetail'
 import { useHierarchyNavigation } from '../../hooks/useHierarchyNavigation'

--- a/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
@@ -1,5 +1,8 @@
 import type { FC } from 'react'
+import { useIntl } from 'react-intl'
+import { message } from 'src/i18n/src/messages'
 
+import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 
 import { useSystemDetail } from '../../hooks/queries/useSystemDetail'
@@ -8,10 +11,12 @@ import { SystemDetailHeader } from './SystemDetailHeader.comp'
 import { SystemDetailTabsContainer } from './SystemDetailTabs.cont'
 
 export const SystemDetailViewContainer: FC = () => {
-    const { selectedLeafUid, goBackToLeaves, selectParent } = useHierarchyNavigation()
+    const { formatMessage: fm } = useIntl()
+    const { selectedLeafUid, goBackToLeaves, selectParent, clearSelection } =
+        useHierarchyNavigation()
     const { system, isLoading } = useSystemDetail(selectedLeafUid)
 
-    if (isLoading || !system) {
+    if (isLoading) {
         return (
             <div className="flex flex-col h-full">
                 <div className="flex items-center gap-3 border-b border-border px-4 py-2">
@@ -22,6 +27,26 @@ export const SystemDetailViewContainer: FC = () => {
                     <Skeleton className="h-9 w-64" />
                     <Skeleton className="h-40 w-full" />
                 </div>
+            </div>
+        )
+    }
+
+    // query settled without a match — deleted system or invalid deep link
+    if (!system) {
+        return (
+            <div
+                className="flex flex-col items-center justify-center h-full gap-2 p-4 text-center"
+                data-testid="system-detail-not-found"
+            >
+                <p className="text-lg font-semibold">
+                    {fm({ id: message.systemHierarchy.detail.notFoundTitle })}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                    {fm({ id: message.systemHierarchy.detail.notFoundDescription })}
+                </p>
+                <Button variant="outline" className="mt-2" onClick={clearSelection}>
+                    {fm({ id: message.systemHierarchy.detail.notFoundBack })}
+                </Button>
             </div>
         )
     }

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+
+import { SystemDetailViewContainer } from '../SystemDetailView.cont'
+
+const mockClearSelection = jest.fn()
+
+jest.mock('../../../hooks/useHierarchyNavigation', () => ({
+    useHierarchyNavigation: () => ({
+        selectedLeafUid: 'sys-1',
+        goBackToLeaves: jest.fn(),
+        selectParent: jest.fn(),
+        clearSelection: mockClearSelection,
+    }),
+}))
+
+let mockSystem: { uid: string; name: string } | null = null
+let mockIsLoading = false
+
+jest.mock('../../../hooks/queries/useSystemDetail', () => ({
+    useSystemDetail: () => ({ system: mockSystem, isLoading: mockIsLoading }),
+}))
+
+jest.mock('../SystemDetailHeader.comp', () => ({
+    SystemDetailHeader: () => <div data-testid="detail-header-stub" />,
+}))
+jest.mock('../SystemDetailTabs.cont', () => ({
+    SystemDetailTabsContainer: () => <div data-testid="detail-tabs-stub" />,
+}))
+
+const messages: Record<string, string> = {
+    'systemHierarchy.detail.notFoundTitle': 'System not found',
+    'systemHierarchy.detail.notFoundDescription':
+        'The system may have been deleted or the link is no longer valid.',
+    'systemHierarchy.detail.notFoundBack': 'Back to hierarchy',
+}
+
+const renderView = () =>
+    render(
+        <IntlProvider locale="en" messages={messages}>
+            <SystemDetailViewContainer />
+        </IntlProvider>,
+    )
+
+describe('SystemDetailViewContainer', () => {
+    beforeEach(() => {
+        mockSystem = null
+        mockIsLoading = false
+        mockClearSelection.mockClear()
+    })
+
+    it('renders skeleton while loading', () => {
+        mockIsLoading = true
+        renderView()
+        expect(screen.queryByTestId('system-detail-not-found')).not.toBeInTheDocument()
+        expect(screen.queryByTestId('detail-tabs-stub')).not.toBeInTheDocument()
+    })
+
+    it('renders not-found state when query settles without a match', () => {
+        renderView()
+        expect(screen.getByTestId('system-detail-not-found')).toBeInTheDocument()
+        expect(screen.getByText('System not found')).toBeInTheDocument()
+    })
+
+    it('not-found back button clears the selection', () => {
+        renderView()
+        fireEvent.click(screen.getByText('Back to hierarchy'))
+        expect(mockClearSelection).toHaveBeenCalled()
+    })
+
+    it('renders header and tabs when system is loaded', () => {
+        mockSystem = { uid: 'sys-1', name: 'Test System' }
+        renderView()
+        expect(screen.getByTestId('detail-header-stub')).toBeInTheDocument()
+        expect(screen.getByTestId('detail-tabs-stub')).toBeInTheDocument()
+    })
+})

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
@@ -17,9 +17,16 @@ jest.mock('../../../hooks/useHierarchyNavigation', () => ({
 
 let mockSystem: { uid: string; name: string } | null = null
 let mockIsLoading = false
+let mockError: Error | null = null
+const mockRefetch = jest.fn()
 
 jest.mock('../../../hooks/queries/useSystemDetail', () => ({
-    useSystemDetail: () => ({ system: mockSystem, isLoading: mockIsLoading }),
+    useSystemDetail: () => ({
+        system: mockSystem,
+        isLoading: mockIsLoading,
+        error: mockError,
+        refetch: mockRefetch,
+    }),
 }))
 
 jest.mock('../SystemDetailHeader.comp', () => ({
@@ -34,6 +41,10 @@ const messages: Record<string, string> = {
     'systemHierarchy.detail.notFoundDescription':
         'The system may have been deleted or the link is no longer valid.',
     'systemHierarchy.detail.notFoundBack': 'Back to hierarchy',
+    'systemHierarchy.detail.loadErrorTitle': 'Failed to load system',
+    'systemHierarchy.detail.loadErrorDescription':
+        'Something went wrong while loading the system detail.',
+    'common.buttons.retry': 'Retry',
 }
 
 const renderView = () =>
@@ -47,14 +58,26 @@ describe('SystemDetailViewContainer', () => {
     beforeEach(() => {
         mockSystem = null
         mockIsLoading = false
+        mockError = null
         mockClearSelection.mockClear()
+        mockRefetch.mockClear()
     })
 
     it('renders skeleton while loading', () => {
         mockIsLoading = true
         renderView()
+        expect(screen.getByTestId('system-detail-skeleton')).toBeInTheDocument()
         expect(screen.queryByTestId('system-detail-not-found')).not.toBeInTheDocument()
         expect(screen.queryByTestId('detail-tabs-stub')).not.toBeInTheDocument()
+    })
+
+    it('renders error state with retry when the fetch failed', () => {
+        mockError = new Error('network down')
+        renderView()
+        expect(screen.getByTestId('system-detail-error')).toBeInTheDocument()
+        expect(screen.queryByTestId('system-detail-not-found')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText('Retry'))
+        expect(mockRefetch).toHaveBeenCalled()
     })
 
     it('renders not-found state when query settles without a match', () => {

--- a/src/modules/systemHierarchy/components/history/SystemHistoryFeed.comp.tsx
+++ b/src/modules/systemHierarchy/components/history/SystemHistoryFeed.comp.tsx
@@ -234,6 +234,7 @@ const SystemLink: FC<SystemLinkProps> = ({ detail }) => {
         <Link
             href={getSystemHierarchyDetailPath(detail.systemUid)}
             target="_blank"
+            rel="noopener noreferrer"
             className="font-medium text-primary underline-offset-2 hover:underline"
         >
             {detail.systemName}

--- a/src/modules/systemHierarchy/components/history/SystemHistoryFeed.comp.tsx
+++ b/src/modules/systemHierarchy/components/history/SystemHistoryFeed.comp.tsx
@@ -6,16 +6,12 @@ import { useIntl } from 'react-intl'
 import { Badge } from '@/components/ui/badge'
 import { message } from '@/i18n/src/messages'
 import { cn } from '@/lib/utils'
-import { HISTORY_TYPE } from '@/modules/systemItem/types/constants'
-import type {
-    ChangeValue,
-    FieldChangeEntry,
-    HistoryResponse,
-} from '@/modules/systemItem/types/responses'
-import { PATH } from '@/types/constants/paths'
 import { formatDate } from '@/utils/formatters'
 
+import type { ChangeValue, FieldChangeEntry, HistoryResponse } from '../../types/history'
+import { HISTORY_TYPE } from '../../types/history'
 import { getFieldLabelKey } from '../../utils/fieldChangeBuilder'
+import { getSystemHierarchyDetailPath } from '../../utils/hierarchyLinks'
 import { getHistoryTypeVisual } from './historyFeed.visuals'
 
 interface SystemHistoryFeedProps {
@@ -236,7 +232,7 @@ interface SystemLinkProps {
 const SystemLink: FC<SystemLinkProps> = ({ detail }) => {
     return (
         <Link
-            href={`${PATH.SYSTEM}/${detail.systemUid}`}
+            href={getSystemHierarchyDetailPath(detail.systemUid)}
             target="_blank"
             className="font-medium text-primary underline-offset-2 hover:underline"
         >

--- a/src/modules/systemHierarchy/components/history/__tests__/historyFeed.visuals.spec.ts
+++ b/src/modules/systemHierarchy/components/history/__tests__/historyFeed.visuals.spec.ts
@@ -1,5 +1,4 @@
-import { HISTORY_TYPE } from '@/modules/systemItem/types/constants'
-
+import { HISTORY_TYPE } from '../../../types/history'
 import { getHistoryTypeVisual } from '../historyFeed.visuals'
 
 describe('getHistoryTypeVisual', () => {

--- a/src/modules/systemHierarchy/components/history/historyFeed.visuals.ts
+++ b/src/modules/systemHierarchy/components/history/historyFeed.visuals.ts
@@ -1,6 +1,6 @@
 import { ArrowRightLeft, Box, CircleDot, type LucideIcon, Repeat } from 'lucide-react'
 
-import { HISTORY_TYPE } from '@/modules/systemItem/types/constants'
+import { HISTORY_TYPE } from '../../types/history'
 
 interface HistoryTypeVisual {
     badgeClassName: string

--- a/src/modules/systemHierarchy/components/tabs/HistoryTab.cont.tsx
+++ b/src/modules/systemHierarchy/components/tabs/HistoryTab.cont.tsx
@@ -15,10 +15,10 @@ import {
     SelectValue,
 } from '@/components/ui/select'
 import { message } from '@/i18n/src/messages'
-import { HISTORY_TYPE } from '@/modules/systemItem/types/constants'
 
 import { useSystemHistory } from '../../hooks/queries/useSystemHistory'
 import type { SystemLeaf } from '../../types'
+import { HISTORY_TYPE } from '../../types/history'
 import { SystemHistoryFeed } from '../history/SystemHistoryFeed.comp'
 
 interface HistoryTabProps {

--- a/src/modules/systemHierarchy/hooks/__tests__/useHierarchyDeepLinkResolver.spec.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useHierarchyDeepLinkResolver.spec.tsx
@@ -1,0 +1,113 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import React from 'react'
+
+import { useHierarchyStore } from '../../store/useHierarchyStore'
+import { useHierarchyDeepLinkResolver } from '../useHierarchyDeepLinkResolver'
+
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: new QueryClient() }, children)
+
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+let mockQuery: Record<string, string | undefined> = {}
+let mockIsReady = true
+
+jest.mock('next/router', () => ({
+    useRouter: () => ({
+        query: mockQuery,
+        pathname: '/systems/hierarchy',
+        isReady: mockIsReady,
+        push: mockPush,
+        replace: mockReplace,
+    }),
+}))
+
+type MockSystem = { uid: string; parentPath: { uid: string; name: string }[] | null } | null
+let mockSystem: MockSystem = null
+
+jest.mock('../queries/useSystemDetail', () => ({
+    useSystemDetail: () => ({ system: mockSystem }),
+    primeSystemDetailCache: jest.fn(),
+}))
+
+const lastReplacedQuery = () => mockReplace.mock.calls.at(-1)?.[0]?.query
+
+describe('useHierarchyDeepLinkResolver', () => {
+    beforeEach(() => {
+        mockPush.mockClear()
+        mockReplace.mockClear()
+        mockQuery = {}
+        mockIsReady = true
+        mockSystem = null
+        useHierarchyStore.setState({ expandedNodes: [] })
+    })
+
+    it('resolves parent from parentPath and expands ancestors', () => {
+        mockQuery = { leaf: 'X' }
+        mockSystem = {
+            uid: 'X',
+            parentPath: [
+                { uid: 'root', name: 'Root' },
+                { uid: 'mid', name: 'Mid' },
+            ],
+        }
+        renderHook(() => useHierarchyDeepLinkResolver(), { wrapper })
+        expect(lastReplacedQuery()).toEqual({ leaf: 'X', parent: 'mid' })
+        expect(useHierarchyStore.getState().expandedNodes).toEqual(['root', 'mid'])
+    })
+
+    it('root system (empty parentPath) resolves parent to the leaf itself', () => {
+        mockQuery = { leaf: 'R' }
+        mockSystem = { uid: 'R', parentPath: [] }
+        renderHook(() => useHierarchyDeepLinkResolver(), { wrapper })
+        expect(lastReplacedQuery()).toEqual({ leaf: 'R', parent: 'R' })
+        expect(useHierarchyStore.getState().expandedNodes).toEqual(['R'])
+    })
+
+    it('does nothing when parent is already present', () => {
+        mockQuery = { leaf: 'X', parent: 'P' }
+        mockSystem = { uid: 'X', parentPath: [{ uid: 'P', name: 'P' }] }
+        renderHook(() => useHierarchyDeepLinkResolver(), { wrapper })
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('does nothing while router is not ready', () => {
+        mockIsReady = false
+        mockQuery = { leaf: 'X' }
+        mockSystem = { uid: 'X', parentPath: [{ uid: 'P', name: 'P' }] }
+        renderHook(() => useHierarchyDeepLinkResolver(), { wrapper })
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('ignores stale keepPreviousData detail for a different uid', () => {
+        mockQuery = { leaf: 'X' }
+        mockSystem = { uid: 'previous-leaf', parentPath: [{ uid: 'P', name: 'P' }] }
+        renderHook(() => useHierarchyDeepLinkResolver(), { wrapper })
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('does not replace twice for the same leaf before the URL updates', () => {
+        mockQuery = { leaf: 'X' }
+        mockSystem = { uid: 'X', parentPath: [{ uid: 'P', name: 'P' }] }
+        const { rerender } = renderHook(() => useHierarchyDeepLinkResolver(), { wrapper })
+        // new object identity (e.g. background refetch) while URL not yet updated
+        mockSystem = { uid: 'X', parentPath: [{ uid: 'P', name: 'P' }] }
+        rerender()
+        expect(mockReplace).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-resolves a later leaf-only deep link to the same leaf', () => {
+        mockQuery = { leaf: 'X' }
+        mockSystem = { uid: 'X', parentPath: [{ uid: 'P', name: 'P' }] }
+        const { rerender } = renderHook(() => useHierarchyDeepLinkResolver(), { wrapper })
+        expect(mockReplace).toHaveBeenCalledTimes(1)
+
+        // resolution landed in the URL, then user navigates to a leaf-only link again
+        mockQuery = { leaf: 'X', parent: 'P' }
+        rerender()
+        mockQuery = { leaf: 'X' }
+        rerender()
+        expect(mockReplace).toHaveBeenCalledTimes(2)
+    })
+})

--- a/src/modules/systemHierarchy/hooks/mutations/useItemFieldUpdate.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useItemFieldUpdate.ts
@@ -5,14 +5,10 @@ import { toast } from 'sonner'
 
 import { useGraphQLMutation } from '@/hooks/fetch/useGraphQL'
 import { message } from '@/i18n/src/messages'
-import type {
-    ChangeValue,
-    CodebookSnapshot,
-    FieldChangeEntry,
-} from '@/modules/systemItem/types/responses'
 import { gql } from '@/types/gql'
 
 import { SYSTEM_DETAIL_QUERY_KEY } from '../../types/constants'
+import type { ChangeValue, CodebookSnapshot, FieldChangeEntry } from '../../types/history'
 import { buildChangeEntry, buildCodebookSnapshot } from '../../utils/fieldChangeBuilder'
 
 // Lightweight mutation for single item field updates. The WAS_UPDATED_BY edge is recorded

--- a/src/modules/systemHierarchy/hooks/mutations/useSystemFieldUpdate.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useSystemFieldUpdate.ts
@@ -5,14 +5,10 @@ import { toast } from 'sonner'
 
 import { useGraphQLMutation } from '@/hooks/fetch/useGraphQL'
 import { message } from '@/i18n/src/messages'
-import type {
-    ChangeValue,
-    CodebookSnapshot,
-    FieldChangeEntry,
-} from '@/modules/systemItem/types/responses'
 import { gql } from '@/types/gql'
 
 import { SYSTEM_DETAIL_QUERY_KEY } from '../../types/constants'
+import type { ChangeValue, CodebookSnapshot, FieldChangeEntry } from '../../types/history'
 import { buildChangeEntry, buildCodebookSnapshot } from '../../utils/fieldChangeBuilder'
 
 // Lightweight mutation for single field updates

--- a/src/modules/systemHierarchy/hooks/queries/useSystemHistory.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemHistory.ts
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 
-import type { FieldChangeEntry, HistoryResponse } from '@/modules/systemItem/types/responses'
 import { queryFetcher } from '@/utils/fetcher'
+
+import type { FieldChangeEntry, HistoryResponse } from '../../types/history'
 
 // Tolerant parser: BE may send `changes` as structured array or as JSON string.
 const normalizeChanges = (raw: unknown): FieldChangeEntry[] | undefined => {

--- a/src/modules/systemHierarchy/hooks/useHierarchyDeepLinkResolver.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyDeepLinkResolver.ts
@@ -1,0 +1,50 @@
+import { useRouter } from 'next/router'
+import { useEffect, useRef } from 'react'
+
+import { useHierarchyStore } from '../store/useHierarchyStore'
+import { useSystemDetail } from './queries/useSystemDetail'
+import { useHierarchyNavigation } from './useHierarchyNavigation'
+
+/**
+ * Resolves the missing parent context for deep links that carry only
+ * `?leaf=<uid>` (see getSystemHierarchyDetailPath): derives the immediate
+ * parent from the system's parentPath, expands the ancestor tree nodes and
+ * replaces the URL (no extra history entry) so the leaves panel and
+ * breadcrumb get full context. Root systems (empty parentPath) resolve to
+ * parent === leaf, which is already a legitimate state (see selectParent).
+ */
+export const useHierarchyDeepLinkResolver = (): void => {
+    const router = useRouter()
+    const { selectedLeafUid, selectedParentUid, resolveParentForLeaf } = useHierarchyNavigation()
+    const needsResolution = !!selectedLeafUid && !selectedParentUid
+    const { system } = useSystemDetail(needsResolution ? selectedLeafUid : null)
+    const expandNodes = useHierarchyStore(state => state.expandNodes)
+    // router.replace is async — the ref keeps resolution idempotent per leaf
+    // until the parent param lands in the URL
+    const resolvedLeafRef = useRef<string | null>(null)
+
+    useEffect(() => {
+        if (!router.isReady) return
+        if (!needsResolution) {
+            resolvedLeafRef.current = null
+            return
+        }
+        // keepPreviousData can momentarily serve the previous leaf's detail
+        if (!system || system.uid !== selectedLeafUid) return
+        if (resolvedLeafRef.current === selectedLeafUid) return
+        resolvedLeafRef.current = selectedLeafUid
+
+        const ancestorUids = (system.parentPath ?? []).map(p => p.uid).filter(Boolean)
+        expandNodes(ancestorUids.length > 0 ? ancestorUids : [system.uid])
+        resolveParentForLeaf(
+            ancestorUids.length > 0 ? ancestorUids[ancestorUids.length - 1] : system.uid,
+        )
+    }, [
+        router.isReady,
+        needsResolution,
+        selectedLeafUid,
+        system,
+        expandNodes,
+        resolveParentForLeaf,
+    ])
+}

--- a/src/modules/systemHierarchy/hooks/useHierarchyDeepLinkResolver.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyDeepLinkResolver.ts
@@ -23,6 +23,13 @@ export const useHierarchyDeepLinkResolver = (): void => {
     // until the parent param lands in the URL
     const resolvedLeafRef = useRef<string | null>(null)
 
+    // useSystemDetail rebuilds `system` every render — depend on stable scalars
+    const systemUid = system?.uid ?? null
+    const ancestorKey = (system?.parentPath ?? [])
+        .map(p => p.uid)
+        .filter(Boolean)
+        .join(',')
+
     useEffect(() => {
         if (!router.isReady) return
         if (!needsResolution) {
@@ -30,20 +37,21 @@ export const useHierarchyDeepLinkResolver = (): void => {
             return
         }
         // keepPreviousData can momentarily serve the previous leaf's detail
-        if (!system || system.uid !== selectedLeafUid) return
+        if (!systemUid || systemUid !== selectedLeafUid) return
         if (resolvedLeafRef.current === selectedLeafUid) return
         resolvedLeafRef.current = selectedLeafUid
 
-        const ancestorUids = (system.parentPath ?? []).map(p => p.uid).filter(Boolean)
-        expandNodes(ancestorUids.length > 0 ? ancestorUids : [system.uid])
+        const ancestorUids = ancestorKey ? ancestorKey.split(',') : []
+        expandNodes(ancestorUids.length > 0 ? ancestorUids : [systemUid])
         resolveParentForLeaf(
-            ancestorUids.length > 0 ? ancestorUids[ancestorUids.length - 1] : system.uid,
+            ancestorUids.length > 0 ? ancestorUids[ancestorUids.length - 1] : systemUid,
         )
     }, [
         router.isReady,
         needsResolution,
         selectedLeafUid,
-        system,
+        systemUid,
+        ancestorKey,
         expandNodes,
         resolveParentForLeaf,
     ])

--- a/src/modules/systemHierarchy/hooks/useHierarchyDeepLinkResolver.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyDeepLinkResolver.ts
@@ -25,10 +25,9 @@ export const useHierarchyDeepLinkResolver = (): void => {
 
     // useSystemDetail rebuilds `system` every render — depend on stable scalars
     const systemUid = system?.uid ?? null
-    const ancestorKey = (system?.parentPath ?? [])
-        .map(p => p.uid)
-        .filter(Boolean)
-        .join(',')
+    const ancestorKey = JSON.stringify(
+        (system?.parentPath ?? []).map(p => p.uid).filter(Boolean),
+    )
 
     useEffect(() => {
         if (!router.isReady) return
@@ -41,7 +40,7 @@ export const useHierarchyDeepLinkResolver = (): void => {
         if (resolvedLeafRef.current === selectedLeafUid) return
         resolvedLeafRef.current = selectedLeafUid
 
-        const ancestorUids = ancestorKey ? ancestorKey.split(',') : []
+        const ancestorUids = JSON.parse(ancestorKey) as string[]
         expandNodes(ancestorUids.length > 0 ? ancestorUids : [systemUid])
         resolveParentForLeaf(
             ancestorUids.length > 0 ? ancestorUids[ancestorUids.length - 1] : systemUid,

--- a/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
@@ -17,7 +17,7 @@ export const useHierarchyNavigation = () => {
     const activeView = ((router.query.view as string) ?? HIERARCHY_VIEWS.TREE) as HierarchyView
 
     const updateQuery = useCallback(
-        (updates: Record<string, string | undefined>) => {
+        (updates: Record<string, string | undefined>, options?: { replace?: boolean }) => {
             const current = { ...router.query }
             for (const [key, value] of Object.entries(updates)) {
                 if (value === undefined) {
@@ -26,7 +26,8 @@ export const useHierarchyNavigation = () => {
                     current[key] = value
                 }
             }
-            router.push({ pathname: router.pathname, query: current }, undefined, {
+            const navigate = options?.replace ? router.replace : router.push
+            navigate({ pathname: router.pathname, query: current }, undefined, {
                 shallow: true,
             })
         },
@@ -55,6 +56,14 @@ export const useHierarchyNavigation = () => {
             updateQuery(inDetail ? { leaf: uid } : { leaf: uid, tab: HIERARCHY_TABS.DETAIL })
         },
         [queryClient, router, updateQuery],
+    )
+
+    // replace (not push) so deep-link resolution does not add a history entry
+    const resolveParentForLeaf = useCallback(
+        (parentUid: string) => {
+            updateQuery({ parent: parentUid }, { replace: true })
+        },
+        [updateQuery],
     )
 
     const setActiveTab = useCallback(
@@ -87,6 +96,7 @@ export const useHierarchyNavigation = () => {
             activeView,
             selectParent,
             selectLeaf,
+            resolveParentForLeaf,
             setActiveTab,
             setActiveView,
             goBackToLeaves,
@@ -99,6 +109,7 @@ export const useHierarchyNavigation = () => {
             activeView,
             selectParent,
             selectLeaf,
+            resolveParentForLeaf,
             setActiveTab,
             setActiveView,
             goBackToLeaves,

--- a/src/modules/systemHierarchy/types/history.ts
+++ b/src/modules/systemHierarchy/types/history.ts
@@ -1,0 +1,37 @@
+export enum HISTORY_TYPE {
+    GENERAL = 'GENERAL',
+    ITEM = 'ITEM',
+    MOVE = 'MOVE',
+    ITEM_MOVE = 'ITEM_MOVE',
+}
+
+export type FieldChangeType = 'string' | 'number' | 'boolean' | 'date' | 'codebook'
+
+export type CodebookSnapshot = {
+    uid: string
+    name: string
+    code?: string
+}
+
+export type ChangeValue = string | number | boolean | CodebookSnapshot
+
+export type FieldChangeEntry = {
+    field: string
+    type: FieldChangeType
+    oldValue: ChangeValue | null
+    newValue: ChangeValue | null
+}
+
+export type HistoryResponse = {
+    uid: string
+    changedAt: string
+    changedBy: string
+    historyType: HISTORY_TYPE
+    action: string
+    detail: {
+        systemUid: string
+        systemName: string
+        direction: 'IN' | 'OUT'
+    }
+    changes?: FieldChangeEntry[]
+}

--- a/src/modules/systemHierarchy/utils/__tests__/hierarchyLinks.spec.ts
+++ b/src/modules/systemHierarchy/utils/__tests__/hierarchyLinks.spec.ts
@@ -1,0 +1,24 @@
+import { PATH } from '@/types/constants/paths'
+
+import { getSystemHierarchyDetailPath } from '../hierarchyLinks'
+
+describe('getSystemHierarchyDetailPath', () => {
+    it('builds a hierarchy detail deep link with the leaf param', () => {
+        expect(getSystemHierarchyDetailPath('abc-123')).toBe(
+            `${PATH.SYSTEMS_HIERARCHY}?leaf=abc-123`,
+        )
+    })
+
+    it('encodes special characters in the uid', () => {
+        const uid = 'test-123_ABC@xyz'
+        expect(getSystemHierarchyDetailPath(uid)).toBe(
+            `${PATH.SYSTEMS_HIERARCHY}?leaf=${encodeURIComponent(uid)}`,
+        )
+    })
+
+    it('does not include tab or parent params', () => {
+        const url = getSystemHierarchyDetailPath('u-1')
+        expect(url).not.toContain('tab=')
+        expect(url).not.toContain('parent=')
+    })
+})

--- a/src/modules/systemHierarchy/utils/fieldChangeBuilder.ts
+++ b/src/modules/systemHierarchy/utils/fieldChangeBuilder.ts
@@ -1,10 +1,11 @@
 import { message } from '@/i18n/src/messages'
+
 import type {
     ChangeValue,
     CodebookSnapshot,
     FieldChangeEntry,
     FieldChangeType,
-} from '@/modules/systemItem/types/responses'
+} from '../types/history'
 
 // GraphQL field names that represent codebook relationships
 const CODEBOOK_FIELDS: ReadonlySet<string> = new Set([

--- a/src/modules/systemHierarchy/utils/hierarchyLinks.ts
+++ b/src/modules/systemHierarchy/utils/hierarchyLinks.ts
@@ -1,0 +1,9 @@
+import { PATH } from '@/types/constants/paths'
+
+/**
+ * Builds a deep link to the system hierarchy explorer with the given system
+ * opened in detail view. The `tab` param is omitted (defaults to detail) and
+ * `parent` is resolved client-side by useHierarchyDeepLinkResolver.
+ */
+export const getSystemHierarchyDetailPath = (uid: string): string =>
+    `${PATH.SYSTEMS_HIERARCHY}?leaf=${encodeURIComponent(uid)}`

--- a/src/modules/systemItem/DEPRECATED.md
+++ b/src/modules/systemItem/DEPRECATED.md
@@ -44,6 +44,10 @@ before deleting this module:
 - `pages/system/alias/[alias].tsx` — alias → uid resolution, then redirects to hierarchy
 - `pages/system/item/[itemUid].tsx` — physical item → system resolution (QR codes), then redirects to hierarchy
 
+Known quirk: `hooks/useSystemDetail` does `router.push(PATH.NOT_FOUND)` itself on an
+empty result, which races the alias/item pages' own not-found UI. Pre-existing;
+fix when the alias/item resolution gets its own query.
+
 ## Removal criteria
 
 1. Extract the "allowed until extracted" utils/hooks/types to

--- a/src/modules/systemItem/DEPRECATED.md
+++ b/src/modules/systemItem/DEPRECATED.md
@@ -1,0 +1,52 @@
+# systemItem — DEPRECATED (2026-06)
+
+Replaced by `src/modules/systemHierarchy`. System detail now lives in the
+hierarchy explorer: `/systems/hierarchy?leaf=<uid>` (build links with
+`getSystemHierarchyDetailPath` from `@/modules/systemHierarchy/utils/hierarchyLinks`).
+
+## What changed
+
+- `/system/<uid>` is a thin redirect to the hierarchy detail view — old
+  bookmarks, QR codes and shared links keep working.
+- All external link sites build hierarchy deep links; the missing `parent`
+  context is resolved client-side by `useHierarchyDeepLinkResolver`.
+- History/field-change types (`HISTORY_TYPE`, `FieldChangeEntry`,
+  `HistoryResponse`, …) moved to `systemHierarchy/types/history.ts`;
+  `types/constants.ts` and `types/responses.ts` here re-export them for
+  back-compat.
+
+## Must NOT gain new consumers
+
+- `SystemItemContainer` (page-level detail UI)
+- `hooks/useSystemDetail`, `hooks/useSuspenseSystemDetail`, `hooks/useSystemCreate`
+- `store/useSystemItemStore`
+
+Links inside this module still target `/system/<uid>` on purpose — they
+resolve via the redirect page and the module is no longer reachable as a page.
+
+## Allowed until extracted
+
+These are still legitimately imported by active modules (systemHierarchy,
+shared/system, systems, components/system); move them to a shared location
+before deleting this module:
+
+- `utils` — `getColorBySystemLevel`, `getFontBySystemLevel`,
+  `getBadgeVariantBySystemLevel`, `formatParentPath`
+- `utils/hookHelpers` — `showErrorToast`, `showSuccessToast`, `validateSystemForm`
+- `hooks/useRecalculate`, `hooks/useSystemCodeClear`, `hooks/useSystemCodeGenerate`
+- `hooks/utils` — `makeSystemInputBody`
+- `components/form/SystemForm.fields`, `components/subsystems/types`
+- `types/form` — `SystemDetailFormType`
+
+## Remaining page consumers
+
+- `pages/system/index.tsx` — legacy create form (nothing links to it)
+- `pages/system/alias/[alias].tsx` — alias → uid resolution, then redirects to hierarchy
+- `pages/system/item/[itemUid].tsx` — physical item → system resolution (QR codes), then redirects to hierarchy
+
+## Removal criteria
+
+1. Extract the "allowed until extracted" utils/hooks/types to
+   `src/modules/shared/system/` or `src/components/system/`.
+2. Give alias/itemUid resolution its own query (shared or systemHierarchy).
+3. Delete the module and the `pages/system/index.tsx` create form.

--- a/src/modules/systemItem/SystemItem.cont.tsx
+++ b/src/modules/systemItem/SystemItem.cont.tsx
@@ -20,6 +20,11 @@ interface Props {
     uid?: string
 }
 
+/**
+ * @deprecated The systemItem module is deprecated — system detail lives in
+ * src/modules/systemHierarchy (/systems/hierarchy?leaf=<uid>). See
+ * src/modules/systemItem/DEPRECATED.md.
+ */
 export const SystemItemContainer = ({ uid }: Props) => {
     const hasEditRole = usePermission([ROLE.SYSTEM_EDIT])
     const [errorState, setErrorState] = useState<Error | null>(null)

--- a/src/modules/systemItem/hooks/useSuspenseSystemDetail.ts
+++ b/src/modules/systemItem/hooks/useSuspenseSystemDetail.ts
@@ -22,6 +22,11 @@ type SearchPatterns = {
     uid?: string
 }
 
+/**
+ * @deprecated The systemItem module is deprecated — system detail lives in
+ * src/modules/systemHierarchy (/systems/hierarchy?leaf=<uid>). See
+ * src/modules/systemItem/DEPRECATED.md.
+ */
 export const useSuspenseSystemDetail = ({ code, uid }: SearchPatterns) => {
     const { data, error, isLoading, refetch, status } = useSuspenseGraphQL(systemDetailQuery, {
         variables: {

--- a/src/modules/systemItem/hooks/useSystemCreate.ts
+++ b/src/modules/systemItem/hooks/useSystemCreate.ts
@@ -28,6 +28,11 @@ const createSystemMutation = gql(`
   }
 `)
 
+/**
+ * @deprecated The systemItem module is deprecated — system detail lives in
+ * src/modules/systemHierarchy (/systems/hierarchy?leaf=<uid>). See
+ * src/modules/systemItem/DEPRECATED.md.
+ */
 export const useSystemCreate = (imageRef?: MutableRefObject<ImageGalleryRef | undefined>) => {
     const intl = useIntl()
     const router = useRouter()

--- a/src/modules/systemItem/hooks/useSystemDetail.ts
+++ b/src/modules/systemItem/hooks/useSystemDetail.ts
@@ -25,6 +25,11 @@ type SearchPatterns = {
     itemUid?: string
 }
 
+/**
+ * @deprecated The systemItem module is deprecated — system detail lives in
+ * src/modules/systemHierarchy (/systems/hierarchy?leaf=<uid>). See
+ * src/modules/systemItem/DEPRECATED.md.
+ */
 export const useSystemDetail = (
     searchPatterns?: SearchPatterns,
     onSuccess?: (data: any) => void,

--- a/src/modules/systemItem/store/useSystemItemStore.tsx
+++ b/src/modules/systemItem/store/useSystemItemStore.tsx
@@ -8,6 +8,11 @@ type SystemStore = {
     clear: () => void
 }
 
+/**
+ * @deprecated The systemItem module is deprecated — system detail lives in
+ * src/modules/systemHierarchy (/systems/hierarchy?leaf=<uid>). See
+ * src/modules/systemItem/DEPRECATED.md.
+ */
 export const useSystemItemStore = create<SystemStore>(set => ({
     selectedPhysicalSystem: undefined,
 

--- a/src/modules/systemItem/types/constants.ts
+++ b/src/modules/systemItem/types/constants.ts
@@ -1,6 +1,3 @@
-export enum HISTORY_TYPE {
-    GENERAL = 'GENERAL',
-    ITEM = 'ITEM',
-    MOVE = 'MOVE',
-    ITEM_MOVE = 'ITEM_MOVE',
-}
+// HISTORY_TYPE moved to the systemHierarchy module (the active system detail UI);
+// re-exported here for back-compat with systemItem internals.
+export { HISTORY_TYPE } from '@/modules/systemHierarchy/types/history'

--- a/src/modules/systemItem/types/responses.ts
+++ b/src/modules/systemItem/types/responses.ts
@@ -1,6 +1,14 @@
 import type { SystemDetail } from '@/types/responses/systems'
 
-import type { HISTORY_TYPE } from './constants'
+// History/field-change types moved to the systemHierarchy module (the active
+// system detail UI); re-exported here for back-compat with systemItem internals.
+export type {
+    ChangeValue,
+    CodebookSnapshot,
+    FieldChangeEntry,
+    FieldChangeType,
+    HistoryResponse,
+} from '@/modules/systemHierarchy/types/history'
 
 export type SystemsForRelResponse = {
     data: SystemDetail[]
@@ -12,35 +20,4 @@ export type SystemRelationshipResponse = {
     relationTypeCode: string
     foreignSystemName: string
     relationUid: string
-}
-
-export type FieldChangeType = 'string' | 'number' | 'boolean' | 'date' | 'codebook'
-
-export type CodebookSnapshot = {
-    uid: string
-    name: string
-    code?: string
-}
-
-export type ChangeValue = string | number | boolean | CodebookSnapshot
-
-export type FieldChangeEntry = {
-    field: string
-    type: FieldChangeType
-    oldValue: ChangeValue | null
-    newValue: ChangeValue | null
-}
-
-export type HistoryResponse = {
-    uid: string
-    changedAt: string
-    changedBy: string
-    historyType: HISTORY_TYPE
-    action: string
-    detail: {
-        systemUid: string
-        systemName: string
-        direction: 'IN' | 'OUT'
-    }
-    changes?: FieldChangeEntry[]
 }

--- a/src/modules/systems/components/table/cells/SystemActionButtons.tsx
+++ b/src/modules/systems/components/table/cells/SystemActionButtons.tsx
@@ -144,6 +144,7 @@ export const SystemActionButtons = ({
                         <Link
                             href={getSystemHierarchyDetailPath(original.uid)}
                             target="_blank"
+                            rel="noopener noreferrer"
                             className="flex items-center cursor-pointer"
                         >
                             <Edit className="h-4 w-4 mr-2" />

--- a/src/modules/systems/components/table/cells/SystemActionButtons.tsx
+++ b/src/modules/systems/components/table/cells/SystemActionButtons.tsx
@@ -15,6 +15,7 @@ import {
 import { message } from '@/i18n/src/messages'
 import { openGraphModal } from '@/modules/shared/system/GraphModal'
 import { PandaTable } from '@/modules/shared/table/pandaTable/PandaTable'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { useSystemDelete } from '@/modules/systems/hooks/useSystemDelete'
 import { useSparePartsColumns } from '@/modules/systemsRelations/components/SpareParts.columns'
 import {
@@ -22,7 +23,6 @@ import {
     useGetSparePartsFor,
 } from '@/modules/systemsRelations/hooks/useGetSpareParts'
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
-import { PATH } from '@/types/constants/paths'
 import type { SystemDetail } from '@/types/responses/systems'
 import type { EndpointProps } from '@/utils/getEndpoints'
 
@@ -142,7 +142,7 @@ export const SystemActionButtons = ({
                 <DropdownMenuContent align="end" sideOffset={4}>
                     <DropdownMenuItem asChild>
                         <Link
-                            href={PATH.SYSTEM + '/' + original.uid}
+                            href={getSystemHierarchyDetailPath(original.uid)}
                             target="_blank"
                             className="flex items-center cursor-pointer"
                         >

--- a/src/modules/systems/components/table/cells/__tests__/SystemActionButtons.spec.tsx
+++ b/src/modules/systems/components/table/cells/__tests__/SystemActionButtons.spec.tsx
@@ -79,7 +79,7 @@ describe('SystemActionButtons', () => {
     it('viewDetail item contains link with /system/{uid}', () => {
         renderWithProviders(<SystemActionButtons {...baseProps} />)
         const link = screen.getByRole('link')
-        expect(link).toHaveAttribute('href', '/system/u-1')
+        expect(link).toHaveAttribute('href', '/systems/hierarchy?leaf=u-1')
         expect(link).toHaveAttribute('target', '_blank')
     })
 

--- a/src/modules/systems/components/table/cells/__tests__/SystemActionButtons.spec.tsx
+++ b/src/modules/systems/components/table/cells/__tests__/SystemActionButtons.spec.tsx
@@ -76,7 +76,7 @@ describe('SystemActionButtons', () => {
         expect(screen.getAllByTestId('dd-item').length).toBeGreaterThanOrEqual(3)
     })
 
-    it('viewDetail item contains link with /system/{uid}', () => {
+    it('viewDetail item contains hierarchy deep link for the uid', () => {
         renderWithProviders(<SystemActionButtons {...baseProps} />)
         const link = screen.getByRole('link')
         expect(link).toHaveAttribute('href', '/systems/hierarchy?leaf=u-1')

--- a/src/pages/system/[uid].tsx
+++ b/src/pages/system/[uid].tsx
@@ -1,49 +1,36 @@
 import type { NextPage } from 'next'
 import Head from 'next/head'
-import { Fragment } from 'react'
+import { useRouter } from 'next/router'
+import { Fragment, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { message } from 'src/i18n/src/messages'
 
-import ErrorPage from '@/components/error/ErrorPage'
 import LoaderComponent from '@/components/loader.comp'
-import { useSystemDetail } from '@/modules/systemItem/hooks/useSystemDetail'
-import { SystemItemContainer } from '@/modules/systemItem/SystemItem.cont'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 
-const messages = message.systemItem
-
-interface Props {
-    key?: string
-    uid?: string
-}
-
-const SystemDetailPage: NextPage = ({ uid }: Props) => {
+// The systemItem detail page is deprecated — old /system/<uid> links (bookmarks,
+// QR codes) land here and are forwarded to the hierarchy explorer detail view.
+const SystemDetailRedirectPage: NextPage = () => {
+    const router = useRouter()
     const intl = useIntl()
-    const { systemDetail, loading, error } = useSystemDetail()
 
-    if (loading) {
-        return <LoaderComponent />
-    }
-
-    if (error) {
-        return <ErrorPage />
-    }
+    useEffect(() => {
+        if (!router.isReady) return
+        const uid = router.query.uid as string | undefined
+        if (uid) {
+            router.replace(getSystemHierarchyDetailPath(uid))
+        }
+    }, [router])
 
     return (
         <Fragment>
             <Head>
-                <title>{intl.formatMessage({ id: messages.head })}</title>
+                <title>{intl.formatMessage({ id: message.systemItem.head })}</title>
                 <meta name="description" content="...." />
             </Head>
-            <div className="min-h-screen bg-background">
-                {systemDetail && <SystemItemContainer uid={uid} />}
-            </div>
+            <LoaderComponent />
         </Fragment>
     )
 }
 
-SystemDetailPage.getInitialProps = ({ query }) => ({
-    key: query.uid,
-    uid: query.uid,
-})
-
-export default SystemDetailPage
+export default SystemDetailRedirectPage

--- a/src/pages/system/[uid].tsx
+++ b/src/pages/system/[uid].tsx
@@ -11,16 +11,16 @@ import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hi
 // The systemItem detail page is deprecated — old /system/<uid> links (bookmarks,
 // QR codes) land here and are forwarded to the hierarchy explorer detail view.
 const SystemDetailRedirectPage: NextPage = () => {
-    const router = useRouter()
+    const { isReady, query, replace } = useRouter()
     const intl = useIntl()
 
     useEffect(() => {
-        if (!router.isReady) return
-        const uid = router.query.uid as string | undefined
+        if (!isReady) return
+        const uid = query.uid as string | undefined
         if (uid) {
-            router.replace(getSystemHierarchyDetailPath(uid))
+            replace(getSystemHierarchyDetailPath(uid))
         }
-    }, [router])
+    }, [isReady, query.uid, replace])
 
     return (
         <Fragment>

--- a/src/pages/system/[uid].tsx
+++ b/src/pages/system/[uid].tsx
@@ -16,7 +16,7 @@ const SystemDetailRedirectPage: NextPage = () => {
 
     useEffect(() => {
         if (!isReady) return
-        const uid = query.uid as string | undefined
+        const uid = Array.isArray(query.uid) ? query.uid[0] : query.uid
         if (uid) {
             replace(getSystemHierarchyDetailPath(uid))
         }

--- a/src/pages/system/__tests__/uid-redirect.spec.tsx
+++ b/src/pages/system/__tests__/uid-redirect.spec.tsx
@@ -1,0 +1,60 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+
+import SystemDetailRedirectPage from '../[uid]'
+
+const mockReplace = jest.fn()
+let mockQuery: Record<string, string | string[] | undefined> = {}
+let mockIsReady = true
+
+jest.mock('next/router', () => ({
+    useRouter: () => ({
+        isReady: mockIsReady,
+        query: mockQuery,
+        replace: mockReplace,
+    }),
+}))
+
+const messages: Record<string, string> = {
+    'systemItem.head': 'System',
+}
+
+const renderPage = () =>
+    render(
+        <IntlProvider locale="en" messages={messages}>
+            <SystemDetailRedirectPage />
+        </IntlProvider>,
+    )
+
+describe('/system/[uid] redirect page', () => {
+    beforeEach(() => {
+        mockReplace.mockClear()
+        mockQuery = {}
+        mockIsReady = true
+    })
+
+    it('replaces to the hierarchy deep link for the uid', () => {
+        mockQuery = { uid: 'u-1' }
+        renderPage()
+        expect(mockReplace).toHaveBeenCalledWith('/systems/hierarchy?leaf=u-1')
+    })
+
+    it('normalizes an array uid param to its first value', () => {
+        mockQuery = { uid: ['u-1', 'u-2'] }
+        renderPage()
+        expect(mockReplace).toHaveBeenCalledWith('/systems/hierarchy?leaf=u-1')
+    })
+
+    it('does nothing until the router is ready', () => {
+        mockIsReady = false
+        mockQuery = { uid: 'u-1' }
+        renderPage()
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
+
+    it('does nothing without a uid', () => {
+        renderPage()
+        expect(mockReplace).not.toHaveBeenCalled()
+    })
+})

--- a/src/pages/system/alias/[alias].tsx
+++ b/src/pages/system/alias/[alias].tsx
@@ -11,6 +11,7 @@ import EliLogoComponent from '@/components/eli-logo.comp'
 import ErrorPage from '@/components/error/ErrorPage'
 import LoaderComponent from '@/components/loader.comp'
 import { messages } from '@/i18n/src/locale/en'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { useSystemDetail } from '@/modules/systemItem/hooks/useSystemDetail'
 import { PATH } from '@/types/constants/paths'
 
@@ -26,7 +27,7 @@ const SystemAliasRedirectPage: NextPage = ({ alias }: Props) => {
     const { loading, error, systemDetail } = useSystemDetail({ alias }, data => {
         const uid = data?.systems[0]?.uid
         if (uid) {
-            router.push(PATH.SYSTEM + '/' + uid)
+            router.replace(getSystemHierarchyDetailPath(uid))
         }
     })
 

--- a/src/pages/system/item/[itemUid].tsx
+++ b/src/pages/system/item/[itemUid].tsx
@@ -2,6 +2,7 @@ import type { NextPage } from 'next'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { useSession } from 'next-auth/react'
 import { Fragment } from 'react'
 import { FormattedMessage } from 'react-intl'
 
@@ -10,6 +11,7 @@ import EliLogoComponent from '@/components/eli-logo.comp'
 import ErrorPage from '@/components/error/ErrorPage'
 import LoaderComponent from '@/components/loader.comp'
 import { messages } from '@/i18n/src/locale/en'
+import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
 import { useSystemDetail } from '@/modules/systemItem/hooks/useSystemDetail'
 import { PATH } from '@/types/constants/paths'
 
@@ -20,11 +22,12 @@ interface Props {
 
 const SystemItemRedirectPage: NextPage = ({ itemUid }: Props) => {
     const router = useRouter()
+    const { status } = useSession()
 
     const { loading, error, systemDetail } = useSystemDetail({ itemUid }, data => {
         const uid = data?.systems[0]?.uid
         if (uid) {
-            router.push(PATH.SYSTEM + '/' + uid)
+            router.replace(getSystemHierarchyDetailPath(uid))
         }
     })
 


### PR DESCRIPTION
## What

Deprecates the `systemItem` module (NOT deleted) and relinks all `/system/<uid>` system-detail links to the hierarchy explorer with the target system selected in detail view.

## Changes

- **`getSystemHierarchyDetailPath(uid)`** (`systemHierarchy/utils/hierarchyLinks.ts`) — canonical deep link `/systems/hierarchy?leaf=<uid>`
- **`useHierarchyDeepLinkResolver`** — when URL has `leaf` w/o `parent`: resolves parent from `parentPath`, expands ancestor tree nodes, `router.replace`s parent (no history entry). Root systems → parent==leaf. Guards vs stale `keepPreviousData` + async-replace double-fire
- **Not-found state** in `SystemDetailView` for deleted/unknown uid (was endless skeleton)
- **Pages**: `/system/[uid]` → thin redirect; `alias/[alias]` + `item/[itemUid]` resolve then redirect to hierarchy (`replace`, no back-button trap); fixed pre-existing undefined `status` bug in item page
- **Relinked call sites**: global search, systems overview action button, order lines (guard-hide links w/ missing uid), control-systems tables, device-info overlay, move wizard, history feed
- **History types extracted** `systemItem` → `systemHierarchy/types/history.ts` (back-compat re-exports) — hierarchy now imports nothing from systemItem
- **Deprecation**: `@deprecated` JSDoc on container + entry-point hooks/store; `DEPRECATED.md` w/ allowed-imports list + removal criteria
- **Docs**: technical (Deep links & URL contract section, system-item deprecation banner, diagrams, glossary) + user guide URL updates

Old `/system/<uid>` bookmarks + QR codes keep working via redirect. Links inside the deprecated module intentionally untouched (resolve via redirect).

## Tests

- New: `hierarchyLinks.spec.ts`, `useHierarchyDeepLinkResolver.spec.tsx` (7 cases), `SystemDetailView.spec.tsx`
- Updated: `getRedirectPath.test.ts`, `SystemInformationSection.spec.tsx`, `SystemActionButtons.spec.tsx`
- Full suite: 3336 passed, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)