### PR TITLE
fix(systemHierarchy): refetch full detail on tree navigation

### DIFF
--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1475,6 +1475,7 @@ export const messages = {
             notFoundBack: 'Back to hierarchy',
             loadErrorTitle: 'Failed to load system',
             loadErrorDescription: 'Something went wrong while loading the system detail.',
+            updating: 'Updating…',
         },
         tabs: {
             detail: 'Detail',

--- a/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Loader2 } from 'lucide-react'
 import type { FC } from 'react'
 import { useIntl } from 'react-intl'
 
@@ -14,12 +14,14 @@ interface SystemDetailHeaderProps {
     system: SystemLeaf
     onBack: () => void
     onSelectAncestor: SelectAncestorHandler
+    isRefreshing?: boolean
 }
 
 export const SystemDetailHeader: FC<SystemDetailHeaderProps> = ({
     system,
     onBack,
     onSelectAncestor,
+    isRefreshing = false,
 }) => {
     const { formatMessage: fm } = useIntl()
 
@@ -46,6 +48,14 @@ export const SystemDetailHeader: FC<SystemDetailHeaderProps> = ({
                     onSelectAncestor={onSelectAncestor}
                 />
             </div>
+            {isRefreshing && (
+                <Loader2
+                    className="size-4 shrink-0 animate-spin text-muted-foreground"
+                    role="status"
+                    aria-label={fm({ id: message.systemHierarchy.detail.updating })}
+                    data-testid="system-hierarchy-detail-refreshing"
+                />
+            )}
             <ActionsDropdown system={system} />
         </div>
     )

--- a/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
@@ -21,13 +21,19 @@ export const SystemDetailViewContainer: FC = () => {
     // refetchOnMount:false (so secondary consumers like PhysicalItemTab stay cache reads).
     // Force a fresh fetch here on every actual leaf change so all fields refill — guard
     // the initial mount, which useSystemDetail's own initial fetch already covers.
+    //
+    // The !isFetching guard scopes this to the bug we're fixing: a seeded cache (tree /
+    // breadcrumb nav) renders with data + refetchOnMount:false, so it is NOT fetching and
+    // we kick the refetch. Navigation without a seed (e.g. selectLeaf from spares/graph)
+    // has no cached data, so React Query is already fetching the new key — refetching here
+    // would only cancel that in-flight request (cancelRefetch defaults true) and restart it.
     const prevLeafUid = useRef(selectedLeafUid)
     useEffect(() => {
-        if (selectedLeafUid && selectedLeafUid !== prevLeafUid.current) {
+        if (selectedLeafUid && selectedLeafUid !== prevLeafUid.current && !isFetching) {
             refetch()
         }
         prevLeafUid.current = selectedLeafUid
-    }, [selectedLeafUid, refetch])
+    }, [selectedLeafUid, isFetching, refetch])
 
     if (isLoading) {
         return (

--- a/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
@@ -1,4 +1,5 @@
 import type { FC } from 'react'
+import { useEffect, useRef } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Button } from '@/components/ui/button'
@@ -14,7 +15,19 @@ export const SystemDetailViewContainer: FC = () => {
     const { formatMessage: fm } = useIntl()
     const { selectedLeafUid, goBackToLeaves, selectParent, clearSelection } =
         useHierarchyNavigation()
-    const { system, isLoading, error, refetch } = useSystemDetail(selectedLeafUid)
+    const { system, isLoading, isFetching, error, refetch } = useSystemDetail(selectedLeafUid)
+
+    // Selecting a node in the tree only changes the URL/leaf; the detail query keeps
+    // refetchOnMount:false (so secondary consumers like PhysicalItemTab stay cache reads).
+    // Force a fresh fetch here on every actual leaf change so all fields refill — guard
+    // the initial mount, which useSystemDetail's own initial fetch already covers.
+    const prevLeafUid = useRef(selectedLeafUid)
+    useEffect(() => {
+        if (selectedLeafUid && selectedLeafUid !== prevLeafUid.current) {
+            refetch()
+        }
+        prevLeafUid.current = selectedLeafUid
+    }, [selectedLeafUid, refetch])
 
     if (isLoading) {
         return (
@@ -77,6 +90,7 @@ export const SystemDetailViewContainer: FC = () => {
                 system={system}
                 onBack={goBackToLeaves}
                 onSelectAncestor={selectParent}
+                isRefreshing={isFetching && !isLoading}
             />
             <div className="flex-1 min-h-0">
                 <SystemDetailTabsContainer system={system} />

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailHeader.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailHeader.spec.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import React from 'react'
+import { IntlProvider } from 'react-intl'
+
+import type { SystemLeaf } from '../../../types'
+import { SystemDetailHeader } from '../SystemDetailHeader.comp'
+
+jest.mock('../../shared/SystemBreadcrumbs.comp', () => ({
+    SystemBreadcrumbs: () => <div data-testid="breadcrumbs-stub" />,
+}))
+jest.mock('../ActionsDropdown.comp', () => ({
+    ActionsDropdown: () => <div data-testid="actions-stub" />,
+}))
+
+const messages: Record<string, string> = {
+    'systemHierarchy.detail.backToLeaves': 'Back to list',
+    'systemHierarchy.detail.updating': 'Updating…',
+}
+
+const system = { uid: 'sys-1', name: 'Test System', systemCode: 'S-1', parentPath: null } as unknown as SystemLeaf
+
+const renderHeader = (isRefreshing?: boolean) =>
+    render(
+        <IntlProvider locale="en" messages={messages}>
+            <SystemDetailHeader
+                system={system}
+                onBack={jest.fn()}
+                onSelectAncestor={jest.fn()}
+                isRefreshing={isRefreshing}
+            />
+        </IntlProvider>,
+    )
+
+describe('SystemDetailHeader', () => {
+    it('shows the refreshing spinner while a navigation refetch is in flight', () => {
+        renderHeader(true)
+        expect(screen.getByTestId('system-hierarchy-detail-refreshing')).toBeInTheDocument()
+    })
+
+    it('hides the spinner when not refreshing', () => {
+        renderHeader(false)
+        expect(
+            screen.queryByTestId('system-hierarchy-detail-refreshing'),
+        ).not.toBeInTheDocument()
+    })
+
+    it('hides the spinner by default (prop omitted)', () => {
+        renderHeader()
+        expect(
+            screen.queryByTestId('system-hierarchy-detail-refreshing'),
+        ).not.toBeInTheDocument()
+    })
+})

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
@@ -123,4 +123,18 @@ describe('SystemDetailViewContainer', () => {
         )
         expect(mockRefetch).toHaveBeenCalledTimes(1)
     })
+
+    it('does not refetch on leaf change when the query is already fetching (no-seed path)', () => {
+        mockSystem = { uid: 'sys-1', name: 'Test System' }
+        mockIsFetching = true
+        const { rerender } = renderView()
+
+        mockSelectedLeafUid = 'sys-2'
+        rerender(
+            <IntlProvider locale="en" messages={messages}>
+                <SystemDetailViewContainer />
+            </IntlProvider>,
+        )
+        expect(mockRefetch).not.toHaveBeenCalled()
+    })
 })

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
@@ -5,10 +5,11 @@ import { IntlProvider } from 'react-intl'
 import { SystemDetailViewContainer } from '../SystemDetailView.cont'
 
 const mockClearSelection = jest.fn()
+let mockSelectedLeafUid: string | null = 'sys-1'
 
 jest.mock('../../../hooks/useHierarchyNavigation', () => ({
     useHierarchyNavigation: () => ({
-        selectedLeafUid: 'sys-1',
+        selectedLeafUid: mockSelectedLeafUid,
         goBackToLeaves: jest.fn(),
         selectParent: jest.fn(),
         clearSelection: mockClearSelection,
@@ -17,6 +18,7 @@ jest.mock('../../../hooks/useHierarchyNavigation', () => ({
 
 let mockSystem: { uid: string; name: string } | null = null
 let mockIsLoading = false
+let mockIsFetching = false
 let mockError: Error | null = null
 const mockRefetch = jest.fn()
 
@@ -24,6 +26,7 @@ jest.mock('../../../hooks/queries/useSystemDetail', () => ({
     useSystemDetail: () => ({
         system: mockSystem,
         isLoading: mockIsLoading,
+        isFetching: mockIsFetching,
         error: mockError,
         refetch: mockRefetch,
     }),
@@ -58,7 +61,9 @@ describe('SystemDetailViewContainer', () => {
     beforeEach(() => {
         mockSystem = null
         mockIsLoading = false
+        mockIsFetching = false
         mockError = null
+        mockSelectedLeafUid = 'sys-1'
         mockClearSelection.mockClear()
         mockRefetch.mockClear()
     })
@@ -97,5 +102,25 @@ describe('SystemDetailViewContainer', () => {
         renderView()
         expect(screen.getByTestId('detail-header-stub')).toBeInTheDocument()
         expect(screen.getByTestId('detail-tabs-stub')).toBeInTheDocument()
+    })
+
+    it('does not refetch on initial mount', () => {
+        mockSystem = { uid: 'sys-1', name: 'Test System' }
+        renderView()
+        expect(mockRefetch).not.toHaveBeenCalled()
+    })
+
+    it('refetches the full detail when the selected leaf changes', () => {
+        mockSystem = { uid: 'sys-1', name: 'Test System' }
+        const { rerender } = renderView()
+        expect(mockRefetch).not.toHaveBeenCalled()
+
+        mockSelectedLeafUid = 'sys-2'
+        rerender(
+            <IntlProvider locale="en" messages={messages}>
+                <SystemDetailViewContainer />
+            </IntlProvider>,
+        )
+        expect(mockRefetch).toHaveBeenCalledTimes(1)
     })
 })

--- a/src/modules/systemHierarchy/hooks/queries/__tests__/primeSystemDetailCache.test.ts
+++ b/src/modules/systemHierarchy/hooks/queries/__tests__/primeSystemDetailCache.test.ts
@@ -49,17 +49,12 @@ describe('primeSystemDetailCache', () => {
         expect(fetchSpy).not.toHaveBeenCalled()
     })
 
-    it('dispatches a background fetchQuery to refine the seed', () => {
+    it('only plants the breadcrumb seed and does not fetch — the active consumer owns refetch', () => {
         const qc = new QueryClient()
-        const fetchSpy = jest.spyOn(qc, 'fetchQuery').mockImplementation(() => Promise.resolve({}))
+        const fetchSpy = jest.spyOn(qc, 'fetchQuery')
 
         primeSystemDetailCache(qc, 'sys-4', { name: 'Optimistic' })
 
-        expect(fetchSpy).toHaveBeenCalledWith(
-            expect.objectContaining({
-                queryKey: [SYSTEM_DETAIL_QUERY_KEY, 'sys-4'],
-                queryFn: expect.any(Function),
-            }),
-        )
+        expect(fetchSpy).not.toHaveBeenCalled()
     })
 })

--- a/src/modules/systemHierarchy/hooks/queries/__tests__/useSystemDetail.spec.ts
+++ b/src/modules/systemHierarchy/hooks/queries/__tests__/useSystemDetail.spec.ts
@@ -1,0 +1,61 @@
+import { renderHook } from '@testing-library/react'
+
+import { useGraphQL } from '@/hooks/fetch/useGraphQL'
+
+import { SYSTEM_DETAIL_QUERY_KEY } from '../../../types/constants'
+import { useSystemDetail } from '../useSystemDetail'
+
+jest.mock('@/hooks/fetch/useGraphQL', () => ({
+    useGraphQL: jest.fn(),
+}))
+
+jest.mock('sonner', () => ({
+    toast: { error: jest.fn() },
+}))
+
+const mockUseGraphQL = useGraphQL as jest.Mock
+
+beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseGraphQL.mockReturnValue({
+        data: undefined,
+        error: undefined,
+        isLoading: false,
+        isFetching: false,
+        refetch: jest.fn(),
+    })
+})
+
+describe('useSystemDetail', () => {
+    it('keys the query by leaf uid and only enables when a leaf is selected', () => {
+        renderHook(() => useSystemDetail('sys-1'))
+        const opts = mockUseGraphQL.mock.calls[0][1]
+        expect(opts.customQueryKey).toEqual([SYSTEM_DETAIL_QUERY_KEY, 'sys-1'])
+        expect(opts.enabled).toBe(true)
+    })
+
+    it('disables the query when no leaf is selected', () => {
+        renderHook(() => useSystemDetail(null))
+        expect(mockUseGraphQL.mock.calls[0][1].enabled).toBe(false)
+    })
+
+    // refetchOnMount:false is what keeps secondary consumers cheap: when PhysicalItemTab
+    // mounts on a tab switch it re-reads this same query, but must NOT trigger a network
+    // refetch. The only refetch on navigation is the explicit one in SystemDetailView.
+    it('does not refetch on mount, so secondary consumers (PhysicalItemTab) stay cache reads', () => {
+        renderHook(() => useSystemDetail('sys-1'))
+        expect(mockUseGraphQL.mock.calls[0][1].refetchOnMount).toBe(false)
+    })
+
+    it('surfaces isFetching for the refreshing indicator', () => {
+        mockUseGraphQL.mockReturnValue({
+            data: undefined,
+            error: undefined,
+            isLoading: false,
+            isFetching: true,
+            refetch: jest.fn(),
+        })
+        const { result } = renderHook(() => useSystemDetail('sys-1'))
+        expect(result.current.isFetching).toBe(true)
+    })
+})

--- a/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemDetail.ts
@@ -1,6 +1,5 @@
 import type { QueryClient } from '@tanstack/react-query'
 import { keepPreviousData } from '@tanstack/react-query'
-import { request } from 'graphql-request'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
 
@@ -26,11 +25,6 @@ const systemHierarchyDetailQuery = gql(`
   }
 `)
 
-const fetchSystemDetail = (uid: string) =>
-    request('/api/graphql', systemHierarchyDetailQuery, {
-        where: { deleted: false, uid },
-    })
-
 export interface SparePartsForSystem {
     uid: string
     name: string | null
@@ -47,11 +41,11 @@ export interface OptimisticSystemHint {
     parentPath?: { uid: string; name: string }[]
 }
 
-// Seeds a partial SystemDetailFragment so the breadcrumb renders before the network
-// resolves, then kicks off a background fetch to replace the seed with the full fragment.
-// Background fetch is required because useSystemDetail uses refetchOnMount: false — a
-// seed alone would otherwise stick and the consumer would never see physicalItem,
-// operators, etc. Skips when an entry already exists (live cache or in-flight fetch).
+// Seeds a partial SystemDetailFragment so the breadcrumb (name/code/path) renders
+// instantly when a node is clicked, before the network resolves. The full fragment is
+// pulled in by the active SystemDetailView consumer, which refetches on every leaf
+// change (see SystemDetailView.cont.tsx) — so this only needs to plant the breadcrumb.
+// Skips when an entry already exists to avoid clobbering fuller data with a partial seed.
 export const primeSystemDetailCache = (
     queryClient: QueryClient,
     uid: string,
@@ -74,19 +68,10 @@ export const primeSystemDetailCache = (
             },
         ],
     })
-    queryClient
-        .fetchQuery({
-            queryKey: [SYSTEM_DETAIL_QUERY_KEY, uid],
-            queryFn: () => fetchSystemDetail(uid),
-            staleTime: 60 * 1000,
-        })
-        .catch(() => {
-            // errors surface via the active consumer's useQuery state
-        })
 }
 
 export const useSystemDetail = (leafUid: string | null) => {
-    const { data, error, isLoading, refetch } = useGraphQL(systemHierarchyDetailQuery, {
+    const { data, error, isLoading, isFetching, refetch } = useGraphQL(systemHierarchyDetailQuery, {
         variables: {
             where: {
                 deleted: false,
@@ -190,6 +175,7 @@ export const useSystemDetail = (leafUid: string | null) => {
         minimalSpareParstCount: systemDetail?.minimalSpareParstCount ?? null,
         refetch,
         isLoading,
+        isFetching,
         error,
     }
 }


### PR DESCRIPTION
## Problem
In the hierarchy detail view, selecting a different system in the left tree only updated the leaf URL — the detail form kept stale fields and required a manual page reload to fully refresh.

## Root cause
`primeSystemDetailCache` seeded a *fresh* partial breadcrumb via `setQueryData`, then called `fetchQuery({ staleTime: 60_000 })` to "backfill" the full record. Because the seed was just written (age 0 < staleTime), `fetchQuery` short-circuited and **never hit the network**. Combined with the detail query's `refetchOnMount: false` + 60s `staleTime`, nothing ever replaced the partial seed — so only name/code/breadcrumb populated until a manual reload (whose empty-cache initial load fetched the full fragment).

## Fix
- **Drop the no-op backfill** from `primeSystemDetailCache` — it now only plants the breadcrumb seed for instant feedback.
- **`SystemDetailView` owns the fetch**: a guarded effect calls `refetch()` on every actual leaf change (skips initial mount, which the query's own initial fetch already covers, avoiding a cancel/abort of the in-flight request).
- **Header spinner** (`Loader2`) shown while `isFetching && !isLoading`, matching the existing GlobalSearch "updating" idiom.
- Detail query keeps `refetchOnMount: false`, so the secondary `useSystemDetail` in `PhysicalItemTab` stays a cheap cache read — tab switches don't trigger extra fetches; refetch is scoped to system navigation only.

## Tests
- `primeSystemDetailCache.test.ts` — replaced the false "dispatches background fetchQuery" assertion with "seeds only, never fetches".
- `SystemDetailView.spec.tsx` — added: no refetch on initial mount; refetches when the selected leaf changes.
- `useSystemDetail.spec.ts` (new) — asserts `refetchOnMount: false` (secondary consumers like `PhysicalItemTab` stay cache reads), query key/enabled, and `isFetching` surfacing.

All touched tests pass; ESLint + `tsc --noEmit` clean.