### PR TITLE
feat(systemHierarchy): per-system edit permission guard

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -25,6 +25,7 @@ When you sharpen a term during a design conversation, update both this file and 
 - **Form Wizard V3** — multi-step RHF wizard in `src/modules/shared/form/wizardV3`. See the `wizard` skill.
 - **`@authorization` directive** — per-entity JWT-gated rule in the GraphQL schema. See [`permissions-model.md`](./technical/permissions-model.md).
 - **JWT role** — string entry in `session.user.roles` (e.g. `systems-view`, `systems-edit`, `admin`). See [`permissions-model.md`](./technical/permissions-model.md).
+- **Per-system edit responsibility** — beyond the `systems-edit` role, may-edit-*this*-system check (direct responsible / `responsibleTeam` / ancestor). Backend `GET /system/{uid}/can-edit`; frontend `useSystemEditPermission`. See [`permissions-model.md`](./technical/permissions-model.md#per-system-edit-responsibility).
 - **Codebook** — generic admin-managed reference list (`CODEBOOK` enum). See [`codebooks.md`](./technical/codebooks.md).
 
 ### Systems family
@@ -78,7 +79,7 @@ When you sharpen a term during a design conversation, update both this file and 
 
 - **User** — `User` node with row-level `@authorization`. See [`administration.md`](./technical/administration.md).
 - **Role** — see *JWT role* above.
-- **Responsible team** — policy-only today; not yet enforced in code.
+- **Responsible team** — a `System`'s `responsibleTeam`. Now enforced for system edits (backend REST 403 + frontend guard) via [*Per-system edit responsibility*](#per-system-edit-responsibility); still policy-only at the GraphQL schema layer.
 
 ## See also
 

--- a/docs/technical/permissions-model.md
+++ b/docs/technical/permissions-model.md
@@ -4,7 +4,7 @@ How ELI PANDA expresses, stores, and enforces user permissions today, and the pl
 
 ## Overview
 
-Permissions are **flat, role-based, and JWT-carried**. A user has a set of role codes; each route, GraphQL operation, and UI control checks "does the user hold *any* of these roles?". There is no inheritance, no per-resource ACL, and (today) no team-scoped enforcement — the latter is policy-only and tracked under [🔮 Planned](#-planned).
+Permissions are **flat, role-based, and JWT-carried**. A user has a set of role codes; each route, GraphQL operation, and UI control checks "does the user hold *any* of these roles?". There is no inheritance and no per-resource ACL in the GraphQL schema. The one exception now live is **[per-system edit responsibility](#per-system-edit-responsibility)** — a per-resource + team-scoped check the backend enforces on its REST endpoints and the `systemHierarchy` module enforces on the client; broader team-scoped enforcement remains policy-only and is tracked under [🔮 Planned](#-planned).
 
 Authorization is enforced in **four** independent layers:
 
@@ -310,6 +310,20 @@ The hook is wrapped in `useMemo`, so the returned value is stable across renders
 
 Sidebar visibility and the middleware route gate are **not** kept in sync automatically. If a `NAV_ITEMS` entry's role differs from the corresponding `PATH_ROLES_CONFIG` entry, a user can see the sidebar item and click it only to bounce to `/404`. See [Maintenance recommendations](#maintenance-recommendations).
 
+## Per-system edit responsibility
+
+A first step beyond the flat role model — and toward [Phase 2](#phase-2--team-based-scoping) — is now live for **systems**. `systems-edit` still answers "may edit systems at all"; a second, per-resource check answers "may edit *this* system": the user must be responsible for it directly, via its `responsibleTeam`, or via any ancestor up the `HAS_SUBSYSTEM` chain.
+
+The backend owns the decision and exposes it as a REST read, and enforces it (403) on its mutating REST endpoints:
+
+```
+GET /system/{uid}/can-edit → { result: boolean, responsibles: User[] }
+```
+
+`result` folds in the role check (a non-`systems-edit` user gets `false`); `responsibles` is deduped across the system + ancestors so the UI can name who to contact.
+
+**Enforcement gap this closes.** `System.@authorization` (Layer 2) gates GraphQL by role only — it has no per-resource predicate — and the `systemHierarchy` module mutates via GraphQL (`updateSystems`, `updateItems`, `createSystems`), which the backend's REST 403 does **not** cover. So the frontend enforces per-system responsibility on the client for that module: it fetches `can-edit`, disables every editable surface when denied, and **hard-guards** the mutation hooks (`guardSystemEdit` before `mutateAsync`) so an unpermitted GraphQL patch cannot fire. This is client-side enforcement standing in until those mutations migrate to guarded REST PATCH endpoints — it is not a substitute for schema-level authorization. Engineering detail: [System Hierarchy → Per-system edit permission](./systems-family/system-hierarchy.md#per-system-edit-permission).
+
 ## Audit trail
 
 Every entity that needs change history points at `User` via the `WAS_UPDATED_BY` relationship:
@@ -395,9 +409,9 @@ Implementation sketch: add a `where: { node: { systemLevel_IN: [...] } }` clause
 
 ### Phase 2 — team-based scoping
 
-> Today this is policy only — please follow it manually.
+> Partially live: the backend now enforces per-system edit responsibility (direct responsible, `responsibleTeam`, or an ancestor's) on its **REST** endpoints, and the `systemHierarchy` module enforces it client-side for its GraphQL mutations — see [Per-system edit responsibility](#per-system-edit-responsibility). What remains below is folding the same rule into `@neo4j/graphql` `@authorization` so raw GraphQL is gated too.
 
-Each system already carries `responsibleTeam: Team @relationship(type: "HAS_RESPONSIBLE_TEAM")`. Phase 2 enforcement needs:
+Each system already carries `responsibleTeam: Team @relationship(type: "HAS_RESPONSIBLE_TEAM")`. Phase 2 schema-level enforcement needs:
 
 - A `User`→`Team` (or `Employee`→`Team`) relationship — the schema does **not** have one today. `Employee.user` exists but no `Team` membership edge does.
 - The JWT carrying the user's team UIDs alongside `roles`.

--- a/docs/technical/systems-family/system-hierarchy.md
+++ b/docs/technical/systems-family/system-hierarchy.md
@@ -250,7 +250,9 @@ Consumers call `useSystemEditPermission(system.uid)` directly rather than sharin
 
 ### Out of scope (phase 1)
 
-Spare-parts / spare-for / relationships tabs stay on the coarse `SYSTEM_EDIT` role gate — spare-assign is a REST endpoint the backend already 403-guards, and functional relationships (everything except `HAS_SUBSYSTEM` creation, which routes through Create Subsystem) are on the backend's *not-guarded* list. System **move** relies on its existing backend 403.
+The **Spare Parts / Spare For / Relationships tabs** stay on the coarse `SYSTEM_EDIT` role gate — spare-assign is a REST endpoint the backend already 403-guards, and functional relationships (everything except `HAS_SUBSYSTEM` creation, which routes through Create Subsystem) are on the backend's *not-guarded* list. System **move** relies on its existing backend 403.
+
+Note this is about the *tabs*. The detail-header **`ActionsDropdown`** (which includes an *Assign Spares* entry that merely navigates to the spare-assignment view) is a detail action and *is* per-system gated — a deliberate, safe over-restriction: the backend 403s the actual assign anyway, and an admin gets `result: true`, so no legitimate action is lost.
 
 ## Deep links & URL contract
 

--- a/docs/technical/systems-family/system-hierarchy.md
+++ b/docs/technical/systems-family/system-hierarchy.md
@@ -92,8 +92,8 @@ The leaves panel toggles between **Tree View** (the default `LeavesTable`) and *
 
 | Hook | Operation |
 |---|---|
-| `useSystemFieldUpdate` | PATCH a single field on a `System` — used by inline edit. Calls `updatedByResolver` for audit. |
-| `useItemFieldUpdate` | PATCH a single field on the attached `Item` (serial, usage, condition, notes). Takes `(systemUid, currentItem)`. Records the `WAS_UPDATED_BY` edge on the **owning System node** (not the Item) — same as `systemItem` — so item edits surface in the system's History tab. Builds change entries via `utils/fieldChangeBuilder` and passes them as `updatedByResolver(changes)`; on success invalidates `SYSTEM_DETAIL_QUERY_KEY` + `['history']`. |
+| `useSystemFieldUpdate` | PATCH a single field on a `System` — used by inline edit. Calls `updatedByResolver` for audit. Hard-guards on `guardSystemEdit` before mutating and invalidates `['systemCanEdit']` after a responsible/team change — see [Per-system edit permission](#per-system-edit-permission). |
+| `useItemFieldUpdate` | PATCH a single field on the attached `Item` (serial, usage, condition, notes). Takes `(systemUid, currentItem)`. Records the `WAS_UPDATED_BY` edge on the **owning System node** (not the Item) — same as `systemItem` — so item edits surface in the system's History tab. Builds change entries via `utils/fieldChangeBuilder` and passes them as `updatedByResolver(changes)`; on success invalidates `SYSTEM_DETAIL_QUERY_KEY` + `['history']`. Hard-guards on `guardSystemEdit` (against the owning system) before mutating. |
 | `useSystemCopy` | Calls REST endpoint `system/<uid>/copy` — server orchestrates the recursive copy |
 | `useCreateSubsystem` | `mutation CreateSystems` via `useGraphQLMutation`. Payload assembled by the pure `utils/buildCreateSubsystemPayload`, including `parentSystem.connect`, parent-inherited `responsible/location/zone`, and the required `updatedBy.connect[edge.action=Insert]` so `updatedByResolver` writes a history edge. On success seeds `[SYSTEM_DETAIL_QUERY_KEY, newUid]` with the full SystemDetail fragment returned by the server, then invalidates `HIERARCHY`, `LEAVES`, `LEAVES_COUNT`, and `RELATIONSHIP_GRAPH` keys. |
 | `useDeleteSystem` | `queryMutate('system', 'delete', { uid })` — REST `DELETE /system/{uid}` (soft + recursive: `deleted=true` on the system and every subsystem). `onSuccess` stays **synchronous** so the delete resolves immediately: fires an instant invalidate of `HIERARCHY`, `LEAVES`, `LEAVES_COUNT`, `RELATIONSHIP_GRAPH`, then a background `recalculateSpareParts` POST that triggers a **second** invalidate on success (`.catch` swallows recalc failure so it can't mask the delete). UX orchestration (confirm, toast, 409, selection reset) lives in `useDeleteSystemAction` — see [Delete System](#delete-system). |
@@ -179,7 +179,7 @@ Override semantics come entirely from `useItemPropertiesData`: service items are
 
 User-facing companion: [Creating systems](../../user-guide/systemHierarchy/workflows/creating-systems.md).
 
-The right-click context menu on a tree node offers **Create System** alongside Copy / Paste. The orchestrator is `hooks/useCreateSubsystemAction.ts` — it mirrors `useSystemCopyPaste`: gated by `usePermission([ROLE.SYSTEM_EDIT])`, opens `CreateSubsystemDialog` through `useDynamicModalStore` with a stable id `create-subsystem-${parentUid}`.
+The right-click context menu on a tree node offers **Create System** alongside Copy / Paste. The orchestrator is `hooks/useCreateSubsystemAction.ts` — it mirrors `useSystemCopyPaste`: gated by `usePermission([ROLE.SYSTEM_EDIT])` (first-line filter) plus a per-system `guardSystemEdit` check-on-click against the **parent** uid ([Per-system edit permission](#per-system-edit-permission)), then opens `CreateSubsystemDialog` through `useDynamicModalStore` with a stable id `create-subsystem-${parentUid}`.
 
 Parent → allowed-child rules are a pure lookup table in `utils/systemLevelRules.ts`:
 
@@ -205,7 +205,7 @@ User-facing companion: [Deleting systems](../../user-guide/systemHierarchy/workf
 
 Right-click **Delete System** is available on all three system surfaces — tree node (`TreeNode`), leaves table row (`LeavesTable`), and graph node (`SystemNode`). All three call a single orchestrator, `hooks/useDeleteSystemAction.ts`, layered on the `useDeleteSystem` mutation. It returns `{ canEdit, handleDeleteSystem, isPending }`:
 
-- **Permission** — `usePermission([ROLE.SYSTEM_EDIT])`. `handleDeleteSystem` also re-checks `!canEdit || isPending` so an in-flight delete can't be re-fired. The guard is per hook-instance — only one context menu is open at a time, so that's the only reachable double-fire path.
+- **Permission** — `usePermission([ROLE.SYSTEM_EDIT])`. `handleDeleteSystem` also re-checks `!canEdit || isPending` so an in-flight delete can't be re-fired, then runs a per-system `guardSystemEdit` check-on-click against the target uid before the confirm ([Per-system edit permission](#per-system-edit-permission)) — belt-and-suspenders with the backend's own 403 on `DELETE /system/{uid}`. The guard is per hook-instance — only one context menu is open at a time, so that's the only reachable double-fire path.
 - **Confirm** — wraps the mutation in `useWarningModal` with recursive wording (`systemHierarchy.delete.confirm` — "…and all its sub-systems"). The backend delete is recursive + soft, so the wording holds even for childless rows.
 - **Feedback** — `toast.promise` (loading / success / error). On HTTP **409** the backend returns the blocking physical items as a bare `SystemPhysicalItemInfo[]` (read from `err.response.data`); the toast lists up to `MAX_LISTED_ITEMS = 3` item names with a locale-neutral `(+N)` overflow, and falls back to a generic message when the body is empty/unparseable.
 - **Selection reset** — on success, `isOpenOrAncestor(uid)` decides whether to call `clearSelection()` (new `useHierarchyNavigation` action that drops `parent`/`leaf`/`tab` from the URL). It returns true when the deleted uid is the open leaf or selected parent, an **ancestor of the open leaf** (via `useSystemDetail(selectedLeafUid).parentPath` — the leaf can be opened with a stale `parent`), or an **ancestor of the selected parent** (via `findHierarchyPath(nodes, selectedParentUid)`). This stops the detail panel pointing at a node the recursive delete just removed.
@@ -213,6 +213,44 @@ Right-click **Delete System** is available on all three system surfaces — tree
 Gating convention matches Copy/Paste/Create: tree + table **render the item `disabled`** when `!canEdit`; the graph **omits** it (`useRelationshipGraphContainerState` passes `onDeleteSystem` only when `canEdit`). The graph callback is threaded node-ward through `useRelationshipGraphFlow` → `utils/graphTransformers`, the same path as `onCopySystem`.
 
 `LeavesTable` wraps its content in a Radix `ContextMenu` **only when `onDeleteSystem` is provided** (otherwise the trigger would suppress the native right-click menu with nothing to show). The right-clicked row is captured by a capture-phase reset on the wrapper (clears the target) plus a bubble-phase `onContextMenu` per row (re-sets it) — so right-clicking empty table area leaves the item disabled.
+
+## Per-system edit permission
+
+User-facing companion: [Understanding edit permissions](../../user-guide/systemHierarchy/workflows/edit-permissions.md). Cross-cutting model: [Permissions model → per-system edit](../permissions-model.md#per-system-edit-responsibility).
+
+`ROLE.SYSTEM_EDIT` (the coarse gate above) answers "may this user edit *systems at all*". A second, finer check answers "may they edit *this* system" — a user may edit only if they are responsible for it directly, via its `responsibleTeam`, or via any ancestor up the `HAS_SUBSYSTEM` chain. The backend owns that decision and exposes it as a REST read:
+
+```
+GET /system/{uid}/can-edit → { result: boolean, responsibles: User[] }
+```
+
+`result` already folds in the role check (a non-`systems-edit` user gets `false`); `responsibles` is always returned (deduped across the system + ancestors) so the UI can point a blocked user at someone.
+
+Why the frontend enforces it at all: the backend guards its **REST** mutating endpoints with a 403, but this module mutates via **GraphQL** (`updateSystems`, `updateItems`, `createSystems`), which `System.@authorization` gates by role only — not per-system. So until those mutations migrate to guarded REST PATCH endpoints, the client must block the GraphQL patch path itself.
+
+### Surface
+
+| File | Role |
+|---|---|
+| `hooks/queries/useSystemCanEdit.ts` | `useSystemCanEdit(uid)` — `queryFetcher('systemCanEdit')` (REST), key `['systemCanEdit', { uid }]`, `staleTime: 0`. Also exports `ensureSystemCanEdit(qc, uid)` (imperative, shared cache) and `SYSTEM_CAN_EDIT_QUERY_KEY`. |
+| `hooks/useSystemEditPermission.ts` | The single decision point. Wraps `useSystemCanEdit` and derives `{ canEdit, responsibles, status, refetch }`. **Fail-closed**: `canEdit` is `true` only when `status === 'allowed'` — `false` while `loading` and on `error`, so an un-verifiable state never leaves editing open. Also exports `formatResponsibleName`. |
+| `utils/guardSystemEdit.ts` | `guardSystemEdit(qc, uid, fm)` — imperative gate for mutation hooks and check-on-click actions. Reads `ensureSystemCanEdit`, and on denial (or verification failure — fail-closed) toasts the responsibles and returns `false`. |
+| `components/detail/SystemEditRestrictionBanner.comp.tsx` | Banner under `SystemDetailHeader`. `denied` → lists responsibles (name + email, Info-tooltip); `error` → a **distinct** "couldn't verify — Retry" state (never the not-responsible copy, which would misattribute a network fault); `loading`/`allowed` → renders nothing. |
+
+Consumers call `useSystemEditPermission(system.uid)` directly rather than sharing a React context — React Query dedups by uid, and the same `system.uid` is read from both the detail-view tree and the separate sidebar tree (`SystemImagePanel`), which a single provider couldn't cover.
+
+### Enforcement (defense-in-depth)
+
+- **UI disable** — every editable detail surface takes `disabled={!canEdit}`: all `DetailTab` fields (incl. the system-code row + `SystemCodeActions`), `PersonsTab` responsible/team + both `EmployeeAssignmentTable`s, `PhysicalItemTab` fields, `AttachmentsTab` (`FileManager hasEditRole={canEdit}`), `SystemImagePanel` (`usePermission([SYSTEM_EDIT]) && canEdit`), and the `ActionsDropdown` items.
+- **Hard guard in the mutation hooks** — `useSystemFieldUpdate` and `useItemFieldUpdate` `await guardSystemEdit(...)` before `mutateAsync` and abort if denied, so an unpermitted GraphQL patch can't fire even if the UI is bypassed. `useItemFieldUpdate` checks the **owning system** uid, not the item.
+- **Self-lockout** — after a `responsibleUid`/`responsibleTeamUid` save, `useSystemFieldUpdate` invalidates `['systemCanEdit']`; if the user reassigned responsibility away from themselves, the controls re-disable without a reload (mirrors what the backend will enforce).
+- **Check-on-click for imperative actions** — `useCreateSubsystemAction` (against the **parent** uid) and `useDeleteSystemAction` (against the **target** uid) keep the coarse role check as a cheap first-line filter, then `await guardSystemEdit(...)` before opening the dialog / confirm; on denial they toast the responsibles and return. This avoids an N-node prefetch across the tree.
+
+`EmployeeAssignmentTable` (shared, `src/modules/shared/system/employee-assignment/`) gained an optional `canEdit?: boolean` prop that ANDs with its internal `SYSTEM_EDIT` role check (defaults to `true`, so other callers are unaffected).
+
+### Out of scope (phase 1)
+
+Spare-parts / spare-for / relationships tabs stay on the coarse `SYSTEM_EDIT` role gate — spare-assign is a REST endpoint the backend already 403-guards, and functional relationships (everything except `HAS_SUBSYSTEM` creation, which routes through Create Subsystem) are on the backend's *not-guarded* list. System **move** relies on its existing backend 403.
 
 ## Deep links & URL contract
 
@@ -305,9 +343,10 @@ Unit coverage under `__tests__/` is heaviest in:
 - `types/__tests__/` — schema parsing.
 - `utils/__tests__/` — tree search, graph layout, filter predicates, change-builder, **parent→child level rules** (`systemLevelRules.spec.ts`), **create-subsystem payload builder** (`buildCreateSubsystemPayload.spec.ts` — locks the `updatedBy[Insert]` audit edge).
 - `hooks/queries/__tests__/` — `primeSystemDetailCache.test.ts` (the contract above), `useSystemLeaves.test.ts`, `useSystemLeavesCount.test.ts`.
-- `hooks/mutations/__tests__/` — `useSystemFieldUpdate.spec.ts`, `useItemFieldUpdate.spec.ts` (locks the System-node `WAS_UPDATED_BY` edge + change entries for item edits), `useDeleteSystem.spec.ts` (immediate invalidate + background recalc → second invalidate; recalc failure keeps only the immediate round).
+- `hooks/mutations/__tests__/` — `useSystemFieldUpdate.spec.ts` (also: guard blocks the patch when denied, `['systemCanEdit']` invalidated after a responsible change), `useItemFieldUpdate.spec.ts` (locks the System-node `WAS_UPDATED_BY` edge + change entries for item edits; guard checks the owning system), `useDeleteSystem.spec.ts` (immediate invalidate + background recalc → second invalidate; recalc failure keeps only the immediate round).
+- **Per-system permission** — `hooks/__tests__/useSystemEditPermission.spec.ts` (fail-closed derivation for loading/error/allowed/denied + `formatResponsibleName`), `utils/__tests__/guardSystemEdit.spec.ts` (allow / deny-with-toast / no-responsibles / fail-closed-on-throw), `components/detail/__tests__/SystemEditRestrictionBanner.spec.tsx` (denied lists responsibles, distinct verify-error + retry, nothing while loading/allowed).
 - `hooks/__tests__/useHierarchyDeepLinkResolver.spec.tsx` — parent resolution from `parentPath`, root parent==leaf case, stale-uid guard, single-replace idempotency, re-resolution after the URL settles; `utils/__tests__/hierarchyLinks.spec.ts` — deep-link shape + encoding; `components/detail/__tests__/SystemDetailView.spec.tsx` — skeleton / not-found / loaded states.
-- `hooks/__tests__/useDeleteSystemAction.spec.tsx` — permission gate, in-flight re-entry guard, recursive confirm, 409 item-list + `(+N)` overflow + generic fallback, and selection reset for both open-leaf-ancestor and selected-parent-ancestor.
+- `hooks/__tests__/useDeleteSystemAction.spec.tsx` — permission gate, in-flight re-entry guard, per-system check-on-click block, recursive confirm, 409 item-list + `(+N)` overflow + generic fallback, and selection reset for both open-leaf-ancestor and selected-parent-ancestor; `hooks/__tests__/useCreateSubsystemAction.spec.tsx` — role gate + per-parent check-on-click.
 - `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden); the Delete context item is covered in `tree/TreeNode.test.tsx`, `graph/SystemNode.test.tsx`, and `leaves/LeavesTable.test.tsx` (the last stubs the virtualized `PandaTableV2` to exercise the capture/bubble row capture, disabled-on-empty-area, and no-handler short-circuit).
 
 ## Deprecated / legacy
@@ -334,4 +373,4 @@ Unit coverage under `__tests__/` is heaviest in:
 
 > 🔧 *Engineer-only; stripped from the wiki.*
 >
-> Relevant schema: `System`, `SystemInterface`, `ParentPathItem` (`src/server/apollo/schema.graphql:266-369`). Relationship registry: `src/modules/systemHierarchy/types/graph.ts` (`RELATIONSHIP_DEFINITIONS`). Endpoint keys consumed: `systemsHierarchy`, `systemSubsystems`, `systemDetail`, `systemRelationships`, `system/<uid>/copy`, `system` (`DELETE /system/{uid}`, soft+recursive, 409 → `SystemPhysicalItemInfo[]`), `recalculateSpareParts`.
+> Relevant schema: `System`, `SystemInterface`, `ParentPathItem` (`src/server/apollo/schema.graphql:266-369`). Relationship registry: `src/modules/systemHierarchy/types/graph.ts` (`RELATIONSHIP_DEFINITIONS`). Endpoint keys consumed: `systemsHierarchy`, `systemSubsystems`, `systemDetail`, `systemCanEdit` (`GET /system/{uid}/can-edit` → `{ result, responsibles }`; `/v1` prefix is already in `BASE_URL`), `systemRelationships`, `system/<uid>/copy`, `system` (`DELETE /system/{uid}`, soft+recursive, 409 → `SystemPhysicalItemInfo[]`), `recalculateSpareParts`.

--- a/docs/user-guide/systemHierarchy/README.md
+++ b/docs/user-guide/systemHierarchy/README.md
@@ -8,22 +8,24 @@ The System Hierarchy module is the central place to browse, organize, and inspec
 
 **Today's reality:**
 - `systems-view` — read-only.
-- `systems-edit` and `admin` — both grant full edit on every system (functionally equivalent right now).
+- `systems-edit` — edit systems you are **responsible** for (directly, via a responsible team, or via an ancestor); see [Understanding edit permissions](./workflows/edit-permissions.md).
+- `admin` — edit any system.
 
 **Personas (today):**
 
 | Persona | Role(s) | Can do |
 |---|---|---|
 | 👁️ **Viewer** | `systems-view` | Browse the tree, view details, view relationships, search and filter, view change history |
-| ✏️ **Editor / Admin** | `systems-edit` or `admin` | Everything in Viewer + edit fields, manage persons, manage relationships, **use and remove spare parts** (feature-flag gated in production), **create subsystems**, copy systems, **delete systems**, assign and move physical items |
+| ✏️ **Editor** | `systems-edit` | Everything in Viewer + on systems you are **responsible for**: edit fields, manage persons, manage relationships, **use and remove spare parts** (feature-flag gated in production), **create subsystems**, copy systems, **delete systems**, assign and move physical items |
+| 🛠️ **Admin** | `admin` | The Editor capabilities on **any** system, regardless of responsibility |
 
 > 🔮 **Coming soon — Phase 1: split between Editor and Admin**
 > - **Admin** will have exclusive edit on systems at `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels (the strategic top of the tree).
 > - **Editor** (`systems-edit`) will be restricted to `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, and `TRASH` levels.
 > - All derived actions (relationships, persons, items, copy/paste) inherit the same level scope.
 
-> 🔮 **Coming soon — Phase 2: team-based scoping (policy today, enforced later)**
-> Each system has a *responsible person* and a *responsible team*. Only members of the responsible team should edit that system and its subtree. **Today this is policy only — please follow it manually**; technical enforcement is planned but the data structure for it is not yet in place.
+> ✅ **Now enforced — responsibility-based editing**
+> Each system has a *responsible person* and a *responsible team*. You may edit a system only if you are responsible for it (directly, via its responsible team, or via an ancestor), or if it is unowned, or if you are an admin. This is now enforced — not just policy. See [Understanding edit permissions](./workflows/edit-permissions.md).
 
 ## Key concepts
 
@@ -33,7 +35,7 @@ The System Hierarchy module is the central place to browse, organize, and inspec
 - **System type** — codebook classification of *what kind* of system this is. Used for code generation and filtering.
 - **System code** — short identifier for the system, generated based on type, level, and ancestry.
 - **Responsible person** — the employee accountable for a system.
-- **Responsible team** — the team accountable for a system. Governs edit policy (Phase 2).
+- **Responsible team** — the team accountable for a system. Members may edit the system and its subtree — see [Understanding edit permissions](./workflows/edit-permissions.md).
 - **Owner** — computed read-only ownership marker.
 - **Operators** — employees authorized to operate the system day-to-day.
 - **Maintained by** — employees responsible for maintenance of the system.
@@ -58,6 +60,7 @@ When a system is selected for full detail view, a tabbed area replaces the leave
 
 ## Common workflows
 
+- [Understanding edit permissions](./workflows/edit-permissions.md) — who can edit a given system, what a blocked user sees, and how to find the responsible person to contact.
 - [Navigating the tree](./workflows/navigating-the-tree.md) — expanding the tree, breadcrumb navigation, switching between table and graph views in the leaves panel.
 - [Searching and filtering](./workflows/searching-and-filtering.md) — search box and the multi-field filter sheet for the leaves panel.
 - [Editing system details](./workflows/editing-system-details.md) — inline edit of name, code, level, type, location, zone, description on the *Detail* tab. Includes system code generation and the special meaning of the `TRASH` level.
@@ -75,7 +78,7 @@ For moving a system to a different parent, see the **Systems Moving** module —
 ## Coming soon
 
 - 🔮 **Permission Phase 1** — split `admin` (top-level system edits at `SYSTEM_DOMAIN`, `TECHNOLOGY_UNIT`) from `systems-edit` (lower levels at `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, `TRASH`). All derived actions scoped accordingly.
-- 🔮 **Permission Phase 2** — team-based edit enforcement (responsible-team membership required to edit subtree). DB structure pending.
+- 🔮 **Permission Phase 2 (remaining)** — responsibility-based editing is now enforced in System Hierarchy; the remaining work is applying the same rule at the raw-data (GraphQL schema) layer so it holds everywhere, not only in this module.
 - 🔮 **Use Spare in production** — the spare-swap wizard is live in System Hierarchy in non-production environments. The `enableSparePartsAssignment` feature flag still hides it in production; once enabled the button becomes active everywhere.
 - 🔮 **Drag-and-drop move at hierarchy level** — currently move lives in the separate Systems Moving module.
 

--- a/docs/user-guide/systemHierarchy/workflows/creating-systems.md
+++ b/docs/user-guide/systemHierarchy/workflows/creating-systems.md
@@ -8,7 +8,7 @@ The dialog is intentionally minimal — only **Name** and **System level** are a
 
 ## Who can do this
 
-✏️ **Editor / Admin** — requires the `systems-edit` role.
+✏️ **Editor / Admin** — requires the `systems-edit` role **and** that you are responsible for the **parent** system (directly, via its responsible team, or via an ancestor). If you aren't, the attempt is blocked with a message naming who to contact. See [Understanding edit permissions](./edit-permissions.md).
 
 > 🔮 *Coming soon — Phase 1:* creation will be scoped by system level. Editors will be able to create systems at `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, and `TRASH` levels only; creating systems at `SYSTEM_DOMAIN` or `TECHNOLOGY_UNIT` will be admin-only.
 

--- a/docs/user-guide/systemHierarchy/workflows/deleting-systems.md
+++ b/docs/user-guide/systemHierarchy/workflows/deleting-systems.md
@@ -8,7 +8,7 @@ Deletion is a soft removal: the systems are flagged as deleted and disappear fro
 
 ## Who can do this
 
-✏️ **Editor / Admin** — requires the `systems-edit` role.
+✏️ **Editor / Admin** — requires the `systems-edit` role **and** that you are responsible for the system being deleted (directly, via its responsible team, or via an ancestor). If you aren't, the delete is blocked with a message naming who to contact. See [Understanding edit permissions](./edit-permissions.md).
 
 > 🔮 *Coming soon — Phase 1:* the delete action will be scoped by system level. Editors will be able to delete systems at `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, and `TRASH` levels only; deleting systems at `SYSTEM_DOMAIN` or `TECHNOLOGY_UNIT` will be admin-only.
 

--- a/docs/user-guide/systemHierarchy/workflows/edit-permissions.md
+++ b/docs/user-guide/systemHierarchy/workflows/edit-permissions.md
@@ -1,0 +1,69 @@
+# Understanding edit permissions
+
+## What this is for
+
+Editing a system is now controlled per system, not just by your role. Having the `systems-edit` role means you *can* edit systems in general; whether you can edit **this particular system** depends on whether you are **responsible** for it. This page explains who can edit a given system, what you see when you can't, and how to find the right person to ask.
+
+## Who can do this
+
+👁️ **Everyone with `systems-view`** can *see* whether they may edit a system and who is responsible for it. Only a responsible user (with the `systems-edit` role) can actually make changes.
+
+You may edit a system when any of these is true:
+
+- You are its **responsible person**.
+- You are a member of its **responsible team**.
+- You are responsible (person or team) for a system **above it** in the hierarchy — responsibility flows down to subsystems.
+- You are an **admin**.
+- The system and all of its ancestors have **no** responsible person or team at all (an unowned system is open to any editor).
+
+> This replaces the earlier "policy only" guidance: responsibility-based editing is now enforced, not just recommended.
+
+See [Access & Responsibilities](../README.md#access--responsibilities) for what the personas mean.
+
+## Prerequisites
+
+- You are looking at a system's detail view in the System Hierarchy module.
+- See [Key concepts](../README.md#key-concepts) for *responsible person* and *responsible team*.
+
+## What you can and can't do
+
+When you **are** allowed to edit a system, everything behaves as documented in the other workflows — fields are editable, actions are enabled.
+
+When you are **not** allowed to edit a system:
+
+- ❌ All fields on the **Detail**, **Persons**, and **Physical Item** tabs are shown but disabled.
+- ❌ Adding or removing operators / maintained-by people is disabled.
+- ❌ Uploading or deleting **Attachments** and the system image is disabled.
+- ❌ The **Actions** menu (move item, assign item, assign spares) is disabled.
+- ❌ Right-click **Create System** (under this system) and **Delete System** are blocked.
+- ✅ You can still browse, search, view relationships, and read the change history.
+
+## Steps
+
+1. **Open a system's detail view.** Select a leaf in the tree, or click *View Detail* on a parent.
+
+2. **Look for the permission notice at the top of the detail view.** If you cannot edit this system, a banner appears below the breadcrumb: *You don't have permission to edit this system.* All editable fields below are greyed out.
+
+   `[SCREENSHOT PLACEHOLDER: system detail view with the "You don't have permission to edit this system" banner under the header, an info icon next to it, and the Detail-tab fields visibly disabled]`
+
+3. **Find out who to contact.** The banner lists the responsible people under *Responsible people you can contact:* with their names and email addresses. Hovering the info icon next to the banner title shows the same list as a tooltip. If no one is listed, it reads *Please contact an administrator to request access.*
+
+   `[SCREENSHOT PLACEHOLDER: the info-icon tooltip open, showing a responsible person's name and email]`
+
+4. **If you try a blocked action anyway** (for example right-clicking *Delete System* on a system you're not responsible for), a message appears: *You're not responsible for this system. Contact: <names>* — and nothing is changed.
+
+`[VIDEO PLACEHOLDER: 25s — open a system you're not responsible for (banner + disabled fields shown), hover the info icon to reveal the responsible contact, then open a system you are responsible for and edit a field successfully]`
+
+## Tips & gotchas
+
+- **Responsibility flows downward.** If you are responsible for a key system, you can also edit everything beneath it — you don't need to be named on every subsystem.
+- **Changing the responsible person or team can remove your own access.** If you reassign responsibility away from yourself on a system you only controlled directly, the fields lock immediately afterward — that's expected.
+- **"Couldn't verify" is different from "not permitted".** If the banner reads *Could not verify your edit permissions* with a **Retry** button, that's a temporary connection problem, not a permission denial — editing stays disabled until it can be confirmed. Click **Retry**.
+- **System codes follow the same rule here.** Generating or releasing a system code is disabled when you can't edit the system.
+
+## Related
+
+- [Editing system details](./editing-system-details.md) — the fields this permission gates.
+- [Managing system people](./managing-system-people.md) — set the responsible person and team that decide who can edit.
+- [Creating systems](./creating-systems.md) and [Deleting systems](./deleting-systems.md) — both check your responsibility for the parent / target.
+- Full permission model → see [user guide index](../../README.md).

--- a/docs/user-guide/systemHierarchy/workflows/editing-system-details.md
+++ b/docs/user-guide/systemHierarchy/workflows/editing-system-details.md
@@ -10,7 +10,7 @@ Update the core attributes of a system on the **Detail** tab: name, description,
 
 > 🔮 *Coming soon — Phase 1:* edits to systems at `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels will be admin-only; Editors will be restricted to lower levels (`KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, `TRASH`).
 
-> 🔮 *Coming soon — Phase 2:* even with the `systems-edit` role you should be a member of the responsible team to edit a system. Today this is policy only.
+> ✅ Even with the `systems-edit` role, you can edit a system only if you are **responsible** for it (directly, via its responsible team, or via an ancestor) — this is now enforced. See [Understanding edit permissions](./edit-permissions.md).
 
 See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
 

--- a/docs/user-guide/systemHierarchy/workflows/managing-physical-items.md
+++ b/docs/user-guide/systemHierarchy/workflows/managing-physical-items.md
@@ -10,7 +10,7 @@ This workflow covers two actions exposed from the system detail's **Actions** me
 
 ✏️ **Editor / Admin** — both Assign Item and Move Item require the `systems-edit` role.
 
-> 🔮 *Coming soon — Phase 1 / Phase 2 permissions:* the same level- and team-based scoping described in [Access & Responsibilities](../README.md#access--responsibilities) will apply to item operations.
+> ✅ Editing a physical item's fields requires that you are **responsible** for its system (now enforced) — see [Understanding edit permissions](./edit-permissions.md). Level-based scoping (Phase 1) is still upcoming.
 
 See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
 

--- a/docs/user-guide/systemHierarchy/workflows/managing-system-people.md
+++ b/docs/user-guide/systemHierarchy/workflows/managing-system-people.md
@@ -2,7 +2,7 @@
 
 ## What this is for
 
-Assign and update the people accountable for a system on the **Persons** tab: the responsible person, the responsible team, the (read-only) owner, plus the *Authorized Operators* and *Maintained By* tables. These assignments drive accountability today and — once Phase 2 ships — the technical edit permissions for the system's subtree.
+Assign and update the people accountable for a system on the **Persons** tab: the responsible person, the responsible team, the (read-only) owner, plus the *Authorized Operators* and *Maintained By* tables. The responsible person and team also **decide who may edit** this system and its subtree — see [Understanding edit permissions](./edit-permissions.md).
 
 ## Who can do this
 
@@ -10,7 +10,7 @@ Assign and update the people accountable for a system on the **Persons** tab: th
 
 > 🔮 *Coming soon — Phase 1:* changes to systems at `SYSTEM_DOMAIN` and `TECHNOLOGY_UNIT` levels (where responsibility decisions are most consequential) will be admin-only.
 
-> 🔮 *Coming soon — Phase 2:* responsible-team membership will technically gate edits to a system and its subtree. **Today this is policy only — the application does not enforce it.**
+> ✅ Responsible-person / responsible-team membership now gates edits to a system and its subtree — enforced, not just policy. Editing the Persons tab itself requires that you already be responsible for the system. See [Understanding edit permissions](./edit-permissions.md).
 
 See [Access & Responsibilities](../README.md#access--responsibilities) for what these personas mean.
 
@@ -41,7 +41,7 @@ The top of the tab shows three single-employee fields. All save on blur (toast: 
 3. **Owner is informational only.** It reflects an ownership computation and cannot be edited from this UI.
 
 > ⚠️ **Changing the responsible team is a high-impact change.**
-> The responsible team determines who *should* be allowed to edit this system and its subtree (per documented policy today, technically enforced in Phase 2). Reassigning the team can move edit-rights for the entire subtree from one team to another. Make sure the new team is aware before changing this.
+> The responsible team determines who is allowed to edit this system and its subtree (now enforced). Reassigning the team moves edit-rights for the entire subtree from one team to another — and can remove your own access if you were only editing via that team. Make sure the new team is aware before changing this.
 
 ### Operators and Maintained-By tables
 

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1480,7 +1480,6 @@ export const messages = {
         permission: {
             deniedTitle: "You don't have permission to edit this system.",
             deniedResponsiblesTooltip: 'Show who is responsible for this system',
-            deniedResponsiblesLabel: 'Responsible people you can contact:',
             deniedNoResponsibles: 'Please contact an administrator to request access.',
             errorTitle: 'Could not verify your edit permissions.',
             errorDescription: 'Editing is disabled until we can confirm your access.',

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1477,6 +1477,17 @@ export const messages = {
             loadErrorDescription: 'Something went wrong while loading the system detail.',
             updating: 'Updating…',
         },
+        permission: {
+            deniedTitle: "You don't have permission to edit this system.",
+            deniedResponsiblesLabel: 'Responsible people you can contact:',
+            deniedNoResponsibles: 'Please contact an administrator to request access.',
+            errorTitle: 'Could not verify your edit permissions.',
+            errorDescription: 'Editing is disabled until we can confirm your access.',
+            retry: 'Retry',
+            blockedToast: "You're not responsible for this system. Contact: {names}",
+            blockedToastNoResponsibles:
+                "You're not responsible for this system. Contact an administrator to request access.",
+        },
         tabs: {
             detail: 'Detail',
             persons: 'Persons',

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1479,6 +1479,7 @@ export const messages = {
         },
         permission: {
             deniedTitle: "You don't have permission to edit this system.",
+            deniedResponsiblesTooltip: 'Show who is responsible for this system',
             deniedResponsiblesLabel: 'Responsible people you can contact:',
             deniedNoResponsibles: 'Please contact an administrator to request access.',
             errorTitle: 'Could not verify your edit permissions.',

--- a/src/modules/shared/system/employee-assignment/components/EmployeeAssignmentTable.comp.tsx
+++ b/src/modules/shared/system/employee-assignment/components/EmployeeAssignmentTable.comp.tsx
@@ -21,6 +21,9 @@ interface EmployeeAssignmentTableProps {
     existingEmployeeUids?: string[]
     isLoading?: boolean
     className?: string
+    // Optional per-system gate ANDed with the SYSTEM_EDIT role. Defaults to
+    // role-only so existing callers are unaffected.
+    canEdit?: boolean
 }
 
 export const EmployeeAssignmentTable = memo(
@@ -32,9 +35,10 @@ export const EmployeeAssignmentTable = memo(
         existingEmployeeUids,
         isLoading = false,
         className,
+        canEdit: canEditProp = true,
     }: EmployeeAssignmentTableProps) => {
         const { formatMessage: fm } = useIntl()
-        const canEdit = usePermission([ROLE.SYSTEM_EDIT])
+        const canEdit = usePermission([ROLE.SYSTEM_EDIT]) && canEditProp
         const withWarningModal = useWarningModal()
 
         const allExistingUids = useMemo(() => {

--- a/src/modules/systemHierarchy/components/detail/ActionsDropdown.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/ActionsDropdown.comp.tsx
@@ -15,6 +15,7 @@ import { openItemMoveModal } from '@/modules/shared/form/itemMoving/item-move.mo
 import { useAssignSparesNavigation } from '@/modules/shared/hooks/useAssignSparesNavigation'
 import type { SystemLevel } from '@/types/gql/graphql'
 
+import { useSystemEditPermission } from '../../hooks/useSystemEditPermission'
 import type { SystemLeaf } from '../../types'
 
 interface ActionsDropdownProps {
@@ -23,6 +24,7 @@ interface ActionsDropdownProps {
 
 export const ActionsDropdown: FC<ActionsDropdownProps> = ({ system }) => {
     const { formatMessage: fm } = useIntl()
+    const { canEdit } = useSystemEditPermission(system.uid)
     const hasPhysicalItem = !!system.physicalItem
 
     const handleAssignSpares = useAssignSparesNavigation({
@@ -47,19 +49,25 @@ export const ActionsDropdown: FC<ActionsDropdownProps> = ({ system }) => {
                 {hasPhysicalItem && (
                     <DropdownMenuItem
                         className="cursor-pointer"
+                        disabled={!canEdit}
                         onClick={() => openItemMoveModal(system)}
                     >
                         <Move className="h-4 w-4 mr-2" />
                         {fm({ id: message.systemHierarchy.detail.moveItem })}
                     </DropdownMenuItem>
                 )}
-                <DropdownMenuItem className="cursor-pointer" onClick={handleAssignSpares}>
+                <DropdownMenuItem
+                    className="cursor-pointer"
+                    disabled={!canEdit}
+                    onClick={handleAssignSpares}
+                >
                     <Wrench className="h-4 w-4 mr-2" />
                     {fm({ id: message.systemHierarchy.detail.assignSpares })}
                 </DropdownMenuItem>
                 {!hasPhysicalItem && (
                     <DropdownMenuItem
                         className="cursor-pointer"
+                        disabled={!canEdit}
                         onClick={() => openItemAssignModal(system)}
                     >
                         <Package className="h-4 w-4 mr-2" />

--- a/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailView.cont.tsx
@@ -8,14 +8,17 @@ import { message } from '@/i18n/src/messages'
 
 import { useSystemDetail } from '../../hooks/queries/useSystemDetail'
 import { useHierarchyNavigation } from '../../hooks/useHierarchyNavigation'
+import { useSystemEditPermission } from '../../hooks/useSystemEditPermission'
 import { SystemDetailHeader } from './SystemDetailHeader.comp'
 import { SystemDetailTabsContainer } from './SystemDetailTabs.cont'
+import { SystemEditRestrictionBanner } from './SystemEditRestrictionBanner.comp'
 
 export const SystemDetailViewContainer: FC = () => {
     const { formatMessage: fm } = useIntl()
     const { selectedLeafUid, goBackToLeaves, selectParent, clearSelection } =
         useHierarchyNavigation()
     const { system, isLoading, isFetching, error, refetch } = useSystemDetail(selectedLeafUid)
+    const editPermission = useSystemEditPermission(selectedLeafUid)
 
     // Selecting a node in the tree only changes the URL/leaf; the detail query keeps
     // refetchOnMount:false (so secondary consumers like PhysicalItemTab stay cache reads).
@@ -97,6 +100,11 @@ export const SystemDetailViewContainer: FC = () => {
                 onBack={goBackToLeaves}
                 onSelectAncestor={selectParent}
                 isRefreshing={isFetching && !isLoading}
+            />
+            <SystemEditRestrictionBanner
+                status={editPermission.status}
+                responsibles={editPermission.responsibles}
+                refetch={editPermission.refetch}
             />
             <div className="flex-1 min-h-0">
                 <SystemDetailTabsContainer system={system} />

--- a/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
@@ -34,57 +34,57 @@ export const SystemEditRestrictionBanner: FC<Props> = ({ status, responsibles, r
 
     if (status === 'error') {
         return (
-            <Alert variant="destructive" className="mx-4 mt-2" data-testid="system-edit-verify-error">
-                <Lock />
-                <AlertTitle>{fm({ id: message.systemHierarchy.permission.errorTitle })}</AlertTitle>
-                <AlertDescription>
-                    <p>{fm({ id: message.systemHierarchy.permission.errorDescription })}</p>
-                    <Button variant="outline" size="sm" className="mt-1" onClick={refetch}>
-                        {fm({ id: message.systemHierarchy.permission.retry })}
-                    </Button>
-                </AlertDescription>
-            </Alert>
+            // px wrapper instead of mx on the Alert: the Alert is w-full, so a
+            // horizontal margin would push it past the container and under the
+            // Quick Info sidebar.
+            <div className="px-4 pt-2">
+                <Alert variant="destructive" data-testid="system-edit-verify-error">
+                    <Lock />
+                    <AlertTitle>
+                        {fm({ id: message.systemHierarchy.permission.errorTitle })}
+                    </AlertTitle>
+                    <AlertDescription>
+                        <p>{fm({ id: message.systemHierarchy.permission.errorDescription })}</p>
+                        <Button variant="outline" size="sm" className="mt-1" onClick={refetch}>
+                            {fm({ id: message.systemHierarchy.permission.retry })}
+                        </Button>
+                    </AlertDescription>
+                </Alert>
+            </div>
         )
     }
 
-    // status === 'denied'
+    // status === 'denied' — keep it compact: the responsibles live in the info
+    // tooltip so the banner stays a single line. Only fall back to inline text
+    // when there is no one to list.
     const hasResponsibles = responsibles.length > 0
     return (
-        <Alert className="mx-4 mt-2" data-testid="system-edit-denied">
-            <Lock />
-            <AlertTitle className="flex items-center gap-1.5">
-                {fm({ id: message.systemHierarchy.permission.deniedTitle })}
-                {hasResponsibles && (
-                    <Tooltip content={buildResponsiblesTooltip(responsibles)}>
-                        <button
-                            type="button"
-                            aria-label={fm({
-                                id: message.systemHierarchy.permission.deniedResponsiblesTooltip,
-                            })}
-                            className="inline-flex shrink-0 cursor-help text-muted-foreground"
-                        >
-                            <Info className="size-4" />
-                        </button>
-                    </Tooltip>
+        <div className="px-4 pt-2">
+            <Alert data-testid="system-edit-denied">
+                <Lock />
+                <AlertTitle className="flex items-center gap-1.5">
+                    {fm({ id: message.systemHierarchy.permission.deniedTitle })}
+                    {hasResponsibles && (
+                        <Tooltip content={buildResponsiblesTooltip(responsibles)}>
+                            <button
+                                type="button"
+                                aria-label={fm({
+                                    id: message.systemHierarchy.permission
+                                        .deniedResponsiblesTooltip,
+                                })}
+                                className="inline-flex shrink-0 cursor-help text-muted-foreground"
+                            >
+                                <Info className="size-4" />
+                            </button>
+                        </Tooltip>
+                    )}
+                </AlertTitle>
+                {!hasResponsibles && (
+                    <AlertDescription>
+                        <p>{fm({ id: message.systemHierarchy.permission.deniedNoResponsibles })}</p>
+                    </AlertDescription>
                 )}
-            </AlertTitle>
-            <AlertDescription>
-                <p>
-                    {hasResponsibles
-                        ? fm({ id: message.systemHierarchy.permission.deniedResponsiblesLabel })
-                        : fm({ id: message.systemHierarchy.permission.deniedNoResponsibles })}
-                </p>
-                {hasResponsibles && (
-                    <ul className="list-none">
-                        {responsibles.map(r => (
-                            <li key={r.uid}>
-                                {formatResponsibleName(r)}
-                                {r.email ? ` (${r.email})` : ''}
-                            </li>
-                        ))}
-                    </ul>
-                )}
-            </AlertDescription>
-        </Alert>
+            </Alert>
+        </div>
     )
 }

--- a/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
@@ -56,7 +56,15 @@ export const SystemEditRestrictionBanner: FC<Props> = ({ status, responsibles, r
                 {fm({ id: message.systemHierarchy.permission.deniedTitle })}
                 {hasResponsibles && (
                     <Tooltip content={buildResponsiblesTooltip(responsibles)}>
-                        <Info className="size-4 shrink-0 text-muted-foreground" />
+                        <button
+                            type="button"
+                            aria-label={fm({
+                                id: message.systemHierarchy.permission.deniedResponsiblesTooltip,
+                            })}
+                            className="inline-flex shrink-0 cursor-help text-muted-foreground"
+                        >
+                            <Info className="size-4" />
+                        </button>
                     </Tooltip>
                 )}
             </AlertTitle>

--- a/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { Info, Lock } from 'lucide-react'
+import type { FC } from 'react'
+import { useIntl } from 'react-intl'
+
+import { Tooltip } from '@/components/Tooltip'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { message } from '@/i18n/src/messages'
+
+import type { SystemEditPermission } from '../../hooks/useSystemEditPermission'
+import { formatResponsibleName } from '../../hooks/useSystemEditPermission'
+
+type Props = Pick<SystemEditPermission, 'status' | 'responsibles' | 'refetch'>
+
+const buildResponsiblesTooltip = (responsibles: Props['responsibles']): string =>
+    responsibles
+        .map(r => {
+            const name = formatResponsibleName(r)
+            return r.email ? `${name} (${r.email})` : name
+        })
+        .filter(Boolean)
+        .join('\n')
+
+/**
+ * Explains why editing is blocked and who to contact. Shown on the system detail
+ * view above the tabs. Renders nothing while permission is loading or allowed.
+ */
+export const SystemEditRestrictionBanner: FC<Props> = ({ status, responsibles, refetch }) => {
+    const { formatMessage: fm } = useIntl()
+
+    if (status === 'loading' || status === 'allowed') return null
+
+    if (status === 'error') {
+        return (
+            <Alert variant="destructive" className="mx-4 mt-2" data-testid="system-edit-verify-error">
+                <Lock />
+                <AlertTitle>{fm({ id: message.systemHierarchy.permission.errorTitle })}</AlertTitle>
+                <AlertDescription>
+                    <p>{fm({ id: message.systemHierarchy.permission.errorDescription })}</p>
+                    <Button variant="outline" size="sm" className="mt-1" onClick={refetch}>
+                        {fm({ id: message.systemHierarchy.permission.retry })}
+                    </Button>
+                </AlertDescription>
+            </Alert>
+        )
+    }
+
+    // status === 'denied'
+    const hasResponsibles = responsibles.length > 0
+    return (
+        <Alert className="mx-4 mt-2" data-testid="system-edit-denied">
+            <Lock />
+            <AlertTitle className="flex items-center gap-1.5">
+                {fm({ id: message.systemHierarchy.permission.deniedTitle })}
+                {hasResponsibles && (
+                    <Tooltip content={buildResponsiblesTooltip(responsibles)}>
+                        <Info className="size-4 shrink-0 text-muted-foreground" />
+                    </Tooltip>
+                )}
+            </AlertTitle>
+            <AlertDescription>
+                <p>
+                    {hasResponsibles
+                        ? fm({ id: message.systemHierarchy.permission.deniedResponsiblesLabel })
+                        : fm({ id: message.systemHierarchy.permission.deniedNoResponsibles })}
+                </p>
+                {hasResponsibles && (
+                    <ul className="list-none">
+                        {responsibles.map(r => (
+                            <li key={r.uid}>
+                                {formatResponsibleName(r)}
+                                {r.email ? ` (${r.email})` : ''}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </AlertDescription>
+        </Alert>
+    )
+}

--- a/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemEditRestrictionBanner.comp.tsx
@@ -18,7 +18,9 @@ const buildResponsiblesTooltip = (responsibles: Props['responsibles']): string =
     responsibles
         .map(r => {
             const name = formatResponsibleName(r)
-            return r.email ? `${name} (${r.email})` : name
+            // Skip the "(email)" suffix when the name already is the email
+            // (formatResponsibleName falls back to email when nothing else exists).
+            return r.email && r.email !== name ? `${name} (${r.email})` : name
         })
         .filter(Boolean)
         .join('\n')

--- a/src/modules/systemHierarchy/components/detail/__tests__/ActionsDropdown.test.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/ActionsDropdown.test.tsx
@@ -20,6 +20,16 @@ jest.mock('@/modules/shared/hooks/useAssignSparesNavigation', () => ({
     useAssignSparesNavigation: () => mockAssignSpares,
 }))
 
+const mockCanEditSystem = jest.fn()
+jest.mock('../../../hooks/useSystemEditPermission', () => ({
+    useSystemEditPermission: () => ({
+        canEdit: mockCanEditSystem(),
+        responsibles: [],
+        status: 'allowed',
+        refetch: jest.fn(),
+    }),
+}))
+
 // Mock Radix dropdown to render content directly (avoids portal/pointer issues)
 jest.mock('@/components/ui/dropdown-menu', () => ({
     DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
@@ -75,6 +85,7 @@ const renderDropdown = (system: SystemLeaf) =>
 describe('ActionsDropdown', () => {
     beforeEach(() => {
         jest.clearAllMocks()
+        mockCanEditSystem.mockReturnValue(true)
     })
 
     it('renders Move Item when system has physicalItem', () => {
@@ -118,5 +129,12 @@ describe('ActionsDropdown', () => {
         renderDropdown(baseSystem)
         fireEvent.click(screen.getByText('Assign Spares'))
         expect(mockAssignSpares).toHaveBeenCalled()
+    })
+
+    it('disables the actions when the user cannot edit the system', () => {
+        mockCanEditSystem.mockReturnValue(false)
+        renderDropdown(systemWithPhysicalItem)
+        expect(screen.getByText('Move Item').closest('button')).toBeDisabled()
+        expect(screen.getByText('Assign Spares').closest('button')).toBeDisabled()
     })
 })

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemDetailView.spec.tsx
@@ -38,6 +38,17 @@ jest.mock('../SystemDetailHeader.comp', () => ({
 jest.mock('../SystemDetailTabs.cont', () => ({
     SystemDetailTabsContainer: () => <div data-testid="detail-tabs-stub" />,
 }))
+jest.mock('../SystemEditRestrictionBanner.comp', () => ({
+    SystemEditRestrictionBanner: () => <div data-testid="edit-restriction-banner-stub" />,
+}))
+jest.mock('../../../hooks/useSystemEditPermission', () => ({
+    useSystemEditPermission: () => ({
+        canEdit: true,
+        responsibles: [],
+        status: 'allowed',
+        refetch: jest.fn(),
+    }),
+}))
 
 const messages: Record<string, string> = {
     'systemHierarchy.detail.notFoundTitle': 'System not found',

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemEditRestrictionBanner.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemEditRestrictionBanner.spec.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { IntlProvider } from 'react-intl'
+
+import { SystemEditRestrictionBanner } from '../SystemEditRestrictionBanner.comp'
+
+const messages: Record<string, string> = {
+    'systemHierarchy.permission.deniedTitle': "You don't have permission to edit this system.",
+    'systemHierarchy.permission.deniedResponsiblesLabel': 'Responsible people you can contact:',
+    'systemHierarchy.permission.deniedNoResponsibles':
+        'Please contact an administrator to request access.',
+    'systemHierarchy.permission.errorTitle': 'Could not verify your edit permissions.',
+    'systemHierarchy.permission.errorDescription':
+        'Editing is disabled until we can confirm your access.',
+    'systemHierarchy.permission.retry': 'Retry',
+}
+
+const responsible = {
+    uid: 'u1',
+    firstName: 'Ann',
+    lastName: 'Lee',
+    username: 'alee',
+    email: 'ann.lee@eli.eu',
+}
+
+const renderBanner = (props: Parameters<typeof SystemEditRestrictionBanner>[0]) =>
+    render(
+        <IntlProvider locale="en" messages={messages}>
+            <SystemEditRestrictionBanner {...props} />
+        </IntlProvider>,
+    )
+
+describe('SystemEditRestrictionBanner', () => {
+    it('renders nothing while loading', () => {
+        const { container } = renderBanner({
+            status: 'loading',
+            responsibles: [],
+            refetch: jest.fn(),
+        })
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('renders nothing when allowed', () => {
+        const { container } = renderBanner({
+            status: 'allowed',
+            responsibles: [],
+            refetch: jest.fn(),
+        })
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('lists responsibles when denied', () => {
+        renderBanner({ status: 'denied', responsibles: [responsible], refetch: jest.fn() })
+        expect(screen.getByTestId('system-edit-denied')).toBeInTheDocument()
+        expect(screen.getByText(/Ann Lee/)).toBeInTheDocument()
+        expect(screen.getByText(/ann\.lee@eli\.eu/)).toBeInTheDocument()
+    })
+
+    it('shows the admin fallback when denied with no responsibles', () => {
+        renderBanner({ status: 'denied', responsibles: [], refetch: jest.fn() })
+        expect(
+            screen.getByText('Please contact an administrator to request access.'),
+        ).toBeInTheDocument()
+    })
+
+    it('shows a distinct verify-error state with a working retry', () => {
+        const refetch = jest.fn()
+        renderBanner({ status: 'error', responsibles: [], refetch })
+        expect(screen.getByTestId('system-edit-verify-error')).toBeInTheDocument()
+        expect(screen.queryByTestId('system-edit-denied')).not.toBeInTheDocument()
+        fireEvent.click(screen.getByText('Retry'))
+        expect(refetch).toHaveBeenCalled()
+    })
+})

--- a/src/modules/systemHierarchy/components/detail/__tests__/SystemEditRestrictionBanner.spec.tsx
+++ b/src/modules/systemHierarchy/components/detail/__tests__/SystemEditRestrictionBanner.spec.tsx
@@ -5,7 +5,8 @@ import { SystemEditRestrictionBanner } from '../SystemEditRestrictionBanner.comp
 
 const messages: Record<string, string> = {
     'systemHierarchy.permission.deniedTitle': "You don't have permission to edit this system.",
-    'systemHierarchy.permission.deniedResponsiblesLabel': 'Responsible people you can contact:',
+    'systemHierarchy.permission.deniedResponsiblesTooltip':
+        'Show who is responsible for this system',
     'systemHierarchy.permission.deniedNoResponsibles':
         'Please contact an administrator to request access.',
     'systemHierarchy.permission.errorTitle': 'Could not verify your edit permissions.',
@@ -48,11 +49,14 @@ describe('SystemEditRestrictionBanner', () => {
         expect(container).toBeEmptyDOMElement()
     })
 
-    it('lists responsibles when denied', () => {
+    it('shows a compact denied banner with a responsibles info trigger (not an inline list)', () => {
         renderBanner({ status: 'denied', responsibles: [responsible], refetch: jest.fn() })
         expect(screen.getByTestId('system-edit-denied')).toBeInTheDocument()
-        expect(screen.getByText(/Ann Lee/)).toBeInTheDocument()
-        expect(screen.getByText(/ann\.lee@eli\.eu/)).toBeInTheDocument()
+        // Responsibles live in the tooltip, not rendered inline — keeps the banner one line.
+        expect(
+            screen.getByRole('button', { name: 'Show who is responsible for this system' }),
+        ).toBeInTheDocument()
+        expect(screen.queryByText(/ann\.lee@eli\.eu/)).not.toBeInTheDocument()
     })
 
     it('shows the admin fallback when denied with no responsibles', () => {

--- a/src/modules/systemHierarchy/components/sidebar/SystemImagePanel.comp.tsx
+++ b/src/modules/systemHierarchy/components/sidebar/SystemImagePanel.comp.tsx
@@ -15,6 +15,8 @@ import { ImagePlaceHolder } from '@/modules/shared/imageManager/components/Image
 import { useImageAutoSave } from '@/modules/shared/imageManager/utils/useImageAutoSave'
 import { ROLE } from '@/types/constants/roles'
 
+import { useSystemEditPermission } from '../../hooks/useSystemEditPermission'
+
 interface SystemImagePanelProps {
     systemUid: string
     systemName?: string | null
@@ -22,7 +24,8 @@ interface SystemImagePanelProps {
 
 export const SystemImagePanel: FC<SystemImagePanelProps> = ({ systemUid, systemName }) => {
     const { formatMessage: fm } = useIntl()
-    const hasEditRole = !!usePermission([ROLE.SYSTEM_EDIT])
+    const { canEdit } = useSystemEditPermission(systemUid)
+    const hasEditRole = !!usePermission([ROLE.SYSTEM_EDIT]) && canEdit
     const withWarnModal = useWarningModal()
     // track the selected image by id so reconcile reordering / deletes don't shift focus;
     // null falls back to index 0 (the newest, since uploads prepend)

--- a/src/modules/systemHierarchy/components/sidebar/__tests__/SystemImagePanel.comp.spec.tsx
+++ b/src/modules/systemHierarchy/components/sidebar/__tests__/SystemImagePanel.comp.spec.tsx
@@ -22,6 +22,16 @@ jest.mock('@/hooks/usePermission', () => ({
     default: () => mockHasPermission(),
 }))
 
+const mockCanEditSystem = jest.fn()
+jest.mock('../../../hooks/useSystemEditPermission', () => ({
+    useSystemEditPermission: () => ({
+        canEdit: mockCanEditSystem(),
+        responsibles: [],
+        status: 'allowed',
+        refetch: jest.fn(),
+    }),
+}))
+
 // run the warning-modal callback immediately so we can assert deleteImage is called
 jest.mock('@/hooks/useWarningModal', () => ({
     __esModule: true,
@@ -38,6 +48,7 @@ beforeEach(() => {
     jest.clearAllMocks()
     mockState = { images: [], isLoading: false, isMutating: false }
     mockHasPermission.mockReturnValue(true)
+    mockCanEditSystem.mockReturnValue(true)
 })
 
 describe('SystemImagePanel', () => {
@@ -70,6 +81,14 @@ describe('SystemImagePanel', () => {
         renderWithProviders(<SystemImagePanel systemUid="s1" />)
         expect(screen.getByRole('button', { name: /upload/i })).toBeInTheDocument()
         expect(screen.getByRole('button', { name: /delete/i })).toBeInTheDocument()
+    })
+
+    it('hides upload/delete controls when not responsible for the system', () => {
+        mockCanEditSystem.mockReturnValue(false)
+        mockState.images = [img('1')]
+        renderWithProviders(<SystemImagePanel systemUid="s1" />)
+        expect(screen.queryByRole('button', { name: /upload/i })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument()
     })
 
     it('disables delete while the selected image is an optimistic temp entry', () => {

--- a/src/modules/systemHierarchy/components/tabs/AttachmentsTab.cont.tsx
+++ b/src/modules/systemHierarchy/components/tabs/AttachmentsTab.cont.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import FileManager from '@/modules/shared/fileManager/FileManager'
 import { FILE_TYPE } from '@/modules/shared/fileManager/types'
 
+import { useSystemEditPermission } from '../../hooks/useSystemEditPermission'
 import type { SystemLeaf } from '../../types'
 
 interface AttachmentsTabProps {
@@ -10,9 +11,11 @@ interface AttachmentsTabProps {
 }
 
 export const AttachmentsTabContainer: FC<AttachmentsTabProps> = ({ system }) => {
+    const { canEdit } = useSystemEditPermission(system.uid)
+
     return (
         <div className="p-4" data-testid={`attachments-${system.uid}`}>
-            <FileManager itemType={FILE_TYPE.SYSTEM} uid={system.uid} hasEditRole />
+            <FileManager itemType={FILE_TYPE.SYSTEM} uid={system.uid} hasEditRole={canEdit} />
         </div>
     )
 }

--- a/src/modules/systemHierarchy/components/tabs/DetailTab.cont.tsx
+++ b/src/modules/systemHierarchy/components/tabs/DetailTab.cont.tsx
@@ -18,6 +18,7 @@ import { CODEBOOK } from '@/types/constants/codebook'
 import { SystemLevel } from '@/types/gql/graphql'
 
 import { useSystemFieldUpdate } from '../../hooks/mutations/useSystemFieldUpdate'
+import { useSystemEditPermission } from '../../hooks/useSystemEditPermission'
 import type { SystemLeaf } from '../../types'
 import { SystemCodeActions } from './SystemCodeActions.comp'
 
@@ -43,6 +44,7 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
     })
     const { openLocationModal } = useLocationSelectionModal()
     const { openSystemTypeModal } = useSystemTypeSelectionModal()
+    const { canEdit } = useSystemEditPermission(system.uid)
 
     const handleSaveField = useCallback(
         async (
@@ -50,9 +52,10 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
             value: unknown,
             options?: { displayName?: string | null; previousValue?: unknown },
         ) => {
+            if (!canEdit) return
             await updateField(system.uid, fieldName, value, options)
         },
-        [system.uid, updateField],
+        [canEdit, system.uid, updateField],
     )
 
     return (
@@ -62,6 +65,7 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
                 value={system.name}
                 onSave={value => handleSaveField('name', value, { previousValue: system.name })}
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldInput
@@ -71,7 +75,10 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
                     handleSaveField('systemCode', value, { previousValue: system.systemCode })
                 }
                 isPending={isPending}
-                rightAction={<SystemCodeActions system={system} disabled={isPending} />}
+                disabled={!canEdit}
+                rightAction={
+                    <SystemCodeActions system={system} disabled={isPending || !canEdit} />
+                }
             />
 
             <InlineFieldSelect
@@ -82,6 +89,7 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
                     handleSaveField('systemLevel', value, { previousValue: system.systemLevel })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldModalSelect
@@ -93,6 +101,7 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
                     handleSaveField('systemTypeUid', uid, { displayName })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldModalSelect
@@ -102,6 +111,7 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
                 onOpenModal={onSelect => openLocationModal(onSelect)}
                 onSave={(uid, displayName) => handleSaveField('locationUid', uid, { displayName })}
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldCombobox
@@ -111,6 +121,7 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
                 codebook={CODEBOOK.ZONE}
                 onSave={(uid, displayName) => handleSaveField('zoneUid', uid, { displayName })}
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldTextArea
@@ -120,6 +131,7 @@ export const DetailTabContainer: FC<DetailTabProps> = ({ system }) => {
                     handleSaveField('description', value, { previousValue: system.description })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
         </div>
     )

--- a/src/modules/systemHierarchy/components/tabs/PersonsTab.cont.tsx
+++ b/src/modules/systemHierarchy/components/tabs/PersonsTab.cont.tsx
@@ -16,6 +16,7 @@ import { CODEBOOK } from '@/types/constants/codebook'
 import { SystemLevel } from '@/types/gql/graphql'
 
 import { useSystemFieldUpdate } from '../../hooks/mutations/useSystemFieldUpdate'
+import { useSystemEditPermission } from '../../hooks/useSystemEditPermission'
 import type { SystemLeaf } from '../../types'
 import { SYSTEM_DETAIL_QUERY_KEY } from '../../types/constants'
 
@@ -26,6 +27,7 @@ interface PersonsTabProps {
 export const PersonsTabContainer: FC<PersonsTabProps> = ({ system }) => {
     const { formatMessage: fm } = useIntl()
     const queryClient = useQueryClient()
+    const { canEdit } = useSystemEditPermission(system.uid)
 
     const refreshSystemDetail = useCallback(() => {
         void queryClient.invalidateQueries({ queryKey: [SYSTEM_DETAIL_QUERY_KEY] })
@@ -65,9 +67,10 @@ export const PersonsTabContainer: FC<PersonsTabProps> = ({ system }) => {
             value: unknown,
             options?: { displayName?: string | null; previousValue?: unknown },
         ) => {
+            if (!canEdit) return
             await updateField(system.uid, fieldName, value, options)
         },
-        [system.uid, updateField],
+        [canEdit, system.uid, updateField],
     )
 
     const operators = system.operators ?? []
@@ -87,6 +90,7 @@ export const PersonsTabContainer: FC<PersonsTabProps> = ({ system }) => {
                     handleSaveField('responsibleUid', uid, { displayName })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldCombobox
@@ -108,6 +112,7 @@ export const PersonsTabContainer: FC<PersonsTabProps> = ({ system }) => {
                     handleSaveField('responsibleTeamUid', uid, { displayName })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             {showEmployeeTables && (
@@ -119,6 +124,7 @@ export const PersonsTabContainer: FC<PersonsTabProps> = ({ system }) => {
                         onAdd={async employee => addOperator(employee.uid)}
                         onRemove={removeOperator}
                         isLoading={isEmployeeMutationPending}
+                        canEdit={canEdit}
                     />
 
                     <EmployeeAssignmentTable
@@ -128,6 +134,7 @@ export const PersonsTabContainer: FC<PersonsTabProps> = ({ system }) => {
                         onAdd={async employee => addMaintainedBy(employee.uid)}
                         onRemove={removeMaintainedBy}
                         isLoading={isEmployeeMutationPending}
+                        canEdit={canEdit}
                     />
                 </div>
             )}

--- a/src/modules/systemHierarchy/components/tabs/PhysicalItemTab.cont.tsx
+++ b/src/modules/systemHierarchy/components/tabs/PhysicalItemTab.cont.tsx
@@ -18,6 +18,7 @@ import { CODEBOOK } from '@/types/constants/codebook'
 
 import { useItemFieldUpdate } from '../../hooks/mutations/useItemFieldUpdate'
 import { useSystemDetail } from '../../hooks/queries/useSystemDetail'
+import { useSystemEditPermission } from '../../hooks/useSystemEditPermission'
 import type { SystemLeaf } from '../../types'
 import { PhysicalItemProperties } from '../physical-item/PhysicalItemProperties.comp'
 
@@ -28,6 +29,8 @@ interface PhysicalItemTabProps {
 export const PhysicalItemTabContainer: FC<PhysicalItemTabProps> = ({ system }) => {
     const { formatMessage: fm } = useIntl()
     const physicalItem = system.physicalItem
+
+    const { canEdit } = useSystemEditPermission(system.uid)
 
     const { updateField, isPending } = useItemFieldUpdate(system.uid, {
         itemUsage: physicalItem?.itemUsage,
@@ -48,10 +51,10 @@ export const PhysicalItemTabContainer: FC<PhysicalItemTabProps> = ({ system }) =
             value: unknown,
             options?: { displayName?: string | null; previousValue?: unknown },
         ) => {
-            if (!physicalItem?.uid) return
+            if (!canEdit || !physicalItem?.uid) return
             await updateField(physicalItem.uid, fieldName, value, options)
         },
-        [physicalItem?.uid, updateField],
+        [canEdit, physicalItem?.uid, updateField],
     )
 
     if (!physicalItem) {
@@ -91,6 +94,7 @@ export const PhysicalItemTabContainer: FC<PhysicalItemTabProps> = ({ system }) =
                     })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldCombobox
@@ -104,6 +108,7 @@ export const PhysicalItemTabContainer: FC<PhysicalItemTabProps> = ({ system }) =
                     handleSaveField('itemUsageUid', uid, { displayName })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldCombobox
@@ -117,6 +122,7 @@ export const PhysicalItemTabContainer: FC<PhysicalItemTabProps> = ({ system }) =
                     handleSaveField('conditionStatusUid', uid, { displayName })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             <InlineFieldTextArea
@@ -126,6 +132,7 @@ export const PhysicalItemTabContainer: FC<PhysicalItemTabProps> = ({ system }) =
                     handleSaveField('notes', value, { previousValue: physicalItem.notes })
                 }
                 isPending={isPending}
+                disabled={!canEdit}
             />
 
             {hasProperties && (

--- a/src/modules/systemHierarchy/hooks/__tests__/useCreateSubsystemAction.spec.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useCreateSubsystemAction.spec.tsx
@@ -5,6 +5,7 @@ import { useDynamicModalStore } from '@/store/useDynamicModalStore'
 import { AllProvidersWrapper } from '@/testutils/wrappers/AllProvidersWrapper'
 import { SystemLevel } from '@/types/gql/graphql'
 
+import { guardSystemEdit } from '../../utils/guardSystemEdit'
 import { useCreateSubsystemAction } from '../useCreateSubsystemAction'
 
 jest.mock('@/hooks/usePermission', () => ({
@@ -19,8 +20,13 @@ jest.mock('../../components/create/CreateSubsystemDialog.comp', () => ({
     CreateSubsystemDialog: () => null,
 }))
 
+jest.mock('../../utils/guardSystemEdit', () => ({
+    guardSystemEdit: jest.fn(),
+}))
+
 const mockUsePermission = usePermission as jest.Mock
 const mockUseDynamicModalStore = useDynamicModalStore as unknown as jest.Mock
+const mockGuardSystemEdit = guardSystemEdit as jest.Mock
 
 let openModal: jest.Mock
 let closeModal: jest.Mock
@@ -30,23 +36,30 @@ beforeEach(() => {
     openModal = jest.fn()
     closeModal = jest.fn()
     mockUseDynamicModalStore.mockReturnValue({ openModal, closeModal })
+    // Default: the per-system check passes; overridden per test.
+    mockGuardSystemEdit.mockResolvedValue(true)
 })
 
 describe('useCreateSubsystemAction', () => {
-    it('opens the create dialog with parent context when user has edit permission', () => {
+    it('opens the create dialog with parent context when user is responsible for the parent', async () => {
         mockUsePermission.mockReturnValue(true)
         const { result } = renderHook(() => useCreateSubsystemAction(), {
             wrapper: AllProvidersWrapper,
         })
 
-        act(() =>
-            result.current.handleCreateSubsystem(
+        await act(async () => {
+            await result.current.handleCreateSubsystem(
                 'parent-1',
                 'Parent',
                 SystemLevel.KeySystems,
-            ),
-        )
+            )
+        })
 
+        expect(mockGuardSystemEdit).toHaveBeenCalledWith(
+            expect.anything(),
+            'parent-1',
+            expect.any(Function),
+        )
         expect(openModal).toHaveBeenCalledTimes(1)
         const [kind, config] = openModal.mock.calls[0]
         expect(kind).toBe('dialog')
@@ -56,20 +69,40 @@ describe('useCreateSubsystemAction', () => {
         expect(config.props.parentLevel).toBe(SystemLevel.KeySystems)
     })
 
-    it('does not open the dialog when user lacks edit permission', () => {
+    it('does not open the dialog when user lacks edit permission', async () => {
         mockUsePermission.mockReturnValue(false)
         const { result } = renderHook(() => useCreateSubsystemAction(), {
             wrapper: AllProvidersWrapper,
         })
 
-        act(() =>
-            result.current.handleCreateSubsystem(
+        await act(async () => {
+            await result.current.handleCreateSubsystem(
                 'parent-1',
                 'Parent',
                 SystemLevel.KeySystems,
-            ),
-        )
+            )
+        })
 
+        expect(mockGuardSystemEdit).not.toHaveBeenCalled()
+        expect(openModal).not.toHaveBeenCalled()
+    })
+
+    it('does not open the dialog when user is not responsible for the parent', async () => {
+        mockUsePermission.mockReturnValue(true)
+        mockGuardSystemEdit.mockResolvedValue(false)
+        const { result } = renderHook(() => useCreateSubsystemAction(), {
+            wrapper: AllProvidersWrapper,
+        })
+
+        await act(async () => {
+            await result.current.handleCreateSubsystem(
+                'parent-1',
+                'Parent',
+                SystemLevel.KeySystems,
+            )
+        })
+
+        expect(mockGuardSystemEdit).toHaveBeenCalled()
         expect(openModal).not.toHaveBeenCalled()
     })
 })

--- a/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
+++ b/src/modules/systemHierarchy/hooks/__tests__/useDeleteSystemAction.spec.tsx
@@ -4,14 +4,17 @@ import { toast } from 'sonner'
 import { usePermission } from '@/hooks/usePermission'
 import useWarningModal from '@/hooks/useWarningModal'
 
+import { guardSystemEdit } from '../../utils/guardSystemEdit'
 import { useDeleteSystem } from '../mutations/useDeleteSystem'
 import { useSystemDetail } from '../queries/useSystemDetail'
 import { useSystemHierarchy } from '../queries/useSystemHierarchy'
 import { useDeleteSystemAction } from '../useDeleteSystemAction'
 import { useHierarchyNavigation } from '../useHierarchyNavigation'
 
+jest.mock('@tanstack/react-query', () => ({ useQueryClient: () => ({}) }))
 jest.mock('@/hooks/usePermission', () => ({ usePermission: jest.fn() }))
 jest.mock('@/hooks/useWarningModal', () => ({ __esModule: true, default: jest.fn() }))
+jest.mock('../../utils/guardSystemEdit', () => ({ guardSystemEdit: jest.fn() }))
 jest.mock('../mutations/useDeleteSystem', () => ({ useDeleteSystem: jest.fn() }))
 jest.mock('../queries/useSystemDetail', () => ({ useSystemDetail: jest.fn() }))
 jest.mock('../queries/useSystemHierarchy', () => ({ useSystemHierarchy: jest.fn() }))
@@ -25,6 +28,7 @@ jest.mock('react-intl', () => ({
 }))
 
 const mockUsePermission = usePermission as jest.Mock
+const mockGuardSystemEdit = guardSystemEdit as jest.Mock
 const mockUseWarningModal = useWarningModal as unknown as jest.Mock
 const mockUseDeleteSystem = useDeleteSystem as jest.Mock
 const mockUseSystemDetail = useSystemDetail as jest.Mock
@@ -52,6 +56,8 @@ beforeEach(() => {
     lastConfirmMessage = undefined
 
     mockUsePermission.mockReturnValue(true)
+    // Per-system check passes by default; overridden per test.
+    mockGuardSystemEdit.mockResolvedValue(true)
     // withWarningModal(cb, msg) → trigger that runs cb immediately (simulating confirm)
     mockUseWarningModal.mockReturnValue(
         (cb: (...args: unknown[]) => void, msg?: string) =>
@@ -76,41 +82,41 @@ const getToastHandlers = () => {
 }
 
 describe('useDeleteSystemAction', () => {
-    it('does nothing when the user lacks edit permission', () => {
+    it('does nothing when the user lacks edit permission', async () => {
         mockUsePermission.mockReturnValue(false)
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
 
         expect(mockToastPromise).not.toHaveBeenCalled()
         expect(mutateAsync).not.toHaveBeenCalled()
     })
 
-    it('ignores re-entry while a delete is already in flight', () => {
+    it('ignores re-entry while a delete is already in flight', async () => {
         mockUseDeleteSystem.mockReturnValue({ mutateAsync, isPending: true })
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
 
         expect(mockToastPromise).not.toHaveBeenCalled()
         expect(mutateAsync).not.toHaveBeenCalled()
     })
 
-    it('confirms with recursive wording then deletes via the mutation', () => {
+    it('confirms with recursive wording then deletes via the mutation', async () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
 
         expect(lastConfirmMessage).toBe('systemHierarchy.delete.confirm|Pump A')
         expect(mutateAsync).toHaveBeenCalledWith({ uid: 'sys-1' })
         expect(mockToastPromise).toHaveBeenCalledTimes(1)
     })
 
-    it('resets selection on success when the deleted system is currently open', () => {
+    it('resets selection on success when the deleted system is currently open', async () => {
         setNavigation({ selectedLeafUid: 'sys-1' })
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
         const { success } = getToastHandlers()
         const successMessage = success()
 
@@ -118,20 +124,20 @@ describe('useDeleteSystemAction', () => {
         expect(successMessage).toBe('systemHierarchy.delete.success|Pump A')
     })
 
-    it('resets selection when the deleted system is an ancestor of the open node', () => {
+    it('resets selection when the deleted system is an ancestor of the open node', async () => {
         mockUseSystemHierarchy.mockReturnValue({
             nodes: [{ uid: 'root', children: [{ uid: 'child', children: [] }] }],
         })
         setNavigation({ selectedParentUid: 'child' })
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('root', 'Root'))
+        await act(async () => result.current.handleDeleteSystem('root', 'Root'))
         getToastHandlers().success()
 
         expect(clearSelection).toHaveBeenCalledTimes(1)
     })
 
-    it('resets selection when the deleted system is an ancestor of the open detail leaf', () => {
+    it('resets selection when the deleted system is an ancestor of the open detail leaf', async () => {
         // Leaf opened via selectLeaf — parent stays on an unrelated root.
         mockUseSystemDetail.mockReturnValue({
             system: { parentPath: [{ uid: 'root' }, { uid: 'mid' }] },
@@ -140,26 +146,26 @@ describe('useDeleteSystemAction', () => {
         setNavigation({ selectedLeafUid: 'leaf-x', selectedParentUid: 'unrelated-root' })
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('mid', 'Mid'))
+        await act(async () => result.current.handleDeleteSystem('mid', 'Mid'))
         getToastHandlers().success()
 
         expect(clearSelection).toHaveBeenCalledTimes(1)
     })
 
-    it('does not reset selection when an unrelated system is deleted', () => {
+    it('does not reset selection when an unrelated system is deleted', async () => {
         setNavigation({ selectedParentUid: 'other', selectedLeafUid: 'other' })
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
         getToastHandlers().success()
 
         expect(clearSelection).not.toHaveBeenCalled()
     })
 
-    it('lists the blocking physical items on a 409 conflict', () => {
+    it('lists the blocking physical items on a 409 conflict', async () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
         const message = getToastHandlers().error({
             response: {
                 status: 409,
@@ -170,10 +176,10 @@ describe('useDeleteSystemAction', () => {
         expect(message).toBe('systemHierarchy.delete.conflict|Pump A|Item A, Item B')
     })
 
-    it('caps the listed items and appends a locale-neutral overflow count', () => {
+    it('caps the listed items and appends a locale-neutral overflow count', async () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
         const message = getToastHandlers().error({
             response: {
                 status: 409,
@@ -189,21 +195,36 @@ describe('useDeleteSystemAction', () => {
         expect(message).toBe('systemHierarchy.delete.conflict|Pump A|Item A, Item B, Item C (+1)')
     })
 
-    it('uses the generic conflict message when the 409 body is empty', () => {
+    it('uses the generic conflict message when the 409 body is empty', async () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
         const message = getToastHandlers().error({ response: { status: 409, data: [] } })
 
         expect(message).toBe('systemHierarchy.delete.conflictGeneric|Pump A')
     })
 
-    it('uses the generic error message for non-409 failures', () => {
+    it('uses the generic error message for non-409 failures', async () => {
         const { result } = renderHook(() => useDeleteSystemAction())
 
-        act(() => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
         const message = getToastHandlers().error({ response: { status: 500 } })
 
         expect(message).toBe('systemHierarchy.delete.error|Pump A')
+    })
+
+    it('checks per-system permission for the target and blocks when not responsible', async () => {
+        mockGuardSystemEdit.mockResolvedValue(false)
+        const { result } = renderHook(() => useDeleteSystemAction())
+
+        await act(async () => result.current.handleDeleteSystem('sys-1', 'Pump A'))
+
+        expect(mockGuardSystemEdit).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys-1',
+            expect.any(Function),
+        )
+        expect(mockToastPromise).not.toHaveBeenCalled()
+        expect(mutateAsync).not.toHaveBeenCalled()
     })
 })

--- a/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react'
+
+import { useSystemCanEdit } from '../queries/useSystemCanEdit'
+import { formatResponsibleName, useSystemEditPermission } from '../useSystemEditPermission'
+
+jest.mock('../queries/useSystemCanEdit', () => ({
+    useSystemCanEdit: jest.fn(),
+}))
+
+const mockUseSystemCanEdit = useSystemCanEdit as jest.Mock
+
+const responsible = {
+    uid: 'u1',
+    firstName: 'Ann',
+    lastName: 'Lee',
+    username: 'alee',
+    email: 'ann.lee@eli.eu',
+}
+
+const setQuery = (overrides: Record<string, unknown>) =>
+    mockUseSystemCanEdit.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        refetch: jest.fn(),
+        ...overrides,
+    })
+
+describe('useSystemEditPermission', () => {
+    it('is denied and fail-closed while loading', () => {
+        setQuery({ isLoading: true })
+        const { result } = renderHook(() => useSystemEditPermission('s1'))
+        expect(result.current.status).toBe('loading')
+        expect(result.current.canEdit).toBe(false)
+    })
+
+    it('is fail-closed on fetch error', () => {
+        setQuery({ isError: true })
+        const { result } = renderHook(() => useSystemEditPermission('s1'))
+        expect(result.current.status).toBe('error')
+        expect(result.current.canEdit).toBe(false)
+    })
+
+    it('allows editing when the backend confirms', () => {
+        setQuery({ data: { result: true, responsibles: [responsible] } })
+        const { result } = renderHook(() => useSystemEditPermission('s1'))
+        expect(result.current.status).toBe('allowed')
+        expect(result.current.canEdit).toBe(true)
+        expect(result.current.responsibles).toEqual([responsible])
+    })
+
+    it('denies and exposes responsibles when the backend says no', () => {
+        setQuery({ data: { result: false, responsibles: [responsible] } })
+        const { result } = renderHook(() => useSystemEditPermission('s1'))
+        expect(result.current.status).toBe('denied')
+        expect(result.current.canEdit).toBe(false)
+        expect(result.current.responsibles).toEqual([responsible])
+    })
+})
+
+describe('formatResponsibleName', () => {
+    it('joins first and last name', () => {
+        expect(formatResponsibleName(responsible)).toBe('Ann Lee')
+    })
+
+    it('falls back to username then email', () => {
+        expect(
+            formatResponsibleName({ ...responsible, firstName: null, lastName: null }),
+        ).toBe('alee')
+        expect(
+            formatResponsibleName({
+                ...responsible,
+                firstName: null,
+                lastName: null,
+                username: null,
+            }),
+        ).toBe('ann.lee@eli.eu')
+    })
+})

--- a/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
@@ -34,6 +34,14 @@ describe('useSystemEditPermission', () => {
         expect(result.current.canEdit).toBe(false)
     })
 
+    it('is not denied when no uid is provided (disabled query)', () => {
+        // A disabled query never loads: data undefined, isLoading false, isError false.
+        setQuery({ isLoading: false })
+        const { result } = renderHook(() => useSystemEditPermission(null))
+        expect(result.current.status).toBe('loading')
+        expect(result.current.canEdit).toBe(false)
+    })
+
     it('is fail-closed on fetch error', () => {
         setQuery({ isError: true })
         const { result } = renderHook(() => useSystemEditPermission('s1'))

--- a/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
@@ -99,6 +99,14 @@ describe('normalizeCanEditResponse', () => {
         expect(normalizeCanEditResponse({ result: 'true' }).result).toBe(false)
         expect(normalizeCanEditResponse(null)).toEqual({ result: false, responsibles: [] })
     })
+
+    it('drops responsibles with no uid (avoids blank/duplicate-key entries)', () => {
+        const normalized = normalizeCanEditResponse({
+            result: false,
+            responsibles: [responsible, { firstName: 'Ghost', email: 'ghost@eli.eu' }],
+        })
+        expect(normalized.responsibles).toEqual([responsible])
+    })
 })
 
 describe('formatResponsibleName', () => {

--- a/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useSystemEditPermission.spec.ts
@@ -1,11 +1,15 @@
 import { renderHook } from '@testing-library/react'
 
-import { useSystemCanEdit } from '../queries/useSystemCanEdit'
+import {
+    normalizeCanEditResponse,
+    useSystemCanEdit,
+} from '../queries/useSystemCanEdit'
 import { formatResponsibleName, useSystemEditPermission } from '../useSystemEditPermission'
 
-jest.mock('../queries/useSystemCanEdit', () => ({
-    useSystemCanEdit: jest.fn(),
-}))
+jest.mock('../queries/useSystemCanEdit', () => {
+    const actual = jest.requireActual('../queries/useSystemCanEdit')
+    return { ...actual, useSystemCanEdit: jest.fn() }
+})
 
 const mockUseSystemCanEdit = useSystemCanEdit as jest.Mock
 
@@ -63,6 +67,37 @@ describe('useSystemEditPermission', () => {
         expect(result.current.status).toBe('denied')
         expect(result.current.canEdit).toBe(false)
         expect(result.current.responsibles).toEqual([responsible])
+    })
+})
+
+describe('normalizeCanEditResponse', () => {
+    it('reads the documented camelCase shape', () => {
+        expect(
+            normalizeCanEditResponse({ result: true, responsibles: [responsible] }),
+        ).toEqual({ result: true, responsibles: [responsible] })
+    })
+
+    it('tolerates PascalCase field names (gateway serializer drift)', () => {
+        const normalized = normalizeCanEditResponse({
+            Result: true,
+            Responsibles: [
+                {
+                    Uid: 'u1',
+                    FirstName: 'Ann',
+                    LastName: 'Lee',
+                    Username: 'alee',
+                    Email: 'ann.lee@eli.eu',
+                },
+            ],
+        })
+        expect(normalized.result).toBe(true)
+        expect(normalized.responsibles[0]).toEqual(responsible)
+    })
+
+    it('fails closed on a missing/garbage result value', () => {
+        expect(normalizeCanEditResponse({ responsibles: [] }).result).toBe(false)
+        expect(normalizeCanEditResponse({ result: 'true' }).result).toBe(false)
+        expect(normalizeCanEditResponse(null)).toEqual({ result: false, responsibles: [] })
     })
 })
 

--- a/src/modules/systemHierarchy/hooks/mutations/__tests__/useItemFieldUpdate.spec.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/__tests__/useItemFieldUpdate.spec.ts
@@ -3,9 +3,13 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { request } from 'graphql-request'
 import React from 'react'
 
+import { guardSystemEdit } from '../../../utils/guardSystemEdit'
+
 jest.mock('graphql-request', () => ({
     request: jest.fn(),
 }))
+
+jest.mock('../../../utils/guardSystemEdit', () => ({ guardSystemEdit: jest.fn() }))
 
 jest.mock('sonner', () => ({ toast: { promise: jest.fn() } }))
 
@@ -16,6 +20,7 @@ jest.mock('react-intl', () => ({
 }))
 
 const mockRequest = request as jest.Mock
+const mockGuardSystemEdit = guardSystemEdit as jest.Mock
 
 const mockSuccessResponse = {
     updateItems: {
@@ -51,6 +56,7 @@ describe('useItemFieldUpdate', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         mockRequest.mockResolvedValue(mockSuccessResponse)
+        mockGuardSystemEdit.mockResolvedValue(true)
     })
 
     it('records WAS_UPDATED_BY against the System node for a scalar item field', async () => {
@@ -143,5 +149,26 @@ describe('useItemFieldUpdate', () => {
         })
 
         invalidateSpy.mockRestore()
+    })
+
+    it('never patches the item when the owning system is not editable', async () => {
+        mockGuardSystemEdit.mockResolvedValue(false)
+        const { useItemFieldUpdate } = await import('../useItemFieldUpdate')
+
+        const { result } = renderHook(() => useItemFieldUpdate('sys-1'), {
+            wrapper: createWrapper(),
+        })
+
+        await act(async () => {
+            await result.current.updateField('item-1', 'notes', 'hello')
+        })
+
+        // Permission is checked against the owning system, not the item.
+        expect(mockGuardSystemEdit).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys-1',
+            expect.any(Function),
+        )
+        expect(mockRequest).not.toHaveBeenCalled()
     })
 })

--- a/src/modules/systemHierarchy/hooks/mutations/__tests__/useSystemFieldUpdate.spec.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/__tests__/useSystemFieldUpdate.spec.ts
@@ -3,9 +3,13 @@ import { act, renderHook, waitFor } from '@testing-library/react'
 import { request } from 'graphql-request'
 import React from 'react'
 
+import { guardSystemEdit } from '../../../utils/guardSystemEdit'
+
 jest.mock('graphql-request', () => ({
     request: jest.fn(),
 }))
+
+jest.mock('../../../utils/guardSystemEdit', () => ({ guardSystemEdit: jest.fn() }))
 
 jest.mock('sonner', () => ({ toast: { promise: jest.fn() } }))
 
@@ -16,6 +20,7 @@ jest.mock('react-intl', () => ({
 }))
 
 const mockRequest = request as jest.Mock
+const mockGuardSystemEdit = guardSystemEdit as jest.Mock
 
 const mockSuccessResponse = {
     updateSystems: {
@@ -56,6 +61,8 @@ describe('useSystemFieldUpdate', () => {
     beforeEach(() => {
         jest.clearAllMocks()
         mockRequest.mockResolvedValue(mockSuccessResponse)
+        // Permission check passes by default; overridden in guard-specific tests.
+        mockGuardSystemEdit.mockResolvedValue(true)
     })
 
     it('sends updatedByResolver params for scalar field update', async () => {
@@ -196,5 +203,49 @@ describe('useSystemFieldUpdate', () => {
         })
 
         await waitFor(() => expect(result.current.isPending).toBe(false))
+    })
+
+    it('never sends the GraphQL patch when the permission guard denies', async () => {
+        mockGuardSystemEdit.mockResolvedValue(false)
+        const { useSystemFieldUpdate } = await import('../useSystemFieldUpdate')
+
+        const { result } = renderHook(() => useSystemFieldUpdate(), {
+            wrapper: createWrapper(),
+        })
+
+        await act(async () => {
+            await result.current.updateField('sys-1', 'name', 'New Name')
+        })
+
+        expect(mockGuardSystemEdit).toHaveBeenCalledWith(
+            expect.anything(),
+            'sys-1',
+            expect.any(Function),
+        )
+        expect(mockRequest).not.toHaveBeenCalled()
+    })
+
+    it('invalidates the can-edit cache after a responsible change', async () => {
+        const { useSystemFieldUpdate } = await import('../useSystemFieldUpdate')
+
+        const { result } = renderHook(() => useSystemFieldUpdate(), {
+            wrapper: createWrapper(),
+        })
+
+        const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries')
+
+        await act(async () => {
+            await result.current.updateField('sys-1', 'responsibleUid', 'emp-2', {
+                displayName: 'Jane',
+            })
+        })
+
+        await waitFor(() => {
+            expect(invalidateSpy).toHaveBeenCalledWith(
+                expect.objectContaining({ queryKey: ['systemCanEdit'] }),
+            )
+        })
+
+        invalidateSpy.mockRestore()
     })
 })

--- a/src/modules/systemHierarchy/hooks/mutations/useItemFieldUpdate.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useItemFieldUpdate.ts
@@ -10,6 +10,7 @@ import { gql } from '@/types/gql'
 import { SYSTEM_DETAIL_QUERY_KEY } from '../../types/constants'
 import type { ChangeValue, CodebookSnapshot, FieldChangeEntry } from '../../types/history'
 import { buildChangeEntry, buildCodebookSnapshot } from '../../utils/fieldChangeBuilder'
+import { guardSystemEdit } from '../../utils/guardSystemEdit'
 
 // Lightweight mutation for single item field updates. The WAS_UPDATED_BY edge is recorded
 // against the owning System node (not the Item) so the change surfaces in the system history
@@ -120,6 +121,10 @@ export const useItemFieldUpdate = (systemUid: string, currentItem?: ItemFieldCac
 
     const updateField = useCallback(
         async (uid: string, fieldName: string, value: unknown, options?: UpdateFieldOptions) => {
+            // Hard guard: physical-item edits are permission-checked against the
+            // owning system. Block the GraphQL patch when the user isn't allowed.
+            if (!(await guardSystemEdit(queryClient, systemUid, fm))) return
+
             const displayName = options?.displayName
             let update: Record<string, unknown>
             let changeEntry: FieldChangeEntry | null = null
@@ -187,7 +192,7 @@ export const useItemFieldUpdate = (systemUid: string, currentItem?: ItemFieldCac
 
             return promise
         },
-        [fm, mutateAsync, systemUid],
+        [fm, mutateAsync, systemUid, queryClient],
     )
 
     return {

--- a/src/modules/systemHierarchy/hooks/mutations/useSystemFieldUpdate.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useSystemFieldUpdate.ts
@@ -239,9 +239,13 @@ export const useSystemFieldUpdate = (currentSystem?: SystemFieldCache) => {
             // A responsible/team change may have revoked the user's own access —
             // re-derive can-edit once the save lands.
             if (RESPONSIBILITY_FIELDS.includes(fieldName)) {
-                void promise.then(() =>
-                    queryClient.invalidateQueries({ queryKey: [SYSTEM_CAN_EDIT_QUERY_KEY] }),
-                )
+                void promise
+                    .then(() =>
+                        queryClient.invalidateQueries({ queryKey: [SYSTEM_CAN_EDIT_QUERY_KEY] }),
+                    )
+                    // The failure itself is surfaced by the toast.promise below; this
+                    // side-chain only needs to avoid an unhandled rejection.
+                    .catch(() => {})
             }
 
             // Custom toast messages for systemCode

--- a/src/modules/systemHierarchy/hooks/mutations/useSystemFieldUpdate.ts
+++ b/src/modules/systemHierarchy/hooks/mutations/useSystemFieldUpdate.ts
@@ -10,6 +10,12 @@ import { gql } from '@/types/gql'
 import { SYSTEM_DETAIL_QUERY_KEY } from '../../types/constants'
 import type { ChangeValue, CodebookSnapshot, FieldChangeEntry } from '../../types/history'
 import { buildChangeEntry, buildCodebookSnapshot } from '../../utils/fieldChangeBuilder'
+import { guardSystemEdit } from '../../utils/guardSystemEdit'
+import { SYSTEM_CAN_EDIT_QUERY_KEY } from '../queries/useSystemCanEdit'
+
+// Changing responsibility can revoke the current user's own edit rights, so the
+// cached can-edit result must be re-derived after these saves.
+const RESPONSIBILITY_FIELDS = ['responsibleUid', 'responsibleTeamUid']
 
 // Lightweight mutation for single field updates
 const updateSystemFieldMutation = gql(`
@@ -154,6 +160,10 @@ export const useSystemFieldUpdate = (currentSystem?: SystemFieldCache) => {
             value: unknown,
             options?: { displayName?: string | null; previousValue?: unknown },
         ) => {
+            // Hard guard: never let an unpermitted GraphQL patch reach the server,
+            // regardless of whether the UI disabled the field.
+            if (!(await guardSystemEdit(queryClient, uid, fm))) return
+
             const displayName = options?.displayName
             let update: Record<string, unknown>
             let changeEntry: FieldChangeEntry | null = null
@@ -226,6 +236,14 @@ export const useSystemFieldUpdate = (currentSystem?: SystemFieldCache) => {
                 changes: changesPayload,
             })
 
+            // A responsible/team change may have revoked the user's own access —
+            // re-derive can-edit once the save lands.
+            if (RESPONSIBILITY_FIELDS.includes(fieldName)) {
+                void promise.then(() =>
+                    queryClient.invalidateQueries({ queryKey: [SYSTEM_CAN_EDIT_QUERY_KEY] }),
+                )
+            }
+
             // Custom toast messages for systemCode
             if (fieldName === 'systemCode') {
                 toast.promise(promise, {
@@ -262,7 +280,7 @@ export const useSystemFieldUpdate = (currentSystem?: SystemFieldCache) => {
 
             return promise
         },
-        [fm, mutateAsync],
+        [fm, mutateAsync, queryClient],
     )
 
     return {

--- a/src/modules/systemHierarchy/hooks/queries/useSystemCanEdit.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemCanEdit.ts
@@ -1,0 +1,54 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
+
+import type { AxiosError } from '@/types/http'
+import type { QueryFetcherKey } from '@/utils/fetcher'
+import { queryFetcher } from '@/utils/fetcher'
+
+export const SYSTEM_CAN_EDIT_QUERY_KEY = 'systemCanEdit'
+
+// A user responsible for a system (or one of its ancestors). Shape mirrors the
+// backend GET /system/{uid}/can-edit response.
+export interface SystemResponsible {
+    uid: string
+    firstName: string | null
+    lastName: string | null
+    username: string | null
+    email: string | null
+}
+
+export interface SystemCanEditResponse {
+    // `true` if the current user may edit this system. Always accompanied by
+    // `responsibles` so the UI can point unpermitted users at someone.
+    result: boolean
+    responsibles: SystemResponsible[]
+}
+
+const canEditQueryFn = queryFetcher<SystemCanEditResponse>('systemCanEdit')
+
+/**
+ * Per-system edit permission from the backend. Authoritative source (GraphQL has
+ * no canEdit/responsibles field and team-membership/ancestors can't be resolved
+ * client-side). Shared cache key with {@link ensureSystemCanEdit}.
+ */
+export const useSystemCanEdit = (uid?: string | null) =>
+    useQuery<SystemCanEditResponse, AxiosError, SystemCanEditResponse, QueryFetcherKey>({
+        queryKey: [SYSTEM_CAN_EDIT_QUERY_KEY, { uid }],
+        queryFn: canEditQueryFn,
+        enabled: !!uid,
+        staleTime: 0,
+    })
+
+/**
+ * Imperative read of the same cached can-edit result, for check-on-click guards
+ * (create/delete). Reuses the query cache so it never double-fetches the system
+ * currently shown in the detail view.
+ */
+export const ensureSystemCanEdit = (
+    queryClient: QueryClient,
+    uid: string,
+): Promise<SystemCanEditResponse> =>
+    queryClient.ensureQueryData<SystemCanEditResponse, AxiosError, SystemCanEditResponse, QueryFetcherKey>({
+        queryKey: [SYSTEM_CAN_EDIT_QUERY_KEY, { uid }],
+        queryFn: canEditQueryFn,
+    })

--- a/src/modules/systemHierarchy/hooks/queries/useSystemCanEdit.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemCanEdit.ts
@@ -1,4 +1,4 @@
-import type { QueryClient } from '@tanstack/react-query'
+import type { QueryClient, QueryFunction } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
 
 import type { AxiosError } from '@/types/http'
@@ -24,7 +24,50 @@ export interface SystemCanEditResponse {
     responsibles: SystemResponsible[]
 }
 
-const canEditQueryFn = queryFetcher<SystemCanEditResponse>('systemCanEdit')
+// First value present under any of the given keys — tolerates casing drift
+// (e.g. a PascalCase gateway serializer) without a bespoke DTO per environment.
+const pick = (obj: Record<string, unknown>, ...keys: string[]): unknown => {
+    for (const key of keys) {
+        if (obj[key] !== undefined && obj[key] !== null) return obj[key]
+    }
+    return undefined
+}
+
+const toStringOrNull = (value: unknown): string | null =>
+    typeof value === 'string' && value !== '' ? value : null
+
+const normalizeResponsible = (raw: Record<string, unknown>): SystemResponsible => ({
+    uid: String(pick(raw, 'uid', 'Uid', 'UID') ?? ''),
+    firstName: toStringOrNull(pick(raw, 'firstName', 'FirstName')),
+    lastName: toStringOrNull(pick(raw, 'lastName', 'LastName')),
+    username: toStringOrNull(pick(raw, 'username', 'Username', 'userName', 'UserName')),
+    email: toStringOrNull(pick(raw, 'email', 'Email')),
+})
+
+/**
+ * Normalizes the raw `can-edit` payload to our contract. Deliberately tolerant of
+ * field-name casing so a serializer difference on the live gateway can't silently
+ * flip every system to `denied` (fail-closed + contract drift = whole-module
+ * lockout). Still fail-closed on the value: `result` must be an explicit boolean
+ * `true`, anything else → `false`.
+ */
+export const normalizeCanEditResponse = (raw: unknown): SystemCanEditResponse => {
+    const obj = (raw && typeof raw === 'object' ? raw : {}) as Record<string, unknown>
+    const result = pick(obj, 'result', 'Result')
+    const responsibles = pick(obj, 'responsibles', 'Responsibles')
+    return {
+        result: result === true,
+        responsibles: Array.isArray(responsibles)
+            ? responsibles
+                  .filter((r): r is Record<string, unknown> => !!r && typeof r === 'object')
+                  .map(normalizeResponsible)
+            : [],
+    }
+}
+
+const rawCanEditQueryFn = queryFetcher<unknown>('systemCanEdit')
+const canEditQueryFn: QueryFunction<SystemCanEditResponse, QueryFetcherKey> = async ctx =>
+    normalizeCanEditResponse(await rawCanEditQueryFn(ctx))
 
 /**
  * Per-system edit permission from the backend. Authoritative source (GraphQL has
@@ -36,6 +79,9 @@ export const useSystemCanEdit = (uid?: string | null) =>
         queryKey: [SYSTEM_CAN_EDIT_QUERY_KEY, { uid }],
         queryFn: canEditQueryFn,
         enabled: !!uid,
+        // Always-fresh on purpose: this is the security gate for otherwise
+        // unguarded GraphQL patches, so we prefer a re-check over a stale allow.
+        // `ensureSystemCanEdit` still reuses this cache entry within a render pass.
         staleTime: 0,
     })
 

--- a/src/modules/systemHierarchy/hooks/queries/useSystemCanEdit.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemCanEdit.ts
@@ -61,6 +61,9 @@ export const normalizeCanEditResponse = (raw: unknown): SystemCanEditResponse =>
             ? responsibles
                   .filter((r): r is Record<string, unknown> => !!r && typeof r === 'object')
                   .map(normalizeResponsible)
+                  // Drop identity-less entries: they'd collide on the React key and
+                  // render blank in the tooltip.
+                  .filter(r => r.uid)
             : [],
     }
 }

--- a/src/modules/systemHierarchy/hooks/useCreateSubsystemAction.ts
+++ b/src/modules/systemHierarchy/hooks/useCreateSubsystemAction.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 import { useIntl } from 'react-intl'
 
@@ -8,15 +9,21 @@ import { ROLE } from '@/types/constants/roles'
 import type { SystemLevel } from '@/types/gql/graphql'
 
 import { CreateSubsystemDialog } from '../components/create/CreateSubsystemDialog.comp'
+import { guardSystemEdit } from '../utils/guardSystemEdit'
 
 export const useCreateSubsystemAction = () => {
     const { formatMessage: fm } = useIntl()
+    const queryClient = useQueryClient()
     const { openModal, closeModal } = useDynamicModalStore()
     const canEdit = usePermission([ROLE.SYSTEM_EDIT])
 
     const handleCreateSubsystem = useCallback(
-        (parentUid: string, parentName: string, parentLevel: SystemLevel) => {
+        async (parentUid: string, parentName: string, parentLevel: SystemLevel) => {
+            // Role is the cheap first-line filter; the per-system check (against the
+            // parent) confirms the user is responsible before opening the dialog.
             if (!canEdit) return
+            if (!(await guardSystemEdit(queryClient, parentUid, fm))) return
+
             const modalId = `create-subsystem-${parentUid}`
             const parentLevelLabel = fm({
                 id: message.systemHierarchy.systemLevels[parentLevel],
@@ -38,7 +45,7 @@ export const useCreateSubsystemAction = () => {
                 },
             })
         },
-        [canEdit, openModal, closeModal, fm],
+        [canEdit, queryClient, openModal, closeModal, fm],
     )
 
     return { handleCreateSubsystem }

--- a/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
+++ b/src/modules/systemHierarchy/hooks/useDeleteSystemAction.ts
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 import { useIntl } from 'react-intl'
 import { toast } from 'sonner'
@@ -9,6 +10,7 @@ import { ROLE } from '@/types/constants/roles'
 import type { AxiosError } from '@/types/http'
 import { createMessageValues } from '@/utils/formatters'
 
+import { guardSystemEdit } from '../utils/guardSystemEdit'
 import { findHierarchyPath } from '../utils/treePath'
 import { useDeleteSystem } from './mutations/useDeleteSystem'
 import { useSystemDetail } from './queries/useSystemDetail'
@@ -34,6 +36,7 @@ type PhysicalItemConflict = {
 
 export const useDeleteSystemAction = () => {
     const { formatMessage: fm } = useIntl()
+    const queryClient = useQueryClient()
     const canEdit = usePermission([ROLE.SYSTEM_EDIT])
     const withWarningModal = useWarningModal()
     const { nodes } = useSystemHierarchy()
@@ -74,8 +77,11 @@ export const useDeleteSystemAction = () => {
     )
 
     const handleDeleteSystem = useCallback(
-        (uid: string, name: string) => {
+        async (uid: string, name: string) => {
             if (!canEdit || isPending) return
+            // Per-system check-on-click: role-holders who aren't responsible for
+            // this node are blocked with a toast before the confirm dialog.
+            if (!(await guardSystemEdit(queryClient, uid, fm))) return
 
             const runDelete = () => {
                 toast.promise(mutateAsync({ uid }), {
@@ -98,6 +104,7 @@ export const useDeleteSystemAction = () => {
         },
         [
             canEdit,
+            queryClient,
             isPending,
             withWarningModal,
             fm,

--- a/src/modules/systemHierarchy/hooks/useSystemEditPermission.ts
+++ b/src/modules/systemHierarchy/hooks/useSystemEditPermission.ts
@@ -20,13 +20,16 @@ export interface SystemEditPermission {
 export const useSystemEditPermission = (uid?: string | null): SystemEditPermission => {
     const { data, isLoading, isError, refetch } = useSystemCanEdit(uid)
 
-    const status: SystemEditPermissionStatus = isLoading
-        ? 'loading'
-        : isError
-          ? 'error'
-          : data?.result
-            ? 'allowed'
-            : 'denied'
+    // No uid → the query is disabled (never loads), so treat it as a non-denied
+    // "nothing to decide yet" state rather than letting the ternary fall to 'denied'.
+    const status: SystemEditPermissionStatus =
+        !uid || isLoading
+            ? 'loading'
+            : isError
+              ? 'error'
+              : data?.result
+                ? 'allowed'
+                : 'denied'
 
     return {
         canEdit: status === 'allowed',

--- a/src/modules/systemHierarchy/hooks/useSystemEditPermission.ts
+++ b/src/modules/systemHierarchy/hooks/useSystemEditPermission.ts
@@ -1,0 +1,43 @@
+import type { SystemResponsible } from './queries/useSystemCanEdit'
+import { useSystemCanEdit } from './queries/useSystemCanEdit'
+
+export type SystemEditPermissionStatus = 'loading' | 'error' | 'allowed' | 'denied'
+
+export interface SystemEditPermission {
+    // True only when the backend confirmed edit rights. Fail-closed: false while
+    // loading and on fetch error, so an un-verifiable state never leaves editing open.
+    canEdit: boolean
+    responsibles: SystemResponsible[]
+    status: SystemEditPermissionStatus
+    refetch: () => void
+}
+
+/**
+ * Single decision point for per-system edit permission. Every consumer (detail
+ * tabs, header actions, sidebar image panel) calls this with its own system uid;
+ * React Query dedups the underlying fetch so it stays one request per system.
+ */
+export const useSystemEditPermission = (uid?: string | null): SystemEditPermission => {
+    const { data, isLoading, isError, refetch } = useSystemCanEdit(uid)
+
+    const status: SystemEditPermissionStatus = isLoading
+        ? 'loading'
+        : isError
+          ? 'error'
+          : data?.result
+            ? 'allowed'
+            : 'denied'
+
+    return {
+        canEdit: status === 'allowed',
+        responsibles: data?.responsibles ?? [],
+        status,
+        refetch: () => void refetch(),
+    }
+}
+
+/** Human-readable "First Last" for a responsible, falling back to username. */
+export const formatResponsibleName = (responsible: SystemResponsible): string => {
+    const fullName = [responsible.firstName, responsible.lastName].filter(Boolean).join(' ').trim()
+    return fullName || responsible.username || responsible.email || ''
+}

--- a/src/modules/systemHierarchy/utils/__tests__/guardSystemEdit.spec.ts
+++ b/src/modules/systemHierarchy/utils/__tests__/guardSystemEdit.spec.ts
@@ -1,0 +1,56 @@
+import type { QueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { ensureSystemCanEdit } from '../../hooks/queries/useSystemCanEdit'
+import { guardSystemEdit } from '../guardSystemEdit'
+
+jest.mock('../../hooks/queries/useSystemCanEdit', () => ({
+    ensureSystemCanEdit: jest.fn(),
+}))
+jest.mock('sonner', () => ({ toast: { error: jest.fn() } }))
+
+const mockEnsure = ensureSystemCanEdit as jest.Mock
+const mockToastError = toast.error as jest.Mock
+
+// Echoes the message id + interpolated values so assertions can inspect them.
+const fm = (({ id }: { id: string }, values?: Record<string, unknown>) =>
+    [id, values?.names].filter(v => v != null).join('|')) as never
+
+const qc = {} as QueryClient
+
+beforeEach(() => jest.clearAllMocks())
+
+describe('guardSystemEdit', () => {
+    it('returns true and stays silent when the user is permitted', async () => {
+        mockEnsure.mockResolvedValue({ result: true, responsibles: [] })
+        await expect(guardSystemEdit(qc, 's1', fm)).resolves.toBe(true)
+        expect(mockToastError).not.toHaveBeenCalled()
+    })
+
+    it('returns false and toasts the responsibles when denied', async () => {
+        mockEnsure.mockResolvedValue({
+            result: false,
+            responsibles: [
+                { uid: 'u1', firstName: 'Ann', lastName: 'Lee', username: 'alee', email: null },
+            ],
+        })
+        await expect(guardSystemEdit(qc, 's1', fm)).resolves.toBe(false)
+        expect(mockToastError).toHaveBeenCalledWith(
+            'systemHierarchy.permission.blockedToast|Ann Lee',
+        )
+    })
+
+    it('uses the no-responsibles message when the list is empty', async () => {
+        mockEnsure.mockResolvedValue({ result: false, responsibles: [] })
+        await expect(guardSystemEdit(qc, 's1', fm)).resolves.toBe(false)
+        expect(mockToastError).toHaveBeenCalledWith(
+            'systemHierarchy.permission.blockedToastNoResponsibles',
+        )
+    })
+
+    it('fails closed (returns false) when the permission check throws', async () => {
+        mockEnsure.mockRejectedValue(new Error('network'))
+        await expect(guardSystemEdit(qc, 's1', fm)).resolves.toBe(false)
+        expect(mockToastError).toHaveBeenCalledWith('systemHierarchy.permission.errorTitle')
+    })
+})

--- a/src/modules/systemHierarchy/utils/guardSystemEdit.ts
+++ b/src/modules/systemHierarchy/utils/guardSystemEdit.ts
@@ -1,0 +1,40 @@
+import type { QueryClient } from '@tanstack/react-query'
+import type { IntlShape } from 'react-intl'
+import { toast } from 'sonner'
+
+import { message } from '@/i18n/src/messages'
+
+import { ensureSystemCanEdit } from '../hooks/queries/useSystemCanEdit'
+import { formatResponsibleName } from '../hooks/useSystemEditPermission'
+
+/**
+ * Imperative per-system edit gate. Reads the (cached) can-edit result and, when
+ * the user isn't permitted, fires a toast naming the responsibles and returns
+ * false. Used by mutation hooks and check-on-click action guards so an
+ * unpermitted GraphQL patch can never reach the server.
+ *
+ * Returns true when permitted, false when blocked (or on verification failure —
+ * fail closed). Callers should abort the mutation when this returns false.
+ */
+export const guardSystemEdit = async (
+    queryClient: QueryClient,
+    uid: string,
+    fm: IntlShape['formatMessage'],
+): Promise<boolean> => {
+    try {
+        const { result, responsibles } = await ensureSystemCanEdit(queryClient, uid)
+        if (result) return true
+
+        const names = responsibles.map(formatResponsibleName).filter(Boolean).join(', ')
+        toast.error(
+            names
+                ? fm({ id: message.systemHierarchy.permission.blockedToast }, { names })
+                : fm({ id: message.systemHierarchy.permission.blockedToastNoResponsibles }),
+        )
+        return false
+    } catch {
+        // Fail closed: if we can't verify permission, don't let the mutation through.
+        toast.error(fm({ id: message.systemHierarchy.permission.errorTitle }))
+        return false
+    }
+}

--- a/src/utils/getEndpoints.ts
+++ b/src/utils/getEndpoints.ts
@@ -48,6 +48,7 @@ export const getEndpoints = ({
         systemImage: `/system/${uid}/image`,
         catalogueCategoryCopy: `/catalogue/category/${uid}/copy`,
         systemDetail: `/system/${uid}`,
+        systemCanEdit: uid ? `/system/${uid}/can-edit` : null,
         systemItemAdd: `/system/${uid}/item`,
         systemsDetails: `/systems${uidPart}`,
         systemRelationships: `/system/${uid}/relationships`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noImplicitAny": false,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "baseUrl": "./",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noImplicitAny": false,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "baseUrl": "./",
     "paths": {


### PR DESCRIPTION
## Context

Editing a system is now permission-controlled: a user may edit only if they are **responsible** for it — directly, via a responsible team, or via any parent up the hierarchy. The backend enforces this on its **REST** mutating endpoints (403) and exposes `GET /system/{uid}/can-edit → { result, responsibles }`.

But the `systemHierarchy` module mutates via **GraphQL** (`updateSystems`, `updateItems`, `createSystems`), which `System.@authorization` gates by **role only** — not per-system. So until those mutations move to guarded REST PATCH endpoints, the frontend must block the GraphQL patch path itself. This is **phase 1**: the detail edit surfaces + the hierarchy actions.

## What's in it

**Data layer**
- `useSystemCanEdit(uid)` — REST `GET /system/{uid}/can-edit` (`/v1` already in `BASE_URL`); `ensureSystemCanEdit()` for imperative check-on-click reads (shared cache).
- `useSystemEditPermission(uid)` — single decision point, **fail-closed**: `canEdit` is `true` only when the backend confirms; `false` while loading and on error.
- `guardSystemEdit(qc, uid, fm)` — imperative gate; toasts the responsibles and returns `false` when blocked (or on verification failure).

**UI**
- `SystemEditRestrictionBanner` under the detail header: `denied` lists responsibles (name + email, info-tooltip); `error` shows a **distinct** "couldn't verify — Retry" state (never misattributes a network fault to a permission denial).
- Disabled when `!canEdit`: all Detail fields (incl. system code), Persons responsible/team + operator/maintainedBy tables, Physical Item fields, Attachments upload/delete, sidebar image panel, ActionsDropdown.

**Enforcement (defense-in-depth)**
- Hard guard inside `useSystemFieldUpdate` / `useItemFieldUpdate` — an unpermitted GraphQL patch can't fire even if the UI is bypassed.
- Editing responsible/team invalidates `['systemCanEdit']` → self-lockout re-derives without reload.
- Check-on-click for `useCreateSubsystemAction` (parent) and `useDeleteSystemAction` (target); blocked with a toast naming responsibles.

**Out of scope (phase 1):** spare-parts / spare-for / relationships tabs stay on the coarse `SYSTEM_EDIT` role gate (spare-assign is REST-403-guarded; functional relationships are backend-unguarded); system *move* relies on its existing backend 403.

## Docs

- Technical: new **Per-system edit permission** section in `systems-family/system-hierarchy.md`; new **Per-system edit responsibility** section in `permissions-model.md` (Phase 2 now partially live); `CONTEXT.md` glossary.
- User guide: new **Understanding edit permissions** workflow; personas + Phase 2 callouts updated across the affected pages.

## Testing

- `type-check` ✅, `lint` ✅, `build` ✅.
- Full suite green (pre-push hook: **3483 passed**). New tests cover the hook (fail-closed states), the guard (allow/deny/no-responsibles/fail-closed), the banner, and the mutation-hook blocking + can-edit invalidation; updated the existing action/mutation/image/dropdown/detail-view specs for the new gate.

## Open follow-ups

- Confirm the exact `can-edit` response casing against a live gateway.
- Decide whether to truncate very long responsibles lists in the tooltip.