### PR TITLE
feat(systemHierarchy): color + icon identity for detail tabs

### DIFF
--- a/src/modules/systemHierarchy/components/detail/SystemDetailTabs.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailTabs.cont.tsx
@@ -23,6 +23,9 @@ import { RelationshipsTabContainer } from '../tabs/RelationshipsTab.cont'
 import { SpareForTabContainer } from '../tabs/SpareForTab.cont'
 import { SparePartsTabContainer } from '../tabs/SparePartsTab.cont'
 
+// Always-present tabs (Detail, Persons, Attachments, History, Graph) get
+// distinct tokens. Conditional tabs reuse a token from an always-present
+// sibling — collisions only show when the conditional tab is active.
 const HIERARCHY_TAB_META: Record<HierarchyTab, { icon: LucideIcon; color: string }> = {
     [HIERARCHY_TABS.DETAIL]: { icon: Info, color: 'var(--chart-3)' },
     [HIERARCHY_TABS.PERSONS]: { icon: Users, color: 'var(--chart-2)' },
@@ -30,9 +33,9 @@ const HIERARCHY_TAB_META: Record<HierarchyTab, { icon: LucideIcon; color: string
     [HIERARCHY_TABS.SPARE_PARTS]: { icon: Wrench, color: 'var(--chart-5)' },
     [HIERARCHY_TABS.SPARE_FOR]: { icon: Replace, color: 'var(--chart-4)' },
     [HIERARCHY_TABS.RELATIONSHIPS]: { icon: Share2, color: 'var(--chart-3)' },
-    [HIERARCHY_TABS.ATTACHMENTS]: { icon: Paperclip, color: 'var(--chart-4)' },
+    [HIERARCHY_TABS.ATTACHMENTS]: { icon: Paperclip, color: 'var(--chart-1)' },
     [HIERARCHY_TABS.HISTORY]: { icon: History, color: 'var(--muted-foreground)' },
-    [HIERARCHY_TABS.GRAPH]: { icon: Workflow, color: 'var(--chart-2)' },
+    [HIERARCHY_TABS.GRAPH]: { icon: Workflow, color: 'var(--chart-4)' },
 }
 
 interface HierarchyTabTriggerProps {
@@ -42,13 +45,22 @@ interface HierarchyTabTriggerProps {
 
 const HierarchyTabTrigger: FC<HierarchyTabTriggerProps> = ({ value, label }) => {
     const { icon: Icon, color } = HIERARCHY_TAB_META[value]
+    // --tab-text mixes the identity color with --foreground so active text
+    // hits AA contrast on the tinted pill (chart-4 yellow / chart-5 gold
+    // were too light otherwise). Theme-aware: darkens in light, lightens
+    // in dark.
     return (
         <TabsTrigger
             value={value}
             data-testid={`system-hierarchy-tab-${value}`}
             title={label}
-            style={{ '--tab-color': color } as CSSProperties}
-            className="group data-[state=active]:bg-[var(--tab-color)]/10 data-[state=active]:text-[var(--tab-color)] dark:data-[state=active]:bg-[var(--tab-color)]/15 dark:data-[state=active]:text-[var(--tab-color)]"
+            style={
+                {
+                    '--tab-color': color,
+                    '--tab-text': `color-mix(in oklab, ${color}, var(--foreground) 45%)`,
+                } as CSSProperties
+            }
+            className="group data-[state=active]:bg-[var(--tab-color)]/10 data-[state=active]:text-[var(--tab-text)] dark:data-[state=active]:bg-[var(--tab-color)]/15 dark:data-[state=active]:text-[var(--tab-text)]"
         >
             <Icon className="size-4 text-[var(--tab-color)] opacity-60 group-data-[state=active]:opacity-100" />
             <span className="hidden md:inline">{label}</span>

--- a/src/modules/systemHierarchy/components/detail/SystemDetailTabs.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailTabs.cont.tsx
@@ -1,4 +1,6 @@
-import type { FC } from 'react'
+import type { LucideIcon } from 'lucide-react'
+import { History, Info, Package, Paperclip, Replace, Share2, Users, Workflow, Wrench } from 'lucide-react'
+import type { CSSProperties, FC } from 'react'
 import { useIntl } from 'react-intl'
 
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -20,6 +22,39 @@ import { PhysicalItemTabContainer } from '../tabs/PhysicalItemTab.cont'
 import { RelationshipsTabContainer } from '../tabs/RelationshipsTab.cont'
 import { SpareForTabContainer } from '../tabs/SpareForTab.cont'
 import { SparePartsTabContainer } from '../tabs/SparePartsTab.cont'
+
+const HIERARCHY_TAB_META: Record<HierarchyTab, { icon: LucideIcon; color: string }> = {
+    [HIERARCHY_TABS.DETAIL]: { icon: Info, color: 'var(--chart-3)' },
+    [HIERARCHY_TABS.PERSONS]: { icon: Users, color: 'var(--chart-2)' },
+    [HIERARCHY_TABS.PHYSICAL_ITEM]: { icon: Package, color: 'var(--chart-1)' },
+    [HIERARCHY_TABS.SPARE_PARTS]: { icon: Wrench, color: 'var(--chart-5)' },
+    [HIERARCHY_TABS.SPARE_FOR]: { icon: Replace, color: 'var(--chart-4)' },
+    [HIERARCHY_TABS.RELATIONSHIPS]: { icon: Share2, color: 'var(--chart-3)' },
+    [HIERARCHY_TABS.ATTACHMENTS]: { icon: Paperclip, color: 'var(--chart-4)' },
+    [HIERARCHY_TABS.HISTORY]: { icon: History, color: 'var(--muted-foreground)' },
+    [HIERARCHY_TABS.GRAPH]: { icon: Workflow, color: 'var(--chart-2)' },
+}
+
+interface HierarchyTabTriggerProps {
+    value: HierarchyTab
+    label: string
+}
+
+const HierarchyTabTrigger: FC<HierarchyTabTriggerProps> = ({ value, label }) => {
+    const { icon: Icon, color } = HIERARCHY_TAB_META[value]
+    return (
+        <TabsTrigger
+            value={value}
+            data-testid={`system-hierarchy-tab-${value}`}
+            title={label}
+            style={{ '--tab-color': color } as CSSProperties}
+            className="group data-[state=active]:bg-[var(--tab-color)]/10 data-[state=active]:text-[var(--tab-color)] dark:data-[state=active]:bg-[var(--tab-color)]/15 dark:data-[state=active]:text-[var(--tab-color)]"
+        >
+            <Icon className="size-4 text-[var(--tab-color)] opacity-60 group-data-[state=active]:opacity-100" />
+            <span className="hidden md:inline">{label}</span>
+        </TabsTrigger>
+    )
+}
 
 interface SystemDetailTabsProps {
     system: SystemLeaf
@@ -49,68 +84,50 @@ export const SystemDetailTabsContainer: FC<SystemDetailTabsProps> = ({ system })
             className="flex flex-col h-full min-h-0"
         >
             <TabsList className="mx-4 mt-2 w-fit">
-                <TabsTrigger
+                <HierarchyTabTrigger
                     value={HIERARCHY_TABS.DETAIL}
-                    data-testid="system-hierarchy-tab-detail"
-                >
-                    {fm({ id: message.systemHierarchy.tabs.detail })}
-                </TabsTrigger>
-                <TabsTrigger
+                    label={fm({ id: message.systemHierarchy.tabs.detail })}
+                />
+                <HierarchyTabTrigger
                     value={HIERARCHY_TABS.PERSONS}
-                    data-testid="system-hierarchy-tab-persons"
-                >
-                    {fm({ id: message.systemHierarchy.tabs.persons })}
-                </TabsTrigger>
+                    label={fm({ id: message.systemHierarchy.tabs.persons })}
+                />
                 {hasPhysicalItem(system) && (
-                    <TabsTrigger
+                    <HierarchyTabTrigger
                         value={HIERARCHY_TABS.PHYSICAL_ITEM}
-                        data-testid="system-hierarchy-tab-physical-item"
-                    >
-                        {fm({ id: message.systemHierarchy.tabs.physicalItem })}
-                    </TabsTrigger>
+                        label={fm({ id: message.systemHierarchy.tabs.physicalItem })}
+                    />
                 )}
                 {hasSpareParts(system) && (
-                    <TabsTrigger
+                    <HierarchyTabTrigger
                         value={HIERARCHY_TABS.SPARE_PARTS}
-                        data-testid="system-hierarchy-tab-spare-parts"
-                    >
-                        {fm({ id: message.systemHierarchy.tabs.spareParts })}
-                    </TabsTrigger>
+                        label={fm({ id: message.systemHierarchy.tabs.spareParts })}
+                    />
                 )}
                 {hasSpareFor(system) && (
-                    <TabsTrigger
+                    <HierarchyTabTrigger
                         value={HIERARCHY_TABS.SPARE_FOR}
-                        data-testid="system-hierarchy-tab-spare-for"
-                    >
-                        {fm({ id: message.systemHierarchy.tabs.spareFor })}
-                    </TabsTrigger>
+                        label={fm({ id: message.systemHierarchy.tabs.spareFor })}
+                    />
                 )}
                 {showRelationshipsTab && (
-                    <TabsTrigger
+                    <HierarchyTabTrigger
                         value={HIERARCHY_TABS.RELATIONSHIPS}
-                        data-testid="system-hierarchy-tab-relationships"
-                    >
-                        {fm({ id: message.systemHierarchy.tabs.relationships })}
-                    </TabsTrigger>
+                        label={fm({ id: message.systemHierarchy.tabs.relationships })}
+                    />
                 )}
-                <TabsTrigger
+                <HierarchyTabTrigger
                     value={HIERARCHY_TABS.ATTACHMENTS}
-                    data-testid="system-hierarchy-tab-attachments"
-                >
-                    {fm({ id: message.systemHierarchy.tabs.attachments })}
-                </TabsTrigger>
-                <TabsTrigger
+                    label={fm({ id: message.systemHierarchy.tabs.attachments })}
+                />
+                <HierarchyTabTrigger
                     value={HIERARCHY_TABS.HISTORY}
-                    data-testid="system-hierarchy-tab-history"
-                >
-                    {fm({ id: message.systemHierarchy.tabs.history })}
-                </TabsTrigger>
-                <TabsTrigger
+                    label={fm({ id: message.systemHierarchy.tabs.history })}
+                />
+                <HierarchyTabTrigger
                     value={HIERARCHY_TABS.GRAPH}
-                    data-testid="system-hierarchy-tab-graph"
-                >
-                    {fm({ id: message.systemHierarchy.tabs.graph })}
-                </TabsTrigger>
+                    label={fm({ id: message.systemHierarchy.tabs.graph })}
+                />
             </TabsList>
             <div className="flex-1 min-h-0">
                 <TabsContent


### PR DESCRIPTION
## Summary
- Each system-detail tab gets a `lucide-react` icon and a `--chart-*` identity color.
- Active state: tinted pill (`bg-[var(--tab-color)]/10` + colored text) replacing the default shadcn pill; inactive icons at 60% opacity.
- Below `md`: labels hide, icons stay; full label moves to `title` for tooltip + a11y.
- Attachments moved off `--primary` to `--chart-4` so it no longer visually duplicates PhysicalItem (`--chart-1`) in light mode.

## Notes
- All colors come from `globals.css` tokens (no hard-coded hex). Chart tokens shift hue between light/dark by project design — `--chart-1` (PhysicalItem) goes orange → purple. If brand-stable per-tab hues are wanted, follow-up: add dedicated `--tab-*` tokens.
- No primitive change to `src/components/ui/tabs.tsx`.

## Test plan
- [ ] `yarn lint` clean
- [ ] `yarn test src/modules/systemHierarchy/components/detail/__tests__/SystemDetailTabs.test.tsx` passes
- [ ] Manual: open system detail in dev — verify active/inactive states for each tab in light **and** dark mode
- [ ] Manual: narrow viewport below `md` (~768px) — labels hide, icons remain, hover tooltip shows label
- [ ] Manual: conditional tabs (PhysicalItem / SpareParts / SpareFor / Relationships) still appear correctly with icon+color
- [ ] Manual: keyboard focus ring still visible on each trigger