### PR TITLE
fix(itemMoving): move/assign wizard broken on system hierarchy view

### DIFF
--- a/src/modules/shared/form/itemAssign/__tests__/item-assign.modal.spec.tsx
+++ b/src/modules/shared/form/itemAssign/__tests__/item-assign.modal.spec.tsx
@@ -2,9 +2,9 @@ import { render } from '@testing-library/react'
 
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 
-import { ItemAssignModal, ItemAssignModalContent, openItemAssignModal } from '../item-assign.modal'
-import { useWizardStore } from '../../wizard/store/useWizardStore'
 import { useModalWizardStore } from '../../itemMoving/store/useModalWizardStore'
+import { useWizardStore } from '../../wizard/store/useWizardStore'
+import { ItemAssignModal, ItemAssignModalContent, openItemAssignModal } from '../item-assign.modal'
 
 jest.mock('@/store/useDynamicModalStore', () => ({
     useDynamicModalStore: { getState: jest.fn() } as any,
@@ -14,8 +14,14 @@ jest.mock('../../wizard/store/useWizardStore', () => ({
     useWizardStore: jest.fn(),
 }))
 
-jest.mock('../../itemMoving/store/useModalWizardStore', () => ({
-    useModalWizardStore: jest.fn(),
+jest.mock('../../itemMoving/store/useModalWizardStore', () => {
+    const store = jest.fn() as jest.Mock & { getState: jest.Mock }
+    store.getState = jest.fn()
+    return { useModalWizardStore: store }
+})
+
+jest.mock('../../itemMoving/hooks/useWizardContextSystem', () => ({
+    useWizardContextSystem: jest.fn().mockReturnValue({}),
 }))
 
 jest.mock('../item-assign.cont', () => ({
@@ -24,20 +30,25 @@ jest.mock('../item-assign.cont', () => ({
 
 const mockUseDynamicModalStore = useDynamicModalStore as unknown as { getState: jest.Mock }
 const mockUseWizardStore = useWizardStore as unknown as jest.Mock
-const mockUseModalWizardStore = useModalWizardStore as unknown as jest.Mock
+const mockUseModalWizardStore = useModalWizardStore as unknown as jest.Mock & {
+    getState: jest.Mock
+}
 
 let openModal: jest.Mock
 let resetWizard: jest.Mock
 let setSelectedSystem: jest.Mock
+let setContextSystem: jest.Mock
 
 beforeEach(() => {
     jest.clearAllMocks()
     openModal = jest.fn().mockReturnValue('mid-1')
     resetWizard = jest.fn()
     setSelectedSystem = jest.fn()
+    setContextSystem = jest.fn()
     mockUseDynamicModalStore.getState.mockReturnValue({ openModal })
     mockUseWizardStore.mockReturnValue({ resetWizard })
-    mockUseModalWizardStore.mockReturnValue({ setSelectedSystem })
+    mockUseModalWizardStore.mockReturnValue({ setSelectedSystem, setContextSystem })
+    mockUseModalWizardStore.getState.mockReturnValue({ setContextSystem })
 })
 
 describe('openItemAssignModal', () => {
@@ -48,6 +59,17 @@ describe('openItemAssignModal', () => {
         expect(config.id).toBe('item-assign')
         expect(config.props).toEqual({ title: 'Assign Item', size: 'xl' })
     })
+
+    it('stores the passed destination system snapshot', () => {
+        const system = { uid: 'sys-1', name: 'Sys 1' }
+        openItemAssignModal(system)
+        expect(setContextSystem).toHaveBeenCalledWith(system)
+    })
+
+    it('clears the context system when called without one', () => {
+        openItemAssignModal()
+        expect(setContextSystem).toHaveBeenCalledWith(null)
+    })
 })
 
 describe('ItemAssignModalContent', () => {
@@ -56,11 +78,14 @@ describe('ItemAssignModalContent', () => {
         expect(getByTestId('cont')).toBeInTheDocument()
     })
 
-    it('resets wizard + clears selected system on unmount', () => {
+    it('resets wizard + clears selected system on unmount, keeps context uid', () => {
         const { unmount } = render(<ItemAssignModalContent />)
         unmount()
         expect(resetWizard).toHaveBeenCalled()
         expect(setSelectedSystem).toHaveBeenCalledWith(null)
+        // StrictMode re-runs the cleanup right after mount — clearing the uid
+        // here would break the wizard while the modal is still open
+        expect(setContextSystem).not.toHaveBeenCalled()
     })
 })
 

--- a/src/modules/shared/form/itemAssign/item-assign.button.tsx
+++ b/src/modules/shared/form/itemAssign/item-assign.button.tsx
@@ -9,6 +9,8 @@ import { openItemAssignModal } from './item-assign.modal'
 export const ItemAssignButton: FC = () => {
     const { formatMessage: fm } = useIntl()
     return (
-        <Button onClick={openItemAssignModal}>{fm({ id: message.common.forms.assignItem })}</Button>
+        <Button onClick={() => openItemAssignModal()}>
+            {fm({ id: message.common.forms.assignItem })}
+        </Button>
     )
 }

--- a/src/modules/shared/form/itemAssign/item-assign.modal.tsx
+++ b/src/modules/shared/form/itemAssign/item-assign.modal.tsx
@@ -2,12 +2,20 @@ import React, { type FC } from 'react'
 
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 
-import { useModalWizardStore } from '../itemMoving/store/useModalWizardStore'
+import { useWizardContextSystem } from '../itemMoving/hooks/useWizardContextSystem'
+import {
+    useModalWizardStore,
+    type WizardContextSystem,
+} from '../itemMoving/store/useModalWizardStore'
 import { useWizardStore } from '../wizard/store/useWizardStore'
 import { ItemAssignContainer } from './item-assign.cont'
 
-export function openItemAssignModal() {
+export function openItemAssignModal(contextSystem?: WizardContextSystem) {
     if (typeof window === 'undefined') return // Prevent SSR execution
+
+    // Snapshot of the assignment's destination system; without it the wizard
+    // falls back to fetching by router.query.uid (legacy /system/[uid] view)
+    useModalWizardStore.getState().setContextSystem(contextSystem ?? null)
 
     const { openModal } = useDynamicModalStore.getState()
 
@@ -27,7 +35,13 @@ export const ItemAssignModalContent: FC = () => {
     const { resetWizard } = useWizardStore()
     const { setSelectedSystem } = useModalWizardStore()
 
-    // Reset wizard when modal opens
+    // Kick off the legacy-view fallback fetch as soon as the modal opens so
+    // the data is ready by the Summary step
+    useWizardContextSystem()
+
+    // Reset wizard when modal opens. contextSystem is intentionally NOT
+    // cleared here — StrictMode re-runs this cleanup right after mount, which
+    // would wipe the snapshot set by openItemAssignModal; the next open overwrites it.
     React.useEffect(() => {
         return () => {
             resetWizard()

--- a/src/modules/shared/form/itemMoving/__tests__/item-move.modal.spec.tsx
+++ b/src/modules/shared/form/itemMoving/__tests__/item-move.modal.spec.tsx
@@ -2,8 +2,8 @@ import { render } from '@testing-library/react'
 
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 
-import { ItemMoveModal, ItemMoveModalContent, openItemMoveModal } from '../item-move.modal'
 import { useWizardStore } from '../../wizard/store/useWizardStore'
+import { ItemMoveModal, ItemMoveModalContent, openItemMoveModal } from '../item-move.modal'
 import { useModalWizardStore } from '../store/useModalWizardStore'
 
 jest.mock('@/store/useDynamicModalStore', () => ({
@@ -14,8 +14,14 @@ jest.mock('../../wizard/store/useWizardStore', () => ({
     useWizardStore: jest.fn(),
 }))
 
-jest.mock('../store/useModalWizardStore', () => ({
-    useModalWizardStore: jest.fn(),
+jest.mock('../store/useModalWizardStore', () => {
+    const store = jest.fn() as jest.Mock & { getState: jest.Mock }
+    store.getState = jest.fn()
+    return { useModalWizardStore: store }
+})
+
+jest.mock('../hooks/useWizardContextSystem', () => ({
+    useWizardContextSystem: jest.fn().mockReturnValue({}),
 }))
 
 jest.mock('../item-move.cont', () => ({
@@ -24,20 +30,25 @@ jest.mock('../item-move.cont', () => ({
 
 const mockUseDynamicModalStore = useDynamicModalStore as unknown as { getState: jest.Mock }
 const mockUseWizardStore = useWizardStore as unknown as jest.Mock
-const mockUseModalWizardStore = useModalWizardStore as unknown as jest.Mock
+const mockUseModalWizardStore = useModalWizardStore as unknown as jest.Mock & {
+    getState: jest.Mock
+}
 
 let openModal: jest.Mock
 let resetWizard: jest.Mock
 let setSelectedSystem: jest.Mock
+let setContextSystem: jest.Mock
 
 beforeEach(() => {
     jest.clearAllMocks()
     openModal = jest.fn().mockReturnValue('mid-1')
     resetWizard = jest.fn()
     setSelectedSystem = jest.fn()
+    setContextSystem = jest.fn()
     mockUseDynamicModalStore.getState.mockReturnValue({ openModal })
     mockUseWizardStore.mockReturnValue({ resetWizard })
-    mockUseModalWizardStore.mockReturnValue({ setSelectedSystem })
+    mockUseModalWizardStore.mockReturnValue({ setSelectedSystem, setContextSystem })
+    mockUseModalWizardStore.getState.mockReturnValue({ setContextSystem })
 })
 
 describe('openItemMoveModal', () => {
@@ -49,6 +60,17 @@ describe('openItemMoveModal', () => {
         expect(config.id).toBe('item-move')
         expect(config.props).toEqual({ title: 'Move Item', size: 'l' })
     })
+
+    it('stores the passed source system snapshot', () => {
+        const system = { uid: 'sys-1', name: 'Sys 1' }
+        openItemMoveModal(system)
+        expect(setContextSystem).toHaveBeenCalledWith(system)
+    })
+
+    it('clears the context system when called without one', () => {
+        openItemMoveModal()
+        expect(setContextSystem).toHaveBeenCalledWith(null)
+    })
 })
 
 describe('ItemMoveModalContent', () => {
@@ -57,11 +79,14 @@ describe('ItemMoveModalContent', () => {
         expect(getByTestId('cont')).toBeInTheDocument()
     })
 
-    it('resets wizard + clears selected system on unmount', () => {
+    it('resets wizard + clears selected system on unmount, keeps context uid', () => {
         const { unmount } = render(<ItemMoveModalContent />)
         unmount()
         expect(resetWizard).toHaveBeenCalled()
         expect(setSelectedSystem).toHaveBeenCalledWith(null)
+        // StrictMode re-runs the cleanup right after mount — clearing the uid
+        // here would break the wizard while the modal is still open
+        expect(setContextSystem).not.toHaveBeenCalled()
     })
 })
 

--- a/src/modules/shared/form/itemMoving/hooks/__tests__/useMoveWizardSubmit.spec.tsx
+++ b/src/modules/shared/form/itemMoving/hooks/__tests__/useMoveWizardSubmit.spec.tsx
@@ -1,0 +1,115 @@
+import { useMutation } from '@tanstack/react-query'
+import { renderHook } from '@testing-library/react'
+import { toast } from 'sonner'
+
+import { useWizardStore } from '../../../wizard/store/useWizardStore'
+import { useModalWizardStore } from '../../store/useModalWizardStore'
+import { MOVE_TYPE } from '../../types/constants'
+import { useMoveWizardSubmit } from '../useMoveWizardSubmit'
+import { useWizardContextSystem } from '../useWizardContextSystem'
+
+jest.mock('next/router', () => ({
+    useRouter: () => ({ query: {}, push: jest.fn(), reload: jest.fn() }),
+}))
+
+jest.mock('sonner', () => ({
+    toast: { error: jest.fn(), success: jest.fn() },
+}))
+
+jest.mock('@tanstack/react-query', () => ({
+    useMutation: jest.fn(),
+}))
+
+jest.mock('@/modules/systemItem/hooks/useSystemsReload', () => ({
+    useSystemsReload: () => [jest.fn(), false],
+}))
+
+jest.mock('@/store/useDynamicModalStore', () => ({
+    useDynamicModalStore: () => ({ closeModal: jest.fn() }),
+}))
+
+jest.mock('@/utils/fetcher', () => ({
+    queryMutate: jest.fn(() => jest.fn()),
+}))
+
+jest.mock('../useWizardContextSystem', () => ({
+    useWizardContextSystem: jest.fn(),
+}))
+
+jest.mock('../../../wizard/store/useWizardStore', () => ({
+    useWizardStore: jest.fn(),
+}))
+
+jest.mock('../../store/useModalWizardStore', () => ({
+    useModalWizardStore: jest.fn(),
+}))
+
+const mockUseMutation = useMutation as jest.Mock
+const mockUseWizardContextSystem = useWizardContextSystem as jest.Mock
+const mockUseWizardStore = useWizardStore as unknown as jest.Mock
+const mockUseModalWizardStore = useModalWizardStore as unknown as jest.Mock
+
+let moveMutate: jest.Mock
+let replaceMutate: jest.Mock
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    moveMutate = jest.fn()
+    replaceMutate = jest.fn()
+    mockUseMutation
+        .mockReturnValueOnce({ mutate: moveMutate, isPending: false })
+        .mockReturnValueOnce({ mutate: replaceMutate, isPending: false })
+    mockUseWizardStore.mockReturnValue({
+        formData: {
+            system: { uid: 'dst-1' },
+            name: 'New name',
+            location: { uid: 'loc-1', name: 'Lobby' },
+            itemUsage: { uid: 'u-1', name: 'Spare Part' },
+            conditionStatus: { uid: 'c-1', name: 'New' },
+        },
+        goBack: jest.fn(),
+        resetWizard: jest.fn(),
+        updateFormData: jest.fn(),
+    })
+    mockUseModalWizardStore.mockReturnValue({
+        isMovingToNewSystem: false,
+        setSelectedSystem: jest.fn(),
+        moveType: MOVE_TYPE.DESTINATION_SYSTEM,
+        oldItemParentSystem: null,
+        selectedSystem: null,
+    })
+    mockUseWizardContextSystem.mockReturnValue({
+        systemDetail: { uid: 'src-1', name: 'Source' },
+        physicalItem: null,
+        catalogueItem: null,
+    })
+})
+
+describe('useMoveWizardSubmit › submitWizard', () => {
+    it('fails fast with a toast when the context system is not resolved', () => {
+        mockUseWizardContextSystem.mockReturnValue({
+            systemDetail: null,
+            physicalItem: null,
+            catalogueItem: null,
+        })
+
+        const { result } = renderHook(() => useMoveWizardSubmit())
+        result.current.submitWizard()
+
+        expect(toast.error).toHaveBeenCalled()
+        expect(moveMutate).not.toHaveBeenCalled()
+        expect(replaceMutate).not.toHaveBeenCalled()
+    })
+
+    it('sends the context system uid as sourceSystemUid', () => {
+        const { result } = renderHook(() => useMoveWizardSubmit())
+        result.current.submitWizard()
+
+        expect(moveMutate).toHaveBeenCalledWith(
+            expect.objectContaining({
+                sourceSystemUid: 'src-1',
+                destinationSystemUid: 'dst-1',
+            }),
+        )
+    })
+})

--- a/src/modules/shared/form/itemMoving/hooks/__tests__/useWizardContextSystem.spec.ts
+++ b/src/modules/shared/form/itemMoving/hooks/__tests__/useWizardContextSystem.spec.ts
@@ -1,0 +1,106 @@
+import { renderHook } from '@testing-library/react'
+import { useRouter } from 'next/router'
+
+import { useSystemDetail } from '@/modules/systemHierarchy/hooks/queries/useSystemDetail'
+
+import { useModalWizardStore } from '../../store/useModalWizardStore'
+import { useWizardContextSystem } from '../useWizardContextSystem'
+
+jest.mock('next/router', () => ({
+    useRouter: jest.fn(),
+}))
+
+jest.mock('@/modules/systemHierarchy/hooks/queries/useSystemDetail', () => ({
+    useSystemDetail: jest.fn(),
+}))
+
+const mockUseRouter = useRouter as jest.Mock
+const mockUseSystemDetail = useSystemDetail as jest.Mock
+
+const contextSystem = {
+    uid: 'ctx-1',
+    name: 'Context System',
+    location: { uid: 'loc-1', name: 'Lobby' },
+    physicalItem: {
+        uid: 'pi-1',
+        name: 'Item name',
+        serialNumber: 'SN-1',
+        eun: 'EUN-1',
+        catalogueNumber: 'CAT-1',
+        itemUsage: { uid: 'u-1', name: 'Spare Part' },
+        conditionStatus: { uid: 'c-1', name: 'New' },
+    },
+}
+
+describe('useWizardContextSystem', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        useModalWizardStore.setState({ contextSystem: null })
+        mockUseRouter.mockReturnValue({ query: {} })
+        mockUseSystemDetail.mockReturnValue({
+            system: { uid: 'fetched-1' },
+            physicalItem: { uid: 'pi-f' },
+            catalogueItem: { uid: 'ci-f' },
+            isLoading: false,
+        })
+    })
+
+    it('returns the snapshot passed to the open function without fetching', () => {
+        useModalWizardStore.setState({ contextSystem })
+        mockUseRouter.mockReturnValue({ query: { uid: 'route-1' } })
+
+        const { result } = renderHook(() => useWizardContextSystem())
+
+        expect(mockUseSystemDetail).toHaveBeenCalledWith(null)
+        expect(result.current.systemDetail).toEqual(contextSystem)
+        expect(result.current.physicalItem).toEqual(contextSystem.physicalItem)
+        expect(result.current.isLoading).toBe(false)
+    })
+
+    it('derives catalogue info from flat physicalItem fields (detail panel shape)', () => {
+        useModalWizardStore.setState({ contextSystem })
+
+        const { result } = renderHook(() => useWizardContextSystem())
+
+        expect(result.current.catalogueItem).toEqual({
+            name: 'Item name',
+            catalogueNumber: 'CAT-1',
+        })
+    })
+
+    it('derives catalogue info from nested catalogueItem (leaves list shape)', () => {
+        useModalWizardStore.setState({
+            contextSystem: {
+                ...contextSystem,
+                physicalItem: {
+                    uid: 'pi-1',
+                    catalogueItem: { uid: 'ci-1', name: 'Cat name', catalogueNumber: 'CAT-9' },
+                },
+            },
+        })
+
+        const { result } = renderHook(() => useWizardContextSystem())
+
+        expect(result.current.catalogueItem).toEqual({
+            name: 'Cat name',
+            catalogueNumber: 'CAT-9',
+        })
+    })
+
+    it('falls back to fetching by router.query.uid (legacy /system/[uid] view)', () => {
+        mockUseRouter.mockReturnValue({ query: { uid: 'route-1' } })
+
+        const { result } = renderHook(() => useWizardContextSystem())
+
+        expect(mockUseSystemDetail).toHaveBeenCalledWith('route-1')
+        expect(result.current.systemDetail).toEqual({ uid: 'fetched-1' })
+        expect(result.current.physicalItem).toEqual({ uid: 'pi-f' })
+        expect(result.current.catalogueItem).toEqual({ uid: 'ci-f' })
+    })
+
+    it('passes null to the fetch when no uid is available', () => {
+        renderHook(() => useWizardContextSystem())
+
+        expect(mockUseSystemDetail).toHaveBeenCalledWith(null)
+    })
+})

--- a/src/modules/shared/form/itemMoving/hooks/useMoveWizardSubmit.ts
+++ b/src/modules/shared/form/itemMoving/hooks/useMoveWizardSubmit.ts
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 
 import { getSystemHierarchyDetailPath } from '@/modules/systemHierarchy/utils/hierarchyLinks'
-import { useSystemDetail } from '@/modules/systemItem/hooks/useSystemDetail'
 import { useSystemsReload } from '@/modules/systemItem/hooks/useSystemsReload'
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 import type { AxiosError } from '@/types/http'
@@ -15,6 +14,7 @@ import { useWizardStore } from '../../wizard/store/useWizardStore'
 import { useModalWizardStore } from '../store/useModalWizardStore'
 import type { ItemMovePost } from '../types'
 import { MOVE_TYPE } from '../types/constants'
+import { useWizardContextSystem } from './useWizardContextSystem'
 
 export const useMoveWizardSubmit = () => {
     const {
@@ -26,7 +26,7 @@ export const useMoveWizardSubmit = () => {
     } = useModalWizardStore()
 
     const { closeModal } = useDynamicModalStore()
-    const { physicalItem, catalogueItem, systemDetail } = useSystemDetail()
+    const { physicalItem, catalogueItem, systemDetail } = useWizardContextSystem()
     const { formData, goBack, resetWizard, updateFormData } = useWizardStore()
     const router = useRouter()
 
@@ -34,8 +34,8 @@ export const useMoveWizardSubmit = () => {
 
     const onSuccessRedirect = () => {
         toast.success('Item moved successfully')
-        // NOTE: Modal is opened with ID 'item-move-wizard' in item-move.modal.tsx
-        closeModal('item-move-wizard')
+        // Ids must match the openModal configs in item-move.modal.tsx / item-assign.modal.tsx
+        closeModal(moveType === MOVE_TYPE.ASSIGN ? 'item-assign' : 'item-move')
         resetWizard()
         setSelectedSystem(null)
         if (moveType === MOVE_TYPE.ASSIGN) {
@@ -129,6 +129,10 @@ export const useMoveWizardSubmit = () => {
     })
 
     const submitWizard = () => {
+        if (!systemDetail?.uid) {
+            toast.error('System detail is not loaded yet, please try again')
+            return
+        }
         if (moveType === MOVE_TYPE.EXCHANGE) {
             return mutateReplace({
                 condition: formData.conditionStatus,

--- a/src/modules/shared/form/itemMoving/hooks/useWizardContextSystem.ts
+++ b/src/modules/shared/form/itemMoving/hooks/useWizardContextSystem.ts
@@ -1,0 +1,49 @@
+import { useRouter } from 'next/router'
+
+import { useSystemDetail } from '@/modules/systemHierarchy/hooks/queries/useSystemDetail'
+
+import { useModalWizardStore } from '../store/useModalWizardStore'
+
+/**
+ * Resolves the system the wizard was opened from (move source / assign destination).
+ *
+ * Primary source is the snapshot passed to openItemMoveModal/openItemAssignModal —
+ * synchronously available, no fetch, no race with submit. Only the legacy
+ * /system/[uid] view (which passes nothing) falls back to fetching by route uid.
+ */
+export const useWizardContextSystem = () => {
+    const { contextSystem } = useModalWizardStore()
+    const router = useRouter()
+
+    const fallbackUid = contextSystem
+        ? null
+        : ((router.query.uid as string | undefined) || null)
+    const fetched = useSystemDetail(fallbackUid)
+
+    if (contextSystem) {
+        const physicalItem = contextSystem.physicalItem ?? null
+        return {
+            systemDetail: contextSystem,
+            physicalItem,
+            // Catalogue info lives flat on physicalItem (detail panel shape) or
+            // nested under catalogueItem (leaves list shape) — normalize both
+            catalogueItem: physicalItem
+                ? {
+                      name: physicalItem.catalogueItem?.name ?? physicalItem.name ?? null,
+                      catalogueNumber:
+                          physicalItem.catalogueNumber ??
+                          physicalItem.catalogueItem?.catalogueNumber ??
+                          null,
+                  }
+                : null,
+            isLoading: false,
+        }
+    }
+
+    return {
+        systemDetail: fetched.system,
+        physicalItem: fetched.physicalItem,
+        catalogueItem: fetched.catalogueItem,
+        isLoading: fetched.isLoading,
+    }
+}

--- a/src/modules/shared/form/itemMoving/hooks/useWizardContextSystem.ts
+++ b/src/modules/shared/form/itemMoving/hooks/useWizardContextSystem.ts
@@ -15,9 +15,8 @@ export const useWizardContextSystem = () => {
     const { contextSystem } = useModalWizardStore()
     const router = useRouter()
 
-    const fallbackUid = contextSystem
-        ? null
-        : ((router.query.uid as string | undefined) || null)
+    const routeUid = Array.isArray(router.query.uid) ? router.query.uid[0] : router.query.uid
+    const fallbackUid = contextSystem ? null : routeUid || null
     const fetched = useSystemDetail(fallbackUid)
 
     if (contextSystem) {
@@ -26,7 +25,10 @@ export const useWizardContextSystem = () => {
             systemDetail: contextSystem,
             physicalItem,
             // Catalogue info lives flat on physicalItem (detail panel shape) or
-            // nested under catalogueItem (leaves list shape) — normalize both
+            // nested under catalogueItem (leaves list shape) — normalize both.
+            // The physical item name doubles as the catalogue name in the detail
+            // panel shape: it is mapped from the same PhysicalItemFragment the
+            // wizard's step-3 heading ("Item: <name>") rendered before this change.
             catalogueItem: physicalItem
                 ? {
                       name: physicalItem.catalogueItem?.name ?? physicalItem.name ?? null,

--- a/src/modules/shared/form/itemMoving/item-move.button.tsx
+++ b/src/modules/shared/form/itemMoving/item-move.button.tsx
@@ -8,5 +8,9 @@ import { openItemMoveModal } from './item-move.modal'
 
 export const ItemMoveButton: FC = () => {
     const { formatMessage: fm } = useIntl()
-    return <Button onClick={openItemMoveModal}>{fm({ id: message.common.forms.moveItem })}</Button>
+    return (
+        <Button onClick={() => openItemMoveModal()}>
+            {fm({ id: message.common.forms.moveItem })}
+        </Button>
+    )
 }

--- a/src/modules/shared/form/itemMoving/item-move.modal.tsx
+++ b/src/modules/shared/form/itemMoving/item-move.modal.tsx
@@ -3,11 +3,16 @@ import React, { type FC } from 'react'
 import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 
 import { useWizardStore } from '../wizard/store/useWizardStore'
+import { useWizardContextSystem } from './hooks/useWizardContextSystem'
 import { ItemMoveContainer } from './item-move.cont'
-import { useModalWizardStore } from './store/useModalWizardStore'
+import { useModalWizardStore, type WizardContextSystem } from './store/useModalWizardStore'
 
-export function openItemMoveModal() {
+export function openItemMoveModal(contextSystem?: WizardContextSystem) {
     if (typeof window === 'undefined') return // Prevent SSR execution
+
+    // Snapshot of the move's source system; without it the wizard falls back
+    // to fetching by router.query.uid (legacy /system/[uid] view)
+    useModalWizardStore.getState().setContextSystem(contextSystem ?? null)
 
     const { openModal } = useDynamicModalStore.getState()
 
@@ -27,7 +32,13 @@ export const ItemMoveModalContent: FC = () => {
     const { resetWizard } = useWizardStore()
     const { setSelectedSystem } = useModalWizardStore()
 
-    // Reset wizard when modal opens
+    // Kick off the legacy-view fallback fetch as soon as the modal opens so
+    // the data is ready by the System Detail / Summary steps
+    useWizardContextSystem()
+
+    // Reset wizard when modal opens. contextSystem is intentionally NOT
+    // cleared here — StrictMode re-runs this cleanup right after mount, which
+    // would wipe the snapshot set by openItemMoveModal; the next open overwrites it.
     React.useEffect(() => {
         return () => {
             resetWizard()

--- a/src/modules/shared/form/itemMoving/steps/SystemDetail.step.tsx
+++ b/src/modules/shared/form/itemMoving/steps/SystemDetail.step.tsx
@@ -1,5 +1,5 @@
 import { yupResolver } from '@hookform/resolvers/yup'
-import { type FC, useMemo } from 'react'
+import { type FC, useEffect, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import * as yup from 'yup'
 
@@ -12,7 +12,6 @@ import { Heading } from '@/components/layout/Heading'
 import ModalButtonsComponent from '@/components/overlays/modal/modal.buttons'
 import { message } from '@/i18n/src/messages'
 import { cn } from '@/lib/utils'
-import { useSystemDetail } from '@/modules/systemItem/hooks/useSystemDetail'
 import { getColorBySystemLevel } from '@/modules/systemItem/utils'
 import type { ModalButtons } from '@/types/form'
 import type { CodebookType } from '@/types/responses/codebook'
@@ -21,6 +20,7 @@ import type { SystemDetail } from '@/types/responses/systems'
 import { SelectLocationCombo } from '../../location/SelectLocation.combo'
 import { useWizardStore } from '../../wizard/store/useWizardStore'
 import { useFormFields } from '../hooks/useFormFields'
+import { useWizardContextSystem } from '../hooks/useWizardContextSystem'
 import { useModalWizardStore } from '../store/useModalWizardStore'
 import { SummaryListParam } from './components/SymmaryListParam.comp'
 
@@ -48,7 +48,7 @@ export const SystemDetailStep: FC = () => {
         return [...(system?.parentPath || []), { uid: system?.uid, name: system?.name }]
     }, [system])
 
-    const { physicalItem, catalogueItem } = useSystemDetail()
+    const { physicalItem, catalogueItem } = useWizardContextSystem()
 
     const defaultValues = isMovingToNewSystem
         ? {
@@ -76,6 +76,15 @@ export const SystemDetailStep: FC = () => {
         defaultValues,
         resolver: yupResolver(schema),
     })
+
+    // Re-seed defaults once the moved item's detail arrives — the fetch may
+    // still be in flight when this step mounts
+    useEffect(() => {
+        if (physicalItem && !formMethods.formState.isDirty) {
+            formMethods.reset(defaultValues)
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [physicalItem?.uid])
 
     const submit = (data: SystemDetailForm) => {
         updateFormData({ ...data })

--- a/src/modules/shared/form/itemMoving/store/useModalWizardStore.ts
+++ b/src/modules/shared/form/itemMoving/store/useModalWizardStore.ts
@@ -4,16 +4,50 @@ import type { SystemDetail } from '@/types/responses/systems'
 
 import { MOVE_TYPE } from '../types/constants'
 
+type CodebookRef = {
+    uid: string
+    name: string
+}
+
+// System the wizard was opened from (move source / assign destination).
+// Deliberately a plain data snapshot, not a uid to refetch — the opener
+// (hierarchy detail, leaves table, ...) already has everything the wizard
+// needs, so the wizard must not depend on any route param or async fetch.
+// Structurally compatible with SystemLeaf (systemHierarchy).
+export type WizardContextSystem = {
+    uid: string
+    name: string
+    location?: CodebookRef | null
+    physicalItem?: {
+        uid?: string | null
+        name?: string | null
+        eun?: string | null
+        serialNumber?: string | null
+        catalogueNumber?: string | null
+        itemUsage?: CodebookRef | null
+        conditionStatus?: CodebookRef | null
+        catalogueItem?: {
+            uid?: string | null
+            name?: string | null
+            catalogueNumber?: string | null
+        } | null
+    } | null
+}
+
 type ModalWizard = {
     open: boolean
     isMovingToNewSystem: boolean | null
     selectedSystem: SystemDetail | null
     oldItemParentSystem: SystemDetail | null
+    // Set by openItemMoveModal/openItemAssignModal; when null the wizard falls
+    // back to fetching by router.query.uid (legacy /system/[uid] view).
+    contextSystem: WizardContextSystem | null
     moveType: MOVE_TYPE
     setOpen: (open: boolean) => void
     setIsMovingToNewSystem: (isMovingToNewSystem: boolean | null) => void
     setSelectedSystem: (selectedSystem: SystemDetail | null) => void
     setOldItemParentSystem: (oldItemParentSystem: SystemDetail | null) => void
+    setContextSystem: (contextSystem: WizardContextSystem | null) => void
     setMoveType: (moveType: MOVE_TYPE) => void
 }
 
@@ -22,10 +56,12 @@ export const useModalWizardStore = create<ModalWizard>(set => ({
     isMovingToNewSystem: null,
     selectedSystem: null,
     oldItemParentSystem: null,
+    contextSystem: null,
     moveType: MOVE_TYPE.DEFAULT,
     setMoveType: moveType => set({ moveType }),
     setOpen: open => set({ open }),
     setIsMovingToNewSystem: isMovingToNewSystem => set({ isMovingToNewSystem }),
     setSelectedSystem: selectedSystem => set({ selectedSystem }),
     setOldItemParentSystem: oldItemParentSystem => set({ oldItemParentSystem }),
+    setContextSystem: contextSystem => set({ contextSystem }),
 }))

--- a/src/modules/shared/form/itemMoving/store/useModalWizardStore.ts
+++ b/src/modules/shared/form/itemMoving/store/useModalWizardStore.ts
@@ -1,38 +1,15 @@
 import { create } from 'zustand'
 
+import type { SystemLeaf } from '@/modules/systemHierarchy/types'
 import type { SystemDetail } from '@/types/responses/systems'
 
 import { MOVE_TYPE } from '../types/constants'
-
-type CodebookRef = {
-    uid: string
-    name: string
-}
 
 // System the wizard was opened from (move source / assign destination).
 // Deliberately a plain data snapshot, not a uid to refetch — the opener
 // (hierarchy detail, leaves table, ...) already has everything the wizard
 // needs, so the wizard must not depend on any route param or async fetch.
-// Structurally compatible with SystemLeaf (systemHierarchy).
-export type WizardContextSystem = {
-    uid: string
-    name: string
-    location?: CodebookRef | null
-    physicalItem?: {
-        uid?: string | null
-        name?: string | null
-        eun?: string | null
-        serialNumber?: string | null
-        catalogueNumber?: string | null
-        itemUsage?: CodebookRef | null
-        conditionStatus?: CodebookRef | null
-        catalogueItem?: {
-            uid?: string | null
-            name?: string | null
-            catalogueNumber?: string | null
-        } | null
-    } | null
-}
+export type WizardContextSystem = Pick<SystemLeaf, 'uid' | 'name' | 'location' | 'physicalItem'>
 
 type ModalWizard = {
     open: boolean

--- a/src/modules/systemHierarchy/components/detail/ActionsDropdown.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/ActionsDropdown.comp.tsx
@@ -45,7 +45,10 @@ export const ActionsDropdown: FC<ActionsDropdownProps> = ({ system }) => {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" data-testid={`actions-${system.uid}`}>
                 {hasPhysicalItem && (
-                    <DropdownMenuItem className="cursor-pointer" onClick={openItemMoveModal}>
+                    <DropdownMenuItem
+                        className="cursor-pointer"
+                        onClick={() => openItemMoveModal(system)}
+                    >
                         <Move className="h-4 w-4 mr-2" />
                         {fm({ id: message.systemHierarchy.detail.moveItem })}
                     </DropdownMenuItem>
@@ -55,7 +58,10 @@ export const ActionsDropdown: FC<ActionsDropdownProps> = ({ system }) => {
                     {fm({ id: message.systemHierarchy.detail.assignSpares })}
                 </DropdownMenuItem>
                 {!hasPhysicalItem && (
-                    <DropdownMenuItem className="cursor-pointer" onClick={openItemAssignModal}>
+                    <DropdownMenuItem
+                        className="cursor-pointer"
+                        onClick={() => openItemAssignModal(system)}
+                    >
                         <Package className="h-4 w-4 mr-2" />
                         {fm({ id: message.systemHierarchy.detail.assignItem })}
                     </DropdownMenuItem>


### PR DESCRIPTION
## Problem
Move/assign wizard relied on deprecated `useSystemDetail` reading `router.query.uid`. On `/systems/hierarchy?leaf=<uid>` there is no `uid` param, so:
- payload was sent with `sourceSystemUid: ""` (backend error)
- Summary/System Detail steps had no prefill (serial number, EUN, part number, condition)
- same bug in assign flow (`destinationSystemUid: ""`)

Additionally the modal never closed after submit — `closeModal('item-move-wizard')` didn't match the actual modal id.

## Fix
- `openItemMoveModal(system)` / `openItemAssignModal(system)` now take a `WizardContextSystem` snapshot (uid, name, location, physicalItem) from the opener — synchronously available, no fetch, no race
- `useWizardContextSystem` resolves the wizard's context system from the snapshot; fetching by `router.query.uid` kept only as fallback for legacy `/system/[uid]` view
- fail-fast guard in `submitWizard` (toast instead of empty payload)
- `closeModal` id fixed (`item-move` / `item-assign` by move type)

## Tests
- new spec for `useWizardContextSystem` (snapshot path, catalogue normalization for both physicalItem shapes, legacy fallback)
- updated modal specs
- `tsc` + full jest suite green