### PR TITLE
ELIPANDA-496 fix(table): column visibility dropdown labels + checkbox sync

### DIFF
--- a/src/modules/catalogue/Catalogue.cont.tsx
+++ b/src/modules/catalogue/Catalogue.cont.tsx
@@ -16,6 +16,7 @@ import { CatalogueTable } from '../shared/catalogue/table/CatalogueItems.table'
 import { FilterBadges } from '../shared/form/FilterBadges'
 import { ColumnVisibilityDropdown } from '../shared/table/ColumnVisibilityDropdown.comp'
 import { PaginationV2 as Pagination } from '../shared/table/PaginationV2'
+import { useVisibility } from '../shared/table/pandaTable/hooks/useVisibility'
 import type { PandaTableV2Handle } from '../shared/table/pandaTableV2/PandaTableV2'
 import { SearchBar } from '../shared/table/SearchBar'
 import { CatalogueBreadcrumbs } from './components/breadcrump/CatalogueBreadcrumbs'
@@ -47,6 +48,7 @@ const CatalogueContainer = () => {
     )
     const [open, setOpen] = useState(true)
     const [catalogueTable, setCatalogueTable] = useState<Table<any> | null>(null)
+    const [columnVisibility] = useVisibility(tableId)
 
     const filterFormMethods = useFormFilter<SystemFilterType>({
         tableId,
@@ -74,7 +76,12 @@ const CatalogueContainer = () => {
                 left={<SearchBarButtons filterFormMethods={filterFormMethods} />}
                 tableId={tableId}
                 right={
-                    catalogueTable ? <ColumnVisibilityDropdown table={catalogueTable} /> : undefined
+                    catalogueTable ? (
+                        <ColumnVisibilityDropdown
+                            table={catalogueTable}
+                            columnVisibility={columnVisibility}
+                        />
+                    ) : undefined
                 }
                 secondRow={
                     <FilterBadges

--- a/src/modules/catalogueExplorer/components/middle/CatalogueItemsPanel.cont.tsx
+++ b/src/modules/catalogueExplorer/components/middle/CatalogueItemsPanel.cont.tsx
@@ -14,6 +14,7 @@ import { CatalogueTable } from '@/modules/shared/catalogue/table/CatalogueItems.
 import { FilterBadges } from '@/modules/shared/form/FilterBadges'
 import { ColumnVisibilityDropdown } from '@/modules/shared/table/ColumnVisibilityDropdown.comp'
 import { PaginationV2 } from '@/modules/shared/table/PaginationV2'
+import { useVisibility } from '@/modules/shared/table/pandaTable/hooks/useVisibility'
 import type { PandaTableV2Handle } from '@/modules/shared/table/pandaTableV2/PandaTableV2'
 import { SearchBar } from '@/modules/shared/table/SearchBar'
 
@@ -29,6 +30,7 @@ export const CatalogueItemsPanelContainer: FC = () => {
     const { category } = useCatalogueCategoryDetail(selectedCategoryUid)
     const tableRef = useRef<PandaTableV2Handle>(null)
     const [table, setTable] = useState<Table<any> | null>(null)
+    const [columnVisibility] = useVisibility(CATALOGUE_ITEMS_TABLE_ID)
 
     const defFilterValues = useMemo<CatalogueItemForm>(
         () => ({
@@ -76,7 +78,14 @@ export const CatalogueItemsPanelContainer: FC = () => {
                         tableId={CATALOGUE_ITEMS_TABLE_ID}
                     />
                 }
-                right={table ? <ColumnVisibilityDropdown table={table} /> : undefined}
+                right={
+                    table ? (
+                        <ColumnVisibilityDropdown
+                            table={table}
+                            columnVisibility={columnVisibility}
+                        />
+                    ) : undefined
+                }
                 secondRow={
                     <FilterBadges
                         tableId={CATALOGUE_ITEMS_TABLE_ID}

--- a/src/modules/shared/catalogue/table/CatalogueItems.columns.tsx
+++ b/src/modules/shared/catalogue/table/CatalogueItems.columns.tsx
@@ -175,6 +175,9 @@ export const useCatalogueItemsColumns = ({
                     },
                     id: detail.property.uid,
                     size: 150,
+                    meta: {
+                        title: detail.property.name,
+                    },
                     accessorFn: row =>
                         row.details?.find(
                             originDetail => originDetail?.property.name === detail?.property.name,

--- a/src/modules/shared/catalogue/table/CatalogueItems.table.tsx
+++ b/src/modules/shared/catalogue/table/CatalogueItems.table.tsx
@@ -65,9 +65,11 @@ export const CatalogueTable = forwardRef<PandaTableV2Handle, CatalogueTableProps
         })
 
         useEffect(() => {
-            table.setColumnVisibility({
+            // merge, not replace: replacing wiped every column the user had hidden
+            table.setColumnVisibility(previousVisibility => ({
+                ...previousVisibility,
                 categoryName: categoryList?.length !== 0,
-            })
+            }))
             table.setColumnOrder(table.getAllLeafColumns().map(column => column.id))
         }, [categoryList, columns, table])
 

--- a/src/modules/shared/catalogue/table/__tests__/CatalogueItems.columns.spec.tsx
+++ b/src/modules/shared/catalogue/table/__tests__/CatalogueItems.columns.spec.tsx
@@ -94,5 +94,6 @@ describe('useCatalogueItemsColumns', () => {
             'lastUpdateTime',
             'lastUpdateBy',
         ])
+        expect(result.current.find(column => column.id === 'd1')?.meta?.title).toBe('D1')
     })
 })

--- a/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
+++ b/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
@@ -1,4 +1,4 @@
-import type { Table } from '@tanstack/react-table'
+import type { Column, Table, VisibilityState } from '@tanstack/react-table'
 import { SlidersHorizontal } from 'lucide-react'
 import type { FC } from 'react'
 
@@ -15,13 +15,28 @@ import {
 interface ColumnVisibilityDropdownProps {
     table: Table<any>
     excludeColumns?: string[]
+    // Required when the dropdown is rendered outside the component that owns
+    // the table state (e.g. via onTableReady): the table instance updates one
+    // render after this component, so checked state must come from the
+    // caller's own columnVisibility subscription to stay in sync.
+    columnVisibility?: VisibilityState
 }
 
 export const ColumnVisibilityDropdown: FC<ColumnVisibilityDropdownProps> = ({
     table,
     excludeColumns = [],
+    columnVisibility,
 }) => {
-    const columns = table.getAllLeafColumns().filter(column => !excludeColumns.includes(column.id))
+    const columns = table
+        .getAllLeafColumns()
+        .filter(column => column.getCanHide() && !excludeColumns.includes(column.id))
+
+    const isColumnVisible = (column: Column<any>) =>
+        columnVisibility ? columnVisibility[column.id] !== false : column.getIsVisible()
+
+    const areAllColumnsVisible = columnVisibility
+        ? table.getAllLeafColumns().every(isColumnVisible)
+        : table.getIsAllColumnsVisible()
 
     return (
         <DropdownMenu>
@@ -34,7 +49,7 @@ export const ColumnVisibilityDropdown: FC<ColumnVisibilityDropdownProps> = ({
                 <DropdownMenuLabel>Columns</DropdownMenuLabel>
                 <DropdownMenuSeparator />
                 <DropdownMenuCheckboxItem
-                    checked={table.getIsAllColumnsVisible()}
+                    checked={areAllColumnsVisible}
                     onCheckedChange={checked =>
                         table.getToggleAllColumnsVisibilityHandler()({ target: { checked } })
                     }
@@ -45,12 +60,13 @@ export const ColumnVisibilityDropdown: FC<ColumnVisibilityDropdownProps> = ({
                 {columns.map(column => (
                     <DropdownMenuCheckboxItem
                         key={column.id}
-                        checked={column.getIsVisible()}
+                        checked={isColumnVisible(column)}
                         onCheckedChange={value => column.toggleVisibility(!!value)}
                     >
-                        {typeof column.columnDef.header === 'string'
-                            ? column.columnDef.header || column.id
-                            : column.id}
+                        {column.columnDef.meta?.title ||
+                            (typeof column.columnDef.header === 'string'
+                                ? column.columnDef.header || column.id
+                                : column.id)}
                     </DropdownMenuCheckboxItem>
                 ))}
             </DropdownMenuContent>

--- a/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
+++ b/src/modules/shared/table/ColumnVisibilityDropdown.comp.tsx
@@ -34,9 +34,13 @@ export const ColumnVisibilityDropdown: FC<ColumnVisibilityDropdownProps> = ({
     const isColumnVisible = (column: Column<any>) =>
         columnVisibility ? columnVisibility[column.id] !== false : column.getIsVisible()
 
-    const areAllColumnsVisible = columnVisibility
-        ? table.getAllLeafColumns().every(isColumnVisible)
-        : table.getIsAllColumnsVisible()
+    const areAllColumnsVisible = columns.every(isColumnVisible)
+
+    const setAllListedColumnsVisibility = (visible: boolean) =>
+        table.setColumnVisibility(previousVisibility => ({
+            ...previousVisibility,
+            ...Object.fromEntries(columns.map(column => [column.id, visible])),
+        }))
 
     return (
         <DropdownMenu>
@@ -50,9 +54,7 @@ export const ColumnVisibilityDropdown: FC<ColumnVisibilityDropdownProps> = ({
                 <DropdownMenuSeparator />
                 <DropdownMenuCheckboxItem
                     checked={areAllColumnsVisible}
-                    onCheckedChange={checked =>
-                        table.getToggleAllColumnsVisibilityHandler()({ target: { checked } })
-                    }
+                    onCheckedChange={checked => setAllListedColumnsVisibility(!!checked)}
                 >
                     Toggle All
                 </DropdownMenuCheckboxItem>

--- a/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.integration.spec.tsx
+++ b/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.integration.spec.tsx
@@ -1,0 +1,107 @@
+import { getCoreRowModel, type Table, useReactTable } from '@tanstack/react-table'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useEffect, useState } from 'react'
+
+import { ColumnVisibilityDropdown } from '../ColumnVisibilityDropdown.comp'
+import { useVisibility } from '../pandaTable/hooks/useVisibility'
+
+jest.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DropdownMenuSeparator: () => <hr />,
+    DropdownMenuCheckboxItem: ({
+        children,
+        checked,
+        onCheckedChange,
+    }: {
+        children: React.ReactNode
+        checked: boolean
+        onCheckedChange: (v: boolean) => void
+    }) => (
+        <button
+            data-testid={`dd-${typeof children === 'string' ? children : 'item'}`}
+            data-checked={String(checked)}
+            onClick={() => onCheckedChange(!checked)}
+        >
+            {children}
+        </button>
+    ),
+}))
+
+const TABLE_ID = 'visibility-integration'
+
+type TestRow = { name: string; prop: string }
+
+// Mirrors CatalogueItems.table.tsx: the child owns the table and its
+// visibility state (useVisibility -> localStorage) and reports the table up.
+const TableOwner = ({ onTableReady }: { onTableReady: (table: Table<TestRow>) => void }) => {
+    const [columnVisibility, setColumnVisibility] = useVisibility(TABLE_ID)
+    const table = useReactTable<TestRow>({
+        data: [],
+        columns: [
+            { id: 'name', header: 'Name' },
+            { id: 'prop', header: 'Prop' },
+        ],
+        state: { columnVisibility },
+        onColumnVisibilityChange: setColumnVisibility,
+        filterFns: { fuzzy: () => true },
+        getCoreRowModel: getCoreRowModel(),
+    })
+    useEffect(() => {
+        onTableReady(table)
+    }, [onTableReady, table])
+    return (
+        <div data-testid="visible-columns">
+            {table
+                .getVisibleLeafColumns()
+                .map(column => column.id)
+                .join(',')}
+        </div>
+    )
+}
+
+// Mirrors Catalogue.cont.tsx / CatalogueItemsPanel.cont.tsx: the parent renders
+// the dropdown from an onTableReady-captured table and its own useVisibility
+// subscription.
+const Container = () => {
+    const [table, setTable] = useState<Table<TestRow> | null>(null)
+    const [columnVisibility] = useVisibility(TABLE_ID)
+    return (
+        <>
+            {table ? (
+                <ColumnVisibilityDropdown table={table} columnVisibility={columnVisibility} />
+            ) : null}
+            <TableOwner onTableReady={setTable} />
+        </>
+    )
+}
+
+describe('ColumnVisibilityDropdown rendered outside the table-owning component', () => {
+    beforeEach(() => {
+        window.localStorage.clear()
+    })
+
+    it('unchecking hides the column and the checkbox reflects it immediately', () => {
+        render(<Container />)
+        expect(screen.getByTestId('visible-columns').textContent).toBe('name,prop')
+        expect(screen.getByTestId('dd-Prop').getAttribute('data-checked')).toBe('true')
+
+        fireEvent.click(screen.getByTestId('dd-Prop'))
+        expect(screen.getByTestId('visible-columns').textContent).toBe('name')
+        expect(screen.getByTestId('dd-Prop').getAttribute('data-checked')).toBe('false')
+
+        fireEvent.click(screen.getByTestId('dd-Prop'))
+        expect(screen.getByTestId('visible-columns').textContent).toBe('name,prop')
+        expect(screen.getByTestId('dd-Prop').getAttribute('data-checked')).toBe('true')
+    })
+
+    it('persists the visibility choice under the table id', () => {
+        render(<Container />)
+        fireEvent.click(screen.getByTestId('dd-Prop'))
+        expect(
+            JSON.parse(window.localStorage.getItem(`columnVisibility-${TABLE_ID}`) ?? '{}'),
+        ).toEqual({ prop: false })
+    })
+})

--- a/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.integration.spec.tsx
+++ b/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.integration.spec.tsx
@@ -104,4 +104,15 @@ describe('ColumnVisibilityDropdown rendered outside the table-owning component',
             JSON.parse(window.localStorage.getItem(`columnVisibility-${TABLE_ID}`) ?? '{}'),
         ).toEqual({ prop: false })
     })
+
+    it('Toggle All hides and restores all listed columns in one update', () => {
+        render(<Container />)
+        fireEvent.click(screen.getByTestId('dd-Toggle All'))
+        expect(screen.getByTestId('visible-columns').textContent).toBe('')
+        expect(screen.getByTestId('dd-Toggle All').getAttribute('data-checked')).toBe('false')
+
+        fireEvent.click(screen.getByTestId('dd-Toggle All'))
+        expect(screen.getByTestId('visible-columns').textContent).toBe('name,prop')
+        expect(screen.getByTestId('dd-Toggle All').getAttribute('data-checked')).toBe('true')
+    })
 })

--- a/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.spec.tsx
+++ b/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.spec.tsx
@@ -41,11 +41,10 @@ const makeColumn = (
     columnDef: { header, meta: title ? { title } : undefined },
 })
 
-const makeTable = (columns: any[], allVisible = true, toggleAll = jest.fn()) =>
+const makeTable = (columns: any[]) =>
     ({
         getAllLeafColumns: () => columns,
-        getIsAllColumnsVisible: () => allVisible,
-        getToggleAllColumnsVisibilityHandler: () => toggleAll,
+        setColumnVisibility: jest.fn(),
     }) as any
 
 describe('ColumnVisibilityDropdown', () => {
@@ -74,12 +73,27 @@ describe('ColumnVisibilityDropdown', () => {
         expect(screen.queryByTestId('dd-Fixed')).toBeNull()
     })
 
-    it('Toggle All forwards event in expected shape', () => {
-        const toggleAll = jest.fn()
-        const table = makeTable([], false, toggleAll)
-        render(<ColumnVisibilityDropdown table={table} />)
+    it('Toggle All updates only the columns listed in the dropdown', () => {
+        const table = makeTable([
+            makeColumn('a', true, 'Col A'),
+            makeColumn('excluded', true, 'Excluded'),
+            makeColumn('fixed', true, 'Fixed', false),
+        ])
+        render(<ColumnVisibilityDropdown table={table} excludeColumns={['excluded']} />)
         fireEvent.click(screen.getByTestId('dd-Toggle All'))
-        expect(toggleAll).toHaveBeenCalledWith({ target: { checked: true } })
+        expect(table.setColumnVisibility).toHaveBeenCalledTimes(1)
+        const updater = table.setColumnVisibility.mock.calls[0][0]
+        // excluded + non-hideable columns keep their previous state untouched
+        expect(updater({ excluded: false })).toEqual({ excluded: false, a: false })
+    })
+
+    it('Toggle All checkmark reflects only the listed columns', () => {
+        const table = makeTable([
+            makeColumn('a', true, 'Col A'),
+            makeColumn('hidden-excluded', false, 'Hidden'),
+        ])
+        render(<ColumnVisibilityDropdown table={table} excludeColumns={['hidden-excluded']} />)
+        expect(screen.getByTestId('dd-Toggle All').getAttribute('data-checked')).toBe('true')
     })
 
     it('per-column click flips visibility', () => {
@@ -107,7 +121,7 @@ describe('ColumnVisibilityDropdown', () => {
 
     it('derives checked state from the columnVisibility prop over the table instance', () => {
         // the table instance still reports the column as visible…
-        const table = makeTable([makeColumn('a', true, 'Col A')], true)
+        const table = makeTable([makeColumn('a', true, 'Col A')])
         // …but the caller's live visibility state says it is hidden
         render(<ColumnVisibilityDropdown table={table} columnVisibility={{ a: false }} />)
         expect(screen.getByTestId('dd-Col A').getAttribute('data-checked')).toBe('false')

--- a/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.spec.tsx
+++ b/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.spec.tsx
@@ -27,11 +27,18 @@ jest.mock('@/components/ui/dropdown-menu', () => ({
     ),
 }))
 
-const makeColumn = (id: string, visible = true, header: string | unknown = id) => ({
+const makeColumn = (
+    id: string,
+    visible = true,
+    header: string | unknown = id,
+    canHide = true,
+    title?: string,
+) => ({
     id,
+    getCanHide: () => canHide,
     getIsVisible: () => visible,
     toggleVisibility: jest.fn(),
-    columnDef: { header },
+    columnDef: { header, meta: title ? { title } : undefined },
 })
 
 const makeTable = (columns: any[], allVisible = true, toggleAll = jest.fn()) =>
@@ -57,6 +64,16 @@ describe('ColumnVisibilityDropdown', () => {
         expect(screen.queryByTestId('dd-Col B')).toBeNull()
     })
 
+    it('skips columns that cannot be hidden', () => {
+        const table = makeTable([
+            makeColumn('hideable', true, 'Hideable'),
+            makeColumn('fixed', true, 'Fixed', false),
+        ])
+        render(<ColumnVisibilityDropdown table={table} />)
+        expect(screen.getByTestId('dd-Hideable')).toBeInTheDocument()
+        expect(screen.queryByTestId('dd-Fixed')).toBeNull()
+    })
+
     it('Toggle All forwards event in expected shape', () => {
         const toggleAll = jest.fn()
         const table = makeTable([], false, toggleAll)
@@ -77,5 +94,23 @@ describe('ColumnVisibilityDropdown', () => {
         const table = makeTable([makeColumn('only-id', true, () => 'Node')])
         render(<ColumnVisibilityDropdown table={table} />)
         expect(screen.getByTestId('dd-only-id')).toBeInTheDocument()
+    })
+
+    it('uses the metadata title when header is not a string', () => {
+        const table = makeTable([
+            makeColumn('property-uid', true, () => 'Node', true, 'Property name'),
+        ])
+        render(<ColumnVisibilityDropdown table={table} />)
+        expect(screen.getByTestId('dd-Property name')).toBeInTheDocument()
+        expect(screen.queryByTestId('dd-property-uid')).toBeNull()
+    })
+
+    it('derives checked state from the columnVisibility prop over the table instance', () => {
+        // the table instance still reports the column as visible…
+        const table = makeTable([makeColumn('a', true, 'Col A')], true)
+        // …but the caller's live visibility state says it is hidden
+        render(<ColumnVisibilityDropdown table={table} columnVisibility={{ a: false }} />)
+        expect(screen.getByTestId('dd-Col A').getAttribute('data-checked')).toBe('false')
+        expect(screen.getByTestId('dd-Toggle All').getAttribute('data-checked')).toBe('false')
     })
 })

--- a/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.test.tsx
+++ b/src/modules/shared/table/__tests__/ColumnVisibilityDropdown.test.tsx
@@ -6,6 +6,7 @@ import { ColumnVisibilityDropdown } from '../ColumnVisibilityDropdown.comp'
 const createMockColumn = (id: string, header: string, isVisible = true) => ({
     id,
     columnDef: { header },
+    getCanHide: jest.fn(() => true),
     getIsVisible: jest.fn(() => isVisible),
     toggleVisibility: jest.fn(),
 })

--- a/src/types/react-table.d.ts
+++ b/src/types/react-table.d.ts
@@ -17,6 +17,7 @@ declare module '@tanstack/table-core' {
         enableReorder?: boolean
         noHeader?: boolean
         headerElement?: React.ReactNode
+        title?: string
     }
 
     interface ColumnFilter {


### PR DESCRIPTION
Jira: ELIPANDA-496

## Summary

Fixes the column visibility dropdown (`ColumnVisibilityDropdown.comp.tsx`):

1. **Non-hideable columns are no longer offered as toggleable.** The dropdown listed every leaf column; for columns with `enableHiding: false` (action/select columns in Orders, Systems, System relations, ...) `toggleVisibility()` is a no-op, so the checkbox never changed. They are now filtered out via `column.getCanHide()`.
2. **Dynamic catalogue property columns show their name instead of the raw UID.** Their `header` is a JSX function, so the label fell back to `column.id` (the property GUID). The columns now carry `meta.title = property.name` and the dropdown prefers `meta.title`, then a string header, then the id.
3. **Checkbox state no longer desyncs from real visibility in the catalogue.** The catalogue pages render the dropdown in the page container from an `onTableReady`-captured table, so its checkboxes were frozen at the container's last render even though the column did hide. The containers now subscribe via `useVisibility(tableId)` and pass the live `columnVisibility` to the dropdown. The category effect in `CatalogueItems.table.tsx` also merges instead of replacing the visibility state, so user-hidden columns survive category switches and reloads.

## How to validate

1. Catalogue -> pick a category with custom properties -> open the sliders icon (top right).
2. Property columns are listed by name, not by GUID.
3. Untick a column: it disappears from the table and the checkbox unticks at the same moment; ticking it brings it back.
4. Hidden columns stay hidden after switching categories or reloading.
5. Orders / Systems: the action column no longer appears in the dropdown.

## Tests

- New `ColumnVisibilityDropdown.integration.spec.tsx` reproduces the container-rendered dropdown with a real TanStack table + `useVisibility` and asserts hide + checkbox sync and localStorage persistence.
- Unit tests for `getCanHide` filtering, `meta.title` labels, and the `columnVisibility` prop.
- Full suite green (700 suites / 3466 tests), `tsc --noEmit` clean, eslint + prettier clean.
