### PR TITLE
feat(hierarchy): direct-only view for end systems under a node

### DIFF
--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -32,6 +32,8 @@ When you sharpen a term during a design conversation, update both this file and 
 
 - **System** — facility item with hierarchy and relations. See [`systems-family/systems-overview.md`](./technical/systems-family/systems-overview.md).
 - **System hierarchy** — parent/child tree of systems. See [`systems-family/system-hierarchy.md`](./technical/systems-family/system-hierarchy.md).
+- **End system** — a system with no subsystems of its own; the API calls these *leaves*. Never shown in the hierarchy tree (which lists only nodes that have children) — they live in the leaves table. See [`systems-family/system-hierarchy.md`](./technical/systems-family/system-hierarchy.md#direct-end-systems).
+- **Direct end systems** — the end systems hanging *immediately* below a node, as opposed to every end system anywhere beneath it. Surfaced by the *Direct only* checkbox (`?direct=1` → `directOnly=true`). See [`systems-family/system-hierarchy.md`](./technical/systems-family/system-hierarchy.md#direct-end-systems) and [ADR 0001](./adr/0001-direct-only-param-on-leaves-endpoint.md).
 - **System item** — leaf attached to a system. The `systemItem` module / `/system/<uid>` page is **deprecated** — detail now lives in the hierarchy explorer (`/systems/hierarchy?leaf=<uid>`). See [`systems-family/system-item.md`](./technical/systems-family/system-item.md).
 - **System type** — schema/template that drives a system's editable fields. See [`systems-family/system-type-edit.md`](./technical/systems-family/system-type-edit.md).
 - **Moving flow / Multi-move** — bulk re-parenting of systems. See [`systems-family/moving.md`](./technical/systems-family/moving.md).

--- a/docs/adr/0001-direct-only-param-on-leaves-endpoint.md
+++ b/docs/adr/0001-direct-only-param-on-leaves-endpoint.md
@@ -1,0 +1,35 @@
+# ADR 0001 — Scope the leaves endpoint with `directOnly`, don't reuse `/subsystems`
+
+- **Status**: Accepted
+- **Date**: 2026-08-04
+- **Deciders**: Jan Smrcka
+- **Related**: [`systems-family/system-hierarchy.md` § Direct end systems](../technical/systems-family/system-hierarchy.md#direct-end-systems) · [ELI-panda#1143](https://github.com/eli-eric/ELI-panda/pull/1143) · [eli-panda-api#430](https://github.com/eli-eric/eli-panda-api/pull/430)
+
+## Context
+
+The hierarchy explorer had no way to answer **"what hangs directly off this node"**. The tree returns only nodes that have children, so end systems never appear in it; the leaves table returns every end system below the selected node (`HAS_SUBSYSTEM*1..50`), so a node's own direct end systems drown among everything deeper. End systems sitting high in the hierarchy were effectively unreachable.
+
+A REST endpoint that looks like the obvious answer already existed: `GET /system/{uid}/subsystems` returns a node's direct children, and its Cypher `RETURN` block is character-for-character identical to the leaves one — same fields, same `statistics`, same `physicalItem`. It is used by the systems overview for lazy row expansion.
+
+## Decision
+
+Add an optional `directOnly=true` query parameter to `GET /system/{uid}/leaves` (and its `/count` sibling) that narrows the traversal from `*1..50` to `*1..1`, rather than pointing the hierarchy table at `/system/{uid}/subsystems`.
+
+The existing `WHERE NOT (sys)-[:HAS_SUBSYSTEM]->(:System{deleted:false})` clause is what makes depth 1 mean *direct end systems* rather than *all direct children*, so the feature needs no new predicate — only the depth changes.
+
+## Consequences
+
+- **Positive** — search, column filters, sorting, pagination and `totalCount` keep working and **compose** with the new scope, because nothing about the request pipeline changes. The frontend gains one boolean argument on `useSystemLeaves`; there is no second data path, no client-side sorting mode, and no conditional pagination.
+- **Positive** — the flag is part of the TanStack query key, so the two scopes never serve each other's rows.
+- **Negative** — the feature spans two repositories and two deploys. Until the API ships, the parameter is ignored and the checkbox returns the full list: ineffective, not broken.
+- **Neutral** — `GetSystemLeavesByParentUID` must pass the same flag to its internal count query, or pagination is computed over a different set than the rows. This is a correctness constraint, not a preference, and is covered by a test that asserts both queries agree on the depth.
+
+## Alternatives considered
+
+**Point the hierarchy table at `/system/{uid}/subsystems`.** The response shape matches, so this looks like reuse rather than new API surface — which is exactly why a future reader will suggest it. It fails on everything around the payload: the endpoint accepts no parameters at all. No search, no filters, no sorting, no pagination, a bare array capped at `LIMIT 1000`. Adopting it would have meant a second data-fetching path in the leaves panel, client-side sorting and filtering for one mode only, hiding the pagination control, and a UX compromise where the checkbox and the filter sheet are mutually exclusive. Against that, the chosen route is roughly six lines of Cypher.
+
+**Express it as a column filter (`directOnly` in `columnFilter`).** Tempting because it arrives at the backend already parsed and would render a removable badge for free. Rejected on two counts. Semantically it is a *scope*, not a filter: it decides which set is under consideration, so it should compose with filters rather than sit among them. Mechanically, `useFormFilter` clears all column filters whenever the search value changes (`src/hooks/form/useFormFilters.ts:106`), so typing into search would silently switch the mode off.
+
+**A `depth=N` integer instead of a boolean.** More general, and the hierarchy does have five levels. Rejected because the generality is fake: with the end-system predicate in place, `depth=3` would blend leaves from levels 1 through 3 into one list, which answers no question anyone asks. The boolean states the intent and has no invalid values to validate.
+
+**A separate `/leaves/direct` endpoint.** Leaves the existing contract untouched, but duplicates the entire handler and Cypher query — filters, sorting, pagination and all. That is the same duplication the `/subsystems` route was rejected for, just written by us.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -4,6 +4,12 @@ Short, append-only records of architectural decisions that future contributors (
 
 Until this directory grows, the existing **Maintenance recommendations**, **Open questions**, **Deprecated / legacy**, and **🔮 Planned** sections in [`docs/technical/`](../technical/README.md) act as informal ADRs — promote any entry from there to a proper ADR here when a real decision crystallizes.
 
+## Records
+
+| ADR | Title | Status |
+|---|---|---|
+| [0001](./0001-direct-only-param-on-leaves-endpoint.md) | Scope the leaves endpoint with `directOnly`, don't reuse `/subsystems` | Accepted |
+
 ## When to write an ADR
 
 Write one when:

--- a/docs/technical/systems-family/system-hierarchy.md
+++ b/docs/technical/systems-family/system-hierarchy.md
@@ -350,6 +350,8 @@ Between the two there was no way to ask **"what hangs directly off this node"**.
 
 The **Direct only** checkbox in `LeavesToolbar` (next to the search input) closes that gap by sending `?directOnly=true`, which narrows the server-side traversal to `*1..1`. The existing end-system predicate is what makes depth 1 mean *direct end systems* rather than *all direct children* — no extra predicate is involved.
 
+The explanation is bound to the checkbox with `aria-describedby` → an `sr-only` span, not left to the tooltip alone: Radix puts its own `aria-describedby` on the tooltip *trigger*, which here is the wrapper `div`, so the control itself would carry no description. The tooltip stays for pointer users.
+
 | Aspect | Behaviour |
 |---|---|
 | State | `?direct=1`, read as `directOnly` and written by `setDirectOnly` (`useHierarchyNavigation`). Survives reload, deep links, and tree navigation. |

--- a/docs/technical/systems-family/system-hierarchy.md
+++ b/docs/technical/systems-family/system-hierarchy.md
@@ -357,9 +357,24 @@ The **Direct only** checkbox in `LeavesToolbar` (next to the search input) close
 | Filters / search / sorting | Unaffected. `useSystemLeaves` merges `directOnly` into the query object `useQueryManager` already builds, so the server applies it *and* everything else. The mode narrows scope; it does not replace filtering. |
 | Cache | The flag is part of the query key, so the two modes never serve each other's rows. |
 | Tree badge | Unchanged — still the total descendant-leaf count. It describes the node, not the current view, and `useSystemLeavesCount` runs per rendered node, so binding it to the mode would fire one request per node on every toggle. |
-| Empty state | Takes precedence over the filters empty state and offers **Show all levels** (`setDirectOnly(false)`). |
+| Header count | Rendered as `(N direct)` while the mode is on. The tree badge for the same node still shows the total, so two different numbers sit on screen at once and the header is what accounts for the difference. |
+| Pagination | `setDirectOnly` drops `?page`, but `useQueryManager` reads the zustand `paginationState` *first* and that is only cleared by an effect. `LeavesPanel.cont` therefore calls `useResetPaginationOnChange(LEAVES_TABLE_ID)` before navigating, so no render requests a page that does not exist in the narrowed set. |
 
-**Discoverability** comes from `HierarchyNode.hasLeafChildren`, which the API had always returned and the frontend ignored. `TreeNode` now renders a dot next to the count badge when it is true. The dot is an indicator only — a click target inside a row that already handles clicks would be hit by accident.
+### Empty state
+
+Two independent things can empty the table — the direct-only scope and the search/filter set — and they can both be true. `LeavesEmptyState.comp.tsx` branches on the pair rather than letting one win:
+
+| `directOnly` | narrowed query | Message | Actions |
+|---|---|---|---|
+| off | on | *No subsystems found* | Clear filters |
+| on | off | *No end systems directly under this system* | Show all levels |
+| on | on | *…match the current search and filters* | Show all levels **and** Clear filters |
+
+Letting `directOnly` short-circuit would state something potentially false — there may well be direct end systems, just none matching the filter — and offer an escape that lands the user in a second empty state.
+
+"Narrowed query" counts **search as well as column filters** (`instances[LEAVES_TABLE_ID].search`, not just `storeFilters`), because search narrows the result exactly like a filter does.
+
+**Discoverability** comes from `HierarchyNode.hasLeafChildren`, which the API had always returned and the frontend ignored. `TreeNode` now renders a dot next to the count badge when it is true, carrying `role="img"` + `aria-label` — the tooltip is hover-only, and a marker that exists purely for discoverability must not be invisible to the users least able to compensate. The dot is an indicator only, with no click handler: a small target with different behaviour inside a row that already handles clicks would be hit by accident.
 
 The checkbox is never disabled. Gating it on the cached `hasLeafChildren` would lock the control with no explanation whenever another session had added a child, and would couple the leaves panel to tree data; the empty state says the same thing but only after a real query.
 
@@ -376,7 +391,7 @@ Unit coverage under `__tests__/` is heaviest in:
 - **Per-system permission** (in the shared `edit-permission` module) — `hooks/__tests__/useSystemEditPermission.spec.ts` (fail-closed derivation for loading/error/allowed/denied + `formatResponsibleName`), `utils/__tests__/guardSystemEdit.spec.ts` (allow / deny-with-toast / no-responsibles / fail-closed-on-throw), `components/__tests__/SystemEditRestrictionBanner.spec.tsx` (denied lists responsibles, distinct verify-error + retry, nothing while loading/allowed).
 - `hooks/__tests__/useHierarchyDeepLinkResolver.spec.tsx` — parent resolution from `parentPath`, root parent==leaf case, stale-uid guard, single-replace idempotency, re-resolution after the URL settles; `hooks/__tests__/useHierarchyNavigation.spec.ts` — URL contract per key, including that `setDirectOnly` clears `page` but leaves `filter`/`search` alone and that `direct` survives `selectParent`; `utils/__tests__/hierarchyLinks.spec.ts` — deep-link shape + encoding; `components/detail/__tests__/SystemDetailView.spec.tsx` — skeleton / not-found / loaded states.
 - `hooks/__tests__/useDeleteSystemAction.spec.tsx` — permission gate, in-flight re-entry guard, per-system check-on-click block, recursive confirm, 409 item-list + `(+N)` overflow + generic fallback, and selection reset for both open-leaf-ancestor and selected-parent-ancestor; `hooks/__tests__/useCreateSubsystemAction.spec.tsx` — role gate + per-parent check-on-click.
-- `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden); the Delete context item is covered in `tree/TreeNode.test.tsx`, `graph/SystemNode.test.tsx`, and `leaves/LeavesTable.test.tsx` (the last stubs the virtualized `PandaTableV2` to exercise the capture/bubble row capture, disabled-on-empty-area, and no-handler short-circuit). `tree/TreeNode.test.tsx` also locks the `hasLeafChildren` dot and that the count badge stays the total; `leaves/LeavesToolbar.spec.tsx` locks the Direct-only checkbox (reflects the prop, reports the toggle, never disabled, leaves filter + search reachable so the mode can be exited).
+- `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden); the Delete context item is covered in `tree/TreeNode.test.tsx`, `graph/SystemNode.test.tsx`, and `leaves/LeavesTable.test.tsx` (the last stubs the virtualized `PandaTableV2` to exercise the capture/bubble row capture, disabled-on-empty-area, and no-handler short-circuit). `tree/TreeNode.test.tsx` also locks the `hasLeafChildren` dot and that the count badge stays the total; `leaves/LeavesToolbar.spec.tsx` locks the Direct-only checkbox (reflects the prop, reports the toggle, never disabled, leaves filter + search reachable so the mode can be exited); `leaves/LeavesEmptyState.spec.tsx` locks all four rows of the empty-state matrix above, including that the both-causes case does not assert the scope-only message.
 
 ## Deprecated / legacy
 

--- a/docs/technical/systems-family/system-hierarchy.md
+++ b/docs/technical/systems-family/system-hierarchy.md
@@ -80,8 +80,8 @@ The leaves panel toggles between **Tree View** (the default `LeavesTable`) and *
 | Hook | Endpoint key / GraphQL doc | Cache key (`HIERARCHY_QUERY_KEY` etc.) |
 |---|---|---|
 | `useSystemHierarchy` | `queryFetcher('systemsHierarchy')` (REST) | `HIERARCHY_QUERY_KEY`. 5-minute `staleTime`, no refetch on mount. |
-| `useSystemLeaves` | `queryFetcher('systemSubsystems')` (REST) | parameterised by parent uid |
-| `useSystemLeavesCount` | `queryFetcher('systemSubsystems')` count variant | optimised for tree badges |
+| `useSystemLeaves` | `queryFetcher('systemLeaves')` (REST) | `[LEAVES_QUERY_KEY, { uid, query }]`. `query` carries pagination/search/filter/sorting from `useQueryManager` plus the optional `directOnly` flag — see [Direct end systems](#direct-end-systems). |
+| `useSystemLeavesCount` | `queryFetcher('systemLeavesCount')` (REST) | `[LEAVES_COUNT_QUERY_KEY, { uid }]`, one query **per rendered tree node**. 5-minute `staleTime`. Always counts every descendant leaf — deliberately unaffected by `directOnly`. |
 | `useSystemDetail` | `graphql-request` `query SystemHierarchyDetail($where)` (`gql` document) | seeded by `primeSystemDetailCache` |
 | `useSystemHistory` | REST endpoint per uid | tab consumer |
 | `useSystemRelationships` | REST endpoint per uid | Relationships tab |
@@ -258,7 +258,9 @@ Note this is about the *tabs*. The detail-header **`ActionsDropdown`** (which in
 
 ## Deep links & URL contract
 
-The explorer's URL is its source of truth (`useHierarchyNavigation`): `?parent=<uid>` (tree selection), `?leaf=<uid>` (detail view), `?tab=` (defaults to `detail`), `?view=` (`tree`/`graph`), plus table `page`/`filter`. All in-page updates are shallow `router.push`; `updateQuery` accepts `{ replace: true }` for history-neutral updates.
+The explorer's URL is its source of truth (`useHierarchyNavigation`): `?parent=<uid>` (tree selection), `?leaf=<uid>` (detail view), `?tab=` (defaults to `detail`), `?view=` (`tree`/`graph`), `?direct=1` ([direct end systems](#direct-end-systems)), plus table `page`/`filter`/`search`. All in-page updates are shallow `router.push`; `updateQuery` accepts `{ replace: true }` for history-neutral updates.
+
+`selectParent` resets **only** `page` when the parent changes. `filter`, `search`, and `direct` deliberately carry over — they describe how the user wants to read any node, not one particular node.
 
 **`getSystemHierarchyDetailPath(uid)`** (`utils/hierarchyLinks.ts`) is the canonical builder for cross-module links into the explorer: `/systems/hierarchy?leaf=<uid>`. It deliberately omits `parent` — **`useHierarchyDeepLinkResolver`** (`hooks/useHierarchyDeepLinkResolver.ts`, mounted once in `SystemHierarchyExplorer.cont.tsx`) fills it in client-side:
 
@@ -340,18 +342,41 @@ The leaves filter sheet (`components/filters/`) is a multi-field RHF form persis
 
 `utils/graphFilters.ts` reproduces the filter logic client-side for the graph (which receives the *whole* relationship slice from the server, not a filtered one).
 
+## Direct end systems
+
+`GET /system/{uid}/leaves` returns every **end system** below the selected node — `HAS_SUBSYSTEM*1..50` plus `WHERE NOT (sys)-[:HAS_SUBSYSTEM]->(:System{deleted:false})`. The tree, symmetrically, returns only nodes that *have* children (plus parentless roots), so end systems never appear in it.
+
+Between the two there was no way to ask **"what hangs directly off this node"**. A node with three direct end systems and a subtree of two thousand deeper ones drowned those three in the table, and the tree could not show them at all.
+
+The **Direct only** checkbox in `LeavesToolbar` (next to the search input) closes that gap by sending `?directOnly=true`, which narrows the server-side traversal to `*1..1`. The existing end-system predicate is what makes depth 1 mean *direct end systems* rather than *all direct children* — no extra predicate is involved.
+
+| Aspect | Behaviour |
+|---|---|
+| State | `?direct=1`, read as `directOnly` and written by `setDirectOnly` (`useHierarchyNavigation`). Survives reload, deep links, and tree navigation. |
+| Page reset | `setDirectOnly` clears `?page` in the same `updateQuery` — the narrowed list is shorter, so a retained page would land past its end. |
+| Filters / search / sorting | Unaffected. `useSystemLeaves` merges `directOnly` into the query object `useQueryManager` already builds, so the server applies it *and* everything else. The mode narrows scope; it does not replace filtering. |
+| Cache | The flag is part of the query key, so the two modes never serve each other's rows. |
+| Tree badge | Unchanged — still the total descendant-leaf count. It describes the node, not the current view, and `useSystemLeavesCount` runs per rendered node, so binding it to the mode would fire one request per node on every toggle. |
+| Empty state | Takes precedence over the filters empty state and offers **Show all levels** (`setDirectOnly(false)`). |
+
+**Discoverability** comes from `HierarchyNode.hasLeafChildren`, which the API had always returned and the frontend ignored. `TreeNode` now renders a dot next to the count badge when it is true. The dot is an indicator only — a click target inside a row that already handles clicks would be hit by accident.
+
+The checkbox is never disabled. Gating it on the cached `hasLeafChildren` would lock the control with no explanation whenever another session had added a child, and would couple the leaves panel to tree data; the empty state says the same thing but only after a real query.
+
+Backend contract and the rejected alternatives: [ADR 0001](../../adr/0001-direct-only-param-on-leaves-endpoint.md).
+
 ## Tests
 
 Unit coverage under `__tests__/` is heaviest in:
 
 - `types/__tests__/` — schema parsing.
 - `utils/__tests__/` — tree search, graph layout, filter predicates, change-builder, **parent→child level rules** (`systemLevelRules.spec.ts`), **create-subsystem payload builder** (`buildCreateSubsystemPayload.spec.ts` — locks the `updatedBy[Insert]` audit edge).
-- `hooks/queries/__tests__/` — `primeSystemDetailCache.test.ts` (the contract above), `useSystemLeaves.test.ts`, `useSystemLeavesCount.test.ts`.
+- `hooks/queries/__tests__/` — `primeSystemDetailCache.test.ts` (the contract above), `useSystemLeaves.test.ts`, `useSystemLeaves.spec.ts` (also: `directOnly` reaches the query only when enabled, survives alongside `search`, and keys the two modes apart), `useSystemLeavesCount.test.ts`.
 - `hooks/mutations/__tests__/` — `useSystemFieldUpdate.spec.ts` (also: guard blocks the patch when denied, `['systemCanEdit']` invalidated after a responsible change), `useItemFieldUpdate.spec.ts` (locks the System-node `WAS_UPDATED_BY` edge + change entries for item edits; guard checks the owning system), `useDeleteSystem.spec.ts` (immediate invalidate + background recalc → second invalidate; recalc failure keeps only the immediate round).
 - **Per-system permission** (in the shared `edit-permission` module) — `hooks/__tests__/useSystemEditPermission.spec.ts` (fail-closed derivation for loading/error/allowed/denied + `formatResponsibleName`), `utils/__tests__/guardSystemEdit.spec.ts` (allow / deny-with-toast / no-responsibles / fail-closed-on-throw), `components/__tests__/SystemEditRestrictionBanner.spec.tsx` (denied lists responsibles, distinct verify-error + retry, nothing while loading/allowed).
-- `hooks/__tests__/useHierarchyDeepLinkResolver.spec.tsx` — parent resolution from `parentPath`, root parent==leaf case, stale-uid guard, single-replace idempotency, re-resolution after the URL settles; `utils/__tests__/hierarchyLinks.spec.ts` — deep-link shape + encoding; `components/detail/__tests__/SystemDetailView.spec.tsx` — skeleton / not-found / loaded states.
+- `hooks/__tests__/useHierarchyDeepLinkResolver.spec.tsx` — parent resolution from `parentPath`, root parent==leaf case, stale-uid guard, single-replace idempotency, re-resolution after the URL settles; `hooks/__tests__/useHierarchyNavigation.spec.ts` — URL contract per key, including that `setDirectOnly` clears `page` but leaves `filter`/`search` alone and that `direct` survives `selectParent`; `utils/__tests__/hierarchyLinks.spec.ts` — deep-link shape + encoding; `components/detail/__tests__/SystemDetailView.spec.tsx` — skeleton / not-found / loaded states.
 - `hooks/__tests__/useDeleteSystemAction.spec.tsx` — permission gate, in-flight re-entry guard, per-system check-on-click block, recursive confirm, 409 item-list + `(+N)` overflow + generic fallback, and selection reset for both open-leaf-ancestor and selected-parent-ancestor; `hooks/__tests__/useCreateSubsystemAction.spec.tsx` — role gate + per-parent check-on-click.
-- `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden); the Delete context item is covered in `tree/TreeNode.test.tsx`, `graph/SystemNode.test.tsx`, and `leaves/LeavesTable.test.tsx` (the last stubs the virtualized `PandaTableV2` to exercise the capture/bubble row capture, disabled-on-empty-area, and no-handler short-circuit).
+- `components/{tree,leaves,filters,graph,detail,copy,create,shared,tabs,physical-item}/__tests__/` — `physical-item/` covers the grouped renderer and sidebar wrapper (grouping, override marker, service-only additions, empty → hidden); the Delete context item is covered in `tree/TreeNode.test.tsx`, `graph/SystemNode.test.tsx`, and `leaves/LeavesTable.test.tsx` (the last stubs the virtualized `PandaTableV2` to exercise the capture/bubble row capture, disabled-on-empty-area, and no-handler short-circuit). `tree/TreeNode.test.tsx` also locks the `hasLeafChildren` dot and that the count badge stays the total; `leaves/LeavesToolbar.spec.tsx` locks the Direct-only checkbox (reflects the prop, reports the toggle, never disabled, leaves filter + search reachable so the mode can be exited).
 
 ## Deprecated / legacy
 
@@ -377,4 +402,6 @@ Unit coverage under `__tests__/` is heaviest in:
 
 > 🔧 *Engineer-only; stripped from the wiki.*
 >
-> Relevant schema: `System`, `SystemInterface`, `ParentPathItem` (`src/server/apollo/schema.graphql:266-369`). Relationship registry: `src/modules/systemHierarchy/types/graph.ts` (`RELATIONSHIP_DEFINITIONS`). Endpoint keys consumed: `systemsHierarchy`, `systemSubsystems`, `systemDetail`, `systemCanEdit` (`GET /system/{uid}/can-edit` → `{ result, responsibles }`; `/v1` prefix is already in `BASE_URL`), `systemRelationships`, `system/<uid>/copy`, `system` (`DELETE /system/{uid}`, soft+recursive, 409 → `SystemPhysicalItemInfo[]`), `recalculateSpareParts`.
+> Relevant schema: `System`, `SystemInterface`, `ParentPathItem` (`src/server/apollo/schema.graphql:266-369`). Relationship registry: `src/modules/systemHierarchy/types/graph.ts` (`RELATIONSHIP_DEFINITIONS`). Endpoint keys consumed: `systemsHierarchy`, `systemLeaves` and `systemLeavesCount` (both accept `directOnly=true` → traversal narrows to `*1..1`; `GetSystemLeavesByParentUIDQuery` / `…CountQuery` in the API's `systems-db-queries.go`), `systemDetail`, `systemCanEdit` (`GET /system/{uid}/can-edit` → `{ result, responsibles }`; `/v1` prefix is already in `BASE_URL`), `systemRelationships`, `system/<uid>/copy`, `system` (`DELETE /system/{uid}`, soft+recursive, 409 → `SystemPhysicalItemInfo[]`), `recalculateSpareParts`.
+>
+> `systemSubsystems` (`GET /system/{uid}/subsystems`) exists but is **not** consumed by this module — only by `modules/systems/hooks/useSubsystems.ts` for lazy row expansion in the overview table. See [ADR 0001](../../adr/0001-direct-only-param-on-leaves-endpoint.md) for why the direct-only view did not reuse it.

--- a/docs/user-guide/systemHierarchy/README.md
+++ b/docs/user-guide/systemHierarchy/README.md
@@ -31,6 +31,7 @@ The System Hierarchy module is the central place to browse, organize, and inspec
 
 - **System** — a hierarchical entity representing a piece of facility infrastructure (e.g. a beamline, a vacuum chamber, a controller).
 - **Subsystem** — a system nested under a parent system. A system can have any number of subsystems.
+- **End system** — a system with no subsystems of its own; the bottom of a branch. End systems are never shown in the left tree (which lists only systems that *have* children) — they appear in the middle panel. See [Navigating the tree](./workflows/navigating-the-tree.md#finding-a-nodes-own-end-systems).
 - **System level** — classification of where in the hierarchy a system sits: `SYSTEM_DOMAIN`, `TECHNOLOGY_UNIT`, `KEY_SYSTEMS`, `SUBSYSTEMS_AND_PARTS`, `TRASH`. Levels drive both visual styling and (in Phase 1) edit permissions. The `TRASH` level marks a holding area for retired or replaced items — see [Managing spare parts](./workflows/managing-spare-parts.md).
 - **System type** — codebook classification of *what kind* of system this is. Used for code generation and filtering.
 - **System code** — short identifier for the system, generated based on type, level, and ancestry.
@@ -51,8 +52,8 @@ The System Hierarchy module is the central place to browse, organize, and inspec
 
 The module is a three-panel explorer:
 
-- **Left — System tree.** Resizable. Top of the tree has a search box (300 ms debounced) and a *Collapse All* button. Each tree node shows the system name, a folder icon colored by system level, and a subsystem-count badge. Selecting a node auto-expands its ancestors. On mobile the tree collapses behind a toggle.
-- **Middle — Leaves panel.** Shows the children of the selected tree node, either as a table (default) or as a relationship graph. Has a toolbar with *Filters*, *Search*, and *Column visibility* controls, and a view switcher between *Tree View* (table) and *Graph View*.
+- **Left — System tree.** Resizable. Top of the tree has a search box (300 ms debounced) and a *Collapse All* button. Each tree node shows the system name, a folder icon colored by system level, a badge counting the end systems beneath it, and a small dot when some of them hang directly off that node. Selecting a node auto-expands its ancestors. On mobile the tree collapses behind a toggle.
+- **Middle — Leaves panel.** Shows the end systems beneath the selected tree node — at any depth by default, or only the direct ones with the *Direct only* checkbox — either as a table (default) or as a relationship graph. Has a toolbar with *Filters*, *Search*, *Direct only*, and *Column visibility* controls, and a view switcher between *Tree View* (table) and *Graph View*.
 - **Right — Quick Info sidebar.** On large screens a sticky 320 px panel with statistics (subsystem count, spare-part count, spare coverage), metadata, and — when the system has a physical item — its catalogue properties (with any service-modified values flagged). On smaller screens accessible via a floating *Info* button.
 - **Top — Breadcrumb.** Shows the ancestor path of the currently selected system. Clicking any ancestor navigates to it. Long paths collapse with an ellipsis (first ancestor + last two).
 
@@ -61,8 +62,8 @@ When a system is selected for full detail view, a tabbed area replaces the leave
 ## Common workflows
 
 - [Understanding edit permissions](./workflows/edit-permissions.md) — who can edit a given system, what a blocked user sees, and how to find the responsible person to contact.
-- [Navigating the tree](./workflows/navigating-the-tree.md) — expanding the tree, breadcrumb navigation, switching between table and graph views in the leaves panel.
-- [Searching and filtering](./workflows/searching-and-filtering.md) — search box and the multi-field filter sheet for the leaves panel.
+- [Navigating the tree](./workflows/navigating-the-tree.md) — expanding the tree, breadcrumb navigation, switching between table and graph views in the leaves panel, and finding a node's own end systems.
+- [Searching and filtering](./workflows/searching-and-filtering.md) — search box, the *Direct only* scope control, and the multi-field filter sheet for the leaves panel.
 - [Editing system details](./workflows/editing-system-details.md) — inline edit of name, code, level, type, location, zone, description on the *Detail* tab. Includes system code generation and the special meaning of the `TRASH` level.
 - [Managing system people](./workflows/managing-system-people.md) — responsible person, owner, responsible team, and the operators / maintained-by tables on the *Persons* tab.
 - [Managing relationships](./workflows/managing-relationships.md) — the 9 engineering relationship types, viewing them in the list and the graph, creating and deleting edges.

--- a/docs/user-guide/systemHierarchy/workflows/navigating-the-tree.md
+++ b/docs/user-guide/systemHierarchy/workflows/navigating-the-tree.md
@@ -62,7 +62,7 @@ See [Access & Responsibilities](../README.md#access--responsibilities) for what 
 
 The tree lists only systems that *have* children, and the table lists everything beneath the selected node at any depth. Between the two, a node's own end systems can be hard to spot: three of them sit unnoticed among two thousand rows coming from deeper branches.
 
-13. **Tick *Direct only*** next to the search box in the leaves panel toolbar. The table narrows to the end systems hanging immediately off the selected node.
+13. **Tick *Direct only*** next to the search box in the leaves panel toolbar. The table narrows to the end systems hanging immediately off the selected node, and the count in the panel header reads e.g. *(12 direct)* to distinguish it from the tree badge, which keeps counting everything below.
 
     `[SCREENSHOT PLACEHOLDER: leaves panel toolbar with the Direct only checkbox ticked, and a short table below it — contrast with the same node unticked showing a long paginated list]`
 

--- a/docs/user-guide/systemHierarchy/workflows/navigating-the-tree.md
+++ b/docs/user-guide/systemHierarchy/workflows/navigating-the-tree.md
@@ -25,36 +25,52 @@ See [Access & Responsibilities](../README.md#access--responsibilities) for what 
 
 2. **Click the chevron** next to a node to expand it, or click the node label to select it. Selecting a node automatically expands all its ancestors so you can always see where you are in the tree.
 
-3. **Read each node:** name on the left (highlighted if a search term matches), a folder icon colored by system level, and a small badge with the count of direct subsystems. The badge shows `…` while the count is loading.
+3. **Read each node:** name on the left (highlighted if a search term matches), a folder icon colored by system level, and a small badge with the count of **end systems anywhere beneath it** — not just its direct children. The badge shows `…` while the count is loading.
 
-4. **Click *Collapse All*** to fold the entire tree back to the top level.
+4. **Watch for the small dot** just before the count badge. It means the node has at least one end system hanging *directly* off it. Because end systems never appear in the tree itself, the dot is your only cue that something is there — see [Finding a node's own end systems](#finding-a-nodes-own-end-systems) below.
+
+   `[SCREENSHOT PLACEHOLDER: two adjacent tree nodes at the same level, one showing the dot before its count badge and one without, to make the difference legible]`
+
+5. **Click *Collapse All*** to fold the entire tree back to the top level.
 
 ### Reading the breadcrumb
 
-5. **Look above the leaves panel** for the breadcrumb. It shows the full ancestor path of the currently selected system, ending with the system name and its system-code badge in bold.
+6. **Look above the leaves panel** for the breadcrumb. It shows the full ancestor path of the currently selected system, ending with the system name and its system-code badge in bold.
 
    `[SCREENSHOT PLACEHOLDER: breadcrumb showing ancestors separated by ">" arrows, ending with the current system in bold and a code badge]`
 
-6. **Click any ancestor** in the breadcrumb to navigate to it. The leaves panel and detail update to that ancestor.
+7. **Click any ancestor** in the breadcrumb to navigate to it. The leaves panel and detail update to that ancestor.
 
-7. **Long paths collapse** with an ellipsis: if there are more than four ancestors, the breadcrumb shows the first ancestor, an ellipsis, and the last two. The ellipsis itself is not clickable.
+8. **Long paths collapse** with an ellipsis: if there are more than four ancestors, the breadcrumb shows the first ancestor, an ellipsis, and the last two. The ellipsis itself is not clickable.
 
 ### Working with the leaves panel
 
-8. **Pick a parent in the tree.** The middle panel shows that parent's direct subsystems — its *leaves*. The panel header reads *Subsystems*. If the parent has no children, you see *No subsystems found*.
+9. **Pick a parent in the tree.** The middle panel lists every **end system** beneath that parent — at any depth, not only its direct children. The panel header reads *Subsystems*. If there is nothing beneath it, you see *No subsystems found*.
 
-9. **Use the view switcher** in the panel header to flip between two layouts:
+10. **Use the view switcher** in the panel header to flip between two layouts:
 
    - **Tree View** (default) — a sortable, paginated table of subsystems with columns for code, path, name, type, location, zone, importance, and spare counts. See [Searching and filtering](./searching-and-filtering.md) for the toolbar above it.
    - **Graph View** — a relationship graph centered on the selected parent's children, showing how they relate to each other. See [Managing relationships](./managing-relationships.md) for full graph controls.
 
    `[SCREENSHOT PLACEHOLDER: Subsystems panel with the view switcher (Tree View / Graph View buttons) at the top right of the header, currently in Tree View showing a table of subsystems]`
 
-10. **Click any subsystem row** in the table to open its detail view (or click any node in the graph). The breadcrumb updates and the right sidebar populates with that system's *Quick Info*.
+11. **Click any subsystem row** in the table to open its detail view (or click any node in the graph). The breadcrumb updates and the right sidebar populates with that system's *Quick Info*.
 
-11. **Use *View Detail*** in the leaves panel header to open the full detail of the *currently-selected parent itself* (rather than one of its children).
+12. **Use *View Detail*** in the leaves panel header to open the full detail of the *currently-selected parent itself* (rather than one of its children).
 
-`[VIDEO PLACEHOLDER: 30s — expand a top-level domain in the tree, drill two levels down by clicking nodes, watch the breadcrumb update, click an ancestor in the breadcrumb to jump back, then switch the leaves panel to Graph View and back]`
+### Finding a node's own end systems
+
+The tree lists only systems that *have* children, and the table lists everything beneath the selected node at any depth. Between the two, a node's own end systems can be hard to spot: three of them sit unnoticed among two thousand rows coming from deeper branches.
+
+13. **Tick *Direct only*** next to the search box in the leaves panel toolbar. The table narrows to the end systems hanging immediately off the selected node.
+
+    `[SCREENSHOT PLACEHOLDER: leaves panel toolbar with the Direct only checkbox ticked, and a short table below it — contrast with the same node unticked showing a long paginated list]`
+
+14. **Keep browsing with it on.** The setting stays as you move around the tree, so you can walk down level by level and see what each node holds directly. It is also part of the URL, so a shared link opens in the same mode.
+
+15. **Untick it** — or use *Show all levels* if the table came up empty — to go back to the full list.
+
+`[VIDEO PLACEHOLDER: 30s — expand a top-level domain in the tree, drill two levels down by clicking nodes, watch the breadcrumb update, click an ancestor in the breadcrumb to jump back, tick Direct only on a node marked with the dot, then switch the leaves panel to Graph View and back]`
 
 ## Tips & gotchas
 
@@ -63,10 +79,12 @@ See [Access & Responsibilities](../README.md#access--responsibilities) for what 
 - **The quick-info sidebar** on the right always reflects the *currently selected* system, not the parent you're browsing in the leaves panel. Selecting a leaf row updates it.
 - **Mobile layout** collapses the tree behind a toggle and replaces the right sidebar with a floating *Info* button.
 - **The tree shows folder icons** colored by system level — use this as a quick visual cue for what kind of node you're looking at without having to read the breadcrumb.
+- **The count badge ignores *Direct only*.** It always counts every end system beneath a node, so you can keep comparing nodes against each other while the table shows a narrowed view. A node with a dot and a badge of `250` has *some* direct end systems among those 250 — tick *Direct only* to see how many.
+- **A node with no dot has nothing directly beneath it.** Everything under it sits deeper in the tree, so *Direct only* will come up empty there.
 
 ## Related
 
-- [Searching and filtering](./searching-and-filtering.md) — narrow down what's shown in the leaves panel.
+- [Searching and filtering](./searching-and-filtering.md) — narrow down what's shown in the leaves panel, and the *Direct only* scope control.
 - [Editing system details](./editing-system-details.md) — once you've reached a system, edit its attributes.
 - [Managing relationships](./managing-relationships.md) — full graph view controls and edge editing.
 - [Copying systems](./copying-systems.md) — right-click context menu on a tree node.

--- a/docs/user-guide/systemHierarchy/workflows/searching-and-filtering.md
+++ b/docs/user-guide/systemHierarchy/workflows/searching-and-filtering.md
@@ -38,7 +38,12 @@ By default the table lists every end system beneath the selected parent, however
 
 5. **Combine it freely.** Search, filters, sorting, and paging all keep working on the narrowed list. Ticking the box does not clear anything you had set.
 
-6. **If the table comes up empty**, you see *No end systems directly under this system* — everything beneath the parent sits deeper. Use *Show all levels* in that message to go back to the full list.
+6. **If the table comes up empty**, the message tells you which of the two is responsible:
+
+   | You see | Meaning | Offered |
+   |---|---|---|
+   | *No end systems directly under this system* | Nothing hangs directly off this parent — it all sits deeper | *Show all levels* |
+   | *No end systems directly under this system match the current search and filters* | There may well be some; your search or filter excluded them | *Show all levels* **and** *Clear Filters* |
 
 > **Tip:** the dot next to a node's count badge in the tree tells you in advance whether *Direct only* will find anything there. See [Navigating the tree](./navigating-the-tree.md#finding-a-nodes-own-end-systems).
 

--- a/docs/user-guide/systemHierarchy/workflows/searching-and-filtering.md
+++ b/docs/user-guide/systemHierarchy/workflows/searching-and-filtering.md
@@ -28,13 +28,25 @@ See [Access & Responsibilities](../README.md#access--responsibilities) for what 
 
 3. **Clear the search** by emptying the input. The full subsystem list returns.
 
-> **Tip:** the toolbar search filters only the *leaves panel* (children of the selected parent), not the whole hierarchy. To search the whole tree, use the search box at the top of the System Tree on the left — see [Navigating the tree](./navigating-the-tree.md).
+> **Tip:** the toolbar search filters only the *leaves panel* (everything beneath the selected parent), not the whole hierarchy. To search the whole tree, use the search box at the top of the System Tree on the left — see [Navigating the tree](./navigating-the-tree.md).
+
+### Narrowing to direct end systems
+
+By default the table lists every end system beneath the selected parent, however deep. *Direct only* changes **which systems are under consideration** — unlike the filters below, which narrow a list you already have.
+
+4. **Tick *Direct only*** next to the search box. The table drops to the end systems hanging immediately off the selected parent.
+
+5. **Combine it freely.** Search, filters, sorting, and paging all keep working on the narrowed list. Ticking the box does not clear anything you had set.
+
+6. **If the table comes up empty**, you see *No end systems directly under this system* — everything beneath the parent sits deeper. Use *Show all levels* in that message to go back to the full list.
+
+> **Tip:** the dot next to a node's count badge in the tree tells you in advance whether *Direct only* will find anything there. See [Navigating the tree](./navigating-the-tree.md#finding-a-nodes-own-end-systems).
 
 ### Opening the filter sheet
 
-4. **Click *Filters*** in the leaves panel toolbar. A side sheet slides in with all available filter fields.
+7. **Click *Filters*** in the leaves panel toolbar. A side sheet slides in with all available filter fields.
 
-5. **Watch the filter button:** when one or more filters are active, the button is filled (vs. outline when empty) and a *Filters Applied* tooltip appears on hover. A row of filter badges appears below the toolbar summarizing what is active.
+8. **Watch the filter button:** when one or more filters are active, the button is filled (vs. outline when empty) and a *Filters Applied* tooltip appears on hover. A row of filter badges appears below the toolbar summarizing what is active.
 
    `[SCREENSHOT PLACEHOLDER: leaves panel with the Filters button highlighted/filled and a row of small filter badges visible below the toolbar]`
 
@@ -72,7 +84,7 @@ The filter sheet is laid out in two columns. All fields combine with AND.
 
 ### Dynamic property filters
 
-6. **Pick a *Category*** in the catalogue section. When a category is selected, two extra sections appear at the bottom of the sheet:
+9. **Pick a *Category*** in the catalogue section. When a category is selected, two extra sections appear at the bottom of the sheet:
 
    - **Category Properties** — filters keyed to the properties defined on that catalogue category.
    - **Item Properties** — filters keyed to per-item property values within that category.
@@ -81,18 +93,19 @@ The filter sheet is laid out in two columns. All fields combine with AND.
 
 ### Applying, saving, and clearing
 
-7. **Save your filter setup** with *Save Settings* in the footer of the sheet — this stores the current filter combination as a named preset for later reuse.
+10. **Save your filter setup** with *Save Settings* in the footer of the sheet — this stores the current filter combination as a named preset for later reuse.
 
-8. **Clear everything** with *Clear Filters* in the footer. The form resets and all column filters in the table clear.
+11. **Clear everything** with *Clear Filters* in the footer. The form resets and all column filters in the table clear. *Direct only* is a scope, not a filter, so it stays as you left it.
 
-9. **Close the sheet** by clicking outside it or using the close icon. Active filters remain applied.
+12. **Close the sheet** by clicking outside it or using the close icon. Active filters remain applied.
 
 `[VIDEO PLACEHOLDER: 30s — type a search term and watch the table filter, then open the Filters sheet, set a system level + responsible person + price range, see the badge row appear below the toolbar, then clear all filters]`
 
 ## Tips & gotchas
 
-- **Filters live in the URL.** The current filter set is encoded as a query parameter — you can share the URL or bookmark it to come back to the same view.
-- **Search and filters compose.** A free-text search applies on top of any active filter set; the displayed table is the intersection.
+- **Filters live in the URL.** The current filter set is encoded as a query parameter — you can share the URL or bookmark it to come back to the same view. So does *Direct only*.
+- **Search and filters compose.** A free-text search applies on top of any active filter set; the displayed table is the intersection. *Direct only* composes with both.
+- **Nothing resets when you pick a different parent** — search, filters, and *Direct only* all follow you around the tree until you clear them. Only the page number resets. If a node looks emptier than expected, check the toolbar before concluding it has nothing in it.
 - **Spare-part coverage range** treats blank Min/Max as "no bound" — leave one side empty to filter only on the other.
 - **Category-driven property filters** disappear if you remove the category. If you saved a preset that included property filters, switching categories may leave you with stale property filters that no longer match anything — clear and reapply.
 - **The price range** picks up its dynamic min/max from the currently visible data set, so the slider bounds shift as the rest of the filters narrow the data.

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1502,12 +1502,18 @@ export const messages = {
             noSystems: 'No systems found',
             noResults: 'No matching systems',
             searchPlaceholder: 'Search systems...',
+            hasDirectLeaves: 'Has end systems directly under it',
         },
         leaves: {
             title: 'Subsystems',
             noLeaves: 'No subsystems found',
             selectParent: 'Select a system from the tree to view its subsystems',
             viewParent: 'View Detail',
+            directOnly: 'Direct only',
+            directOnlyTooltip:
+                'Show only end systems directly under this system, instead of everything deeper in the tree.',
+            noDirectLeaves: 'No end systems directly under this system',
+            showAllLevels: 'Show all levels',
             filtersApplied: 'Filters Applied',
             openFilters: 'Open Filters',
         },

--- a/src/i18n/src/locale/en.ts
+++ b/src/i18n/src/locale/en.ts
@@ -1513,7 +1513,10 @@ export const messages = {
             directOnlyTooltip:
                 'Show only end systems directly under this system, instead of everything deeper in the tree.',
             noDirectLeaves: 'No end systems directly under this system',
+            noDirectLeavesMatching:
+                'No end systems directly under this system match the current search and filters',
             showAllLevels: 'Show all levels',
+            directCountSuffix: 'direct',
             filtersApplied: 'Filters Applied',
             openFilters: 'Open Filters',
         },

--- a/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
+++ b/src/modules/systemHierarchy/components/detail/SystemDetailHeader.comp.tsx
@@ -31,7 +31,7 @@ export const SystemDetailHeader: FC<SystemDetailHeaderProps> = ({
             data-testid="system-hierarchy-detail-header"
         >
             <Button
-                variant="ghost"
+                variant="outline"
                 size="sm"
                 onClick={onBack}
                 className="h-8 gap-1.5 px-2 text-xs"

--- a/src/modules/systemHierarchy/components/leaves/LeavesEmptyState.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesEmptyState.comp.tsx
@@ -1,0 +1,68 @@
+import type { FC } from 'react'
+import { useIntl } from 'react-intl'
+
+import { Button } from '@/components/ui/button'
+import { message } from '@/i18n/src/messages'
+
+interface LeavesEmptyStateProps {
+    directOnly: boolean
+    hasNarrowedQuery: boolean
+    onShowAllLevels: () => void
+    onClearFilters: () => void
+}
+
+/**
+ * Two independent things can empty the table — the direct-only scope and the
+ * search/filter set — and they can be true at the same time. Naming only one of them
+ * would state something false ("no end systems directly under this system" when there
+ * are some, just none matching the filter) and offer a way out that leaves the user
+ * in a second empty state. So the message names whichever combination applies and
+ * every applicable escape is offered at once.
+ */
+export const LeavesEmptyState: FC<LeavesEmptyStateProps> = ({
+    directOnly,
+    hasNarrowedQuery,
+    onShowAllLevels,
+    onClearFilters,
+}) => {
+    const { formatMessage: fm } = useIntl()
+
+    const messageId = directOnly
+        ? hasNarrowedQuery
+            ? message.systemHierarchy.leaves.noDirectLeavesMatching
+            : message.systemHierarchy.leaves.noDirectLeaves
+        : message.systemHierarchy.leaves.noLeaves
+
+    return (
+        <div
+            className="flex items-center justify-center py-12 text-muted-foreground text-sm"
+            data-testid="leaves-empty-state"
+        >
+            <div className="text-center">
+                <p>{fm({ id: messageId })}</p>
+                <div className="flex items-center justify-center gap-2 mt-2">
+                    {directOnly && (
+                        <Button
+                            variant="link"
+                            size="sm"
+                            onClick={onShowAllLevels}
+                            data-testid="leaves-show-all-levels"
+                        >
+                            {fm({ id: message.systemHierarchy.leaves.showAllLevels })}
+                        </Button>
+                    )}
+                    {hasNarrowedQuery && (
+                        <Button
+                            variant="link"
+                            size="sm"
+                            onClick={onClearFilters}
+                            data-testid="leaves-clear-filters"
+                        >
+                            {fm({ id: message.common.ui.clearFilters })}
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -3,8 +3,8 @@ import type { FC } from 'react'
 import { useCallback, useEffect } from 'react'
 import { useIntl } from 'react-intl'
 
-import { Button } from '@/components/ui/button'
 import { useFormFilterState } from '@/hooks/form/useFormFilters'
+import { useResetPaginationOnChange } from '@/hooks/table/usePagination'
 import { message } from '@/i18n/src/messages'
 import { usePandaTable } from '@/modules/shared/table/pandaTable/hooks/usePandaTable'
 import useTableStateStore from '@/store/useTableStateStore'
@@ -15,6 +15,7 @@ import { useDeleteSystemAction } from '../../hooks/useDeleteSystemAction'
 import { useHierarchyNavigation } from '../../hooks/useHierarchyNavigation'
 import { LEAVES_TABLE_ID } from '../../types/constants'
 import { SystemDetailViewContainer } from '../detail/SystemDetailView.cont'
+import { LeavesEmptyState } from './LeavesEmptyState.comp'
 import { LeavesPanelHeader } from './LeavesPanelHeader.comp'
 import { LeavesTableComponent } from './LeavesTable.comp'
 import { LeavesToolbar } from './LeavesToolbar.comp'
@@ -87,7 +88,28 @@ export const LeavesPanelContainer: FC = () => {
         tableId: LEAVES_TABLE_ID,
         enableQueryUrl: true,
     })
-    const hasActiveFilters = storeFilters.length > 0
+    // Search narrows the result exactly like a column filter does, so the empty state
+    // has to account for both or it will blame the wrong thing.
+    const activeSearch = useTableStateStore(s => s.instances[LEAVES_TABLE_ID]?.search) ?? ''
+    const hasNarrowedQuery = storeFilters.length > 0 || activeSearch.length > 0
+
+    const handleClearNarrowing = useCallback(() => {
+        setColumnFilters([])
+        setSearch(LEAVES_TABLE_ID, '')
+        setSearchValue(LEAVES_TABLE_ID, '')
+    }, [setColumnFilters, setSearch, setSearchValue])
+
+    // setDirectOnly drops ?page, but useQueryManager reads the zustand paginationState
+    // first and that is only cleared by an effect — one render would otherwise request
+    // a page that does not exist in the narrowed set.
+    const resetPagination = useResetPaginationOnChange(LEAVES_TABLE_ID)
+    const handleDirectOnlyChange = useCallback(
+        (next: boolean) => {
+            resetPagination()
+            setDirectOnly(next)
+        },
+        [resetPagination, setDirectOnly],
+    )
 
     const handleViewParentDetail = useCallback(() => {
         if (selectedParentUid) {
@@ -117,6 +139,7 @@ export const LeavesPanelContainer: FC = () => {
             parentSystemType={parentSystem?.systemType?.name ?? null}
             parentPath={parentSystem?.parentPath ?? null}
             totalCount={totalCount}
+            directOnly={directOnly}
             isLoading={isParentLoading}
             onViewParentDetail={handleViewParentDetail}
             onSelectAncestor={selectParent}
@@ -129,46 +152,19 @@ export const LeavesPanelContainer: FC = () => {
             table={table}
             enableQueryURL={true}
             directOnly={directOnly}
-            onDirectOnlyChange={setDirectOnly}
+            onDirectOnlyChange={handleDirectOnlyChange}
         />
     )
 
-    // Direct-only takes precedence: with the mode on, "nothing here" is far more
-    // likely to be the narrowed scope than the filters, so offer that escape first.
-    const emptyState = directOnly ? (
-        <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
-            <div className="text-center">
-                <p>{fm({ id: message.systemHierarchy.leaves.noDirectLeaves })}</p>
-                <Button
-                    variant="link"
-                    size="sm"
-                    className="mt-2"
-                    onClick={() => setDirectOnly(false)}
-                    data-testid="leaves-show-all-levels"
-                >
-                    {fm({ id: message.systemHierarchy.leaves.showAllLevels })}
-                </Button>
-            </div>
-        </div>
-    ) : hasActiveFilters ? (
-        <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
-            <div className="text-center">
-                <p>{fm({ id: message.systemHierarchy.leaves.noLeaves })}</p>
-                <Button
-                    variant="link"
-                    size="sm"
-                    className="mt-2"
-                    onClick={() => {
-                        setColumnFilters([])
-                        setSearch(LEAVES_TABLE_ID, '')
-                        setSearchValue(LEAVES_TABLE_ID, '')
-                    }}
-                >
-                    {fm({ id: message.common.ui.clearFilters })}
-                </Button>
-            </div>
-        </div>
-    ) : undefined
+    const emptyState =
+        directOnly || hasNarrowedQuery ? (
+            <LeavesEmptyState
+                directOnly={directOnly}
+                hasNarrowedQuery={hasNarrowedQuery}
+                onShowAllLevels={() => handleDirectOnlyChange(false)}
+                onClearFilters={handleClearNarrowing}
+            />
+        ) : undefined
 
     return (
         <div

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanel.cont.tsx
@@ -27,9 +27,14 @@ export const LeavesPanelContainer: FC = () => {
         selectedLeafUid,
         selectLeaf,
         selectParent,
+        directOnly,
+        setDirectOnly,
     } = useHierarchyNavigation()
     const { system: parentSystem, isLoading: isParentLoading } = useSystemDetail(selectedParentUid)
-    const { leaves, totalCount, isLoading, isInitialLoad } = useSystemLeaves(selectedParentUid)
+    const { leaves, totalCount, isLoading, isInitialLoad } = useSystemLeaves(
+        selectedParentUid,
+        directOnly,
+    )
 
     const { columns } = useLeavesColumns()
     const { canEdit, handleDeleteSystem } = useDeleteSystemAction()
@@ -118,9 +123,34 @@ export const LeavesPanelContainer: FC = () => {
         />
     )
 
-    const toolbar = <LeavesToolbar tableId={LEAVES_TABLE_ID} table={table} enableQueryURL={true} />
+    const toolbar = (
+        <LeavesToolbar
+            tableId={LEAVES_TABLE_ID}
+            table={table}
+            enableQueryURL={true}
+            directOnly={directOnly}
+            onDirectOnlyChange={setDirectOnly}
+        />
+    )
 
-    const emptyState = hasActiveFilters ? (
+    // Direct-only takes precedence: with the mode on, "nothing here" is far more
+    // likely to be the narrowed scope than the filters, so offer that escape first.
+    const emptyState = directOnly ? (
+        <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
+            <div className="text-center">
+                <p>{fm({ id: message.systemHierarchy.leaves.noDirectLeaves })}</p>
+                <Button
+                    variant="link"
+                    size="sm"
+                    className="mt-2"
+                    onClick={() => setDirectOnly(false)}
+                    data-testid="leaves-show-all-levels"
+                >
+                    {fm({ id: message.systemHierarchy.leaves.showAllLevels })}
+                </Button>
+            </div>
+        </div>
+    ) : hasActiveFilters ? (
         <div className="flex items-center justify-center py-12 text-muted-foreground text-sm">
             <div className="text-center">
                 <p>{fm({ id: message.systemHierarchy.leaves.noLeaves })}</p>

--- a/src/modules/systemHierarchy/components/leaves/LeavesPanelHeader.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesPanelHeader.comp.tsx
@@ -18,6 +18,7 @@ interface LeavesPanelHeaderProps {
     parentSystemType: string | null
     parentPath: ParentPathItem[] | null
     totalCount: number
+    directOnly?: boolean
     isLoading: boolean
     onViewParentDetail: () => void
     onSelectAncestor: SelectAncestorHandler
@@ -29,6 +30,7 @@ export const LeavesPanelHeader: FC<LeavesPanelHeaderProps> = ({
     parentSystemType,
     parentPath,
     totalCount,
+    directOnly = false,
     isLoading,
     onViewParentDetail,
     onSelectAncestor,
@@ -77,7 +79,14 @@ export const LeavesPanelHeader: FC<LeavesPanelHeaderProps> = ({
                         {fm({ id: message.systemHierarchy.leaves.viewParent })}
                     </Button>
                     {totalCount > 0 && (
-                        <span className="text-xs text-muted-foreground">({totalCount})</span>
+                        // Qualified in direct-only mode: the tree badge for the same node
+                        // still shows the total, so two different numbers are on screen
+                        // at once and the header is what explains the difference.
+                        <span className="text-xs text-muted-foreground">
+                            {directOnly
+                                ? `(${totalCount} ${fm({ id: message.systemHierarchy.leaves.directCountSuffix })})`
+                                : `(${totalCount})`}
+                        </span>
                     )}
                 </div>
             </div>

--- a/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
@@ -5,8 +5,9 @@ import { useIntl } from 'react-intl'
 
 import { Tooltip } from '@/components/Tooltip'
 import { Button } from '@/components/ui/button'
-import { CheckboxWithLabel } from '@/components/ui/checkbox'
+import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { useFormFilterState } from '@/hooks/form/useFormFilters'
 import { message } from '@/i18n/src/messages'
 import { FilterBadges } from '@/modules/shared/form/FilterBadges'
@@ -85,15 +86,28 @@ export const LeavesToolbar: FC<LeavesToolbarProps> = ({
                         />
                     </div>
                 </div>
+                {/* The explanation is bound to the checkbox with aria-describedby rather
+                    than left to live only in the tooltip: Radix puts its describedby on
+                    the trigger, which here is the wrapper, so the control itself would
+                    otherwise carry no description at all. The tooltip stays for pointer
+                    users; sr-only text is what makes it reachable without one. */}
                 <Tooltip content={fm({ id: message.systemHierarchy.leaves.directOnlyTooltip })}>
-                    <div data-testid="leaves-toolbar-direct-only">
-                        <CheckboxWithLabel
+                    <div
+                        className="flex items-center gap-2"
+                        data-testid="leaves-toolbar-direct-only"
+                    >
+                        <Checkbox
                             id="leaves-direct-only"
-                            label={fm({ id: message.systemHierarchy.leaves.directOnly })}
                             checked={directOnly}
-                            onChange={onDirectOnlyChange}
-                            className="whitespace-nowrap"
+                            onCheckedChange={checked => onDirectOnlyChange(checked === true)}
+                            aria-describedby="leaves-direct-only-hint"
                         />
+                        <Label htmlFor="leaves-direct-only" className="whitespace-nowrap">
+                            {fm({ id: message.systemHierarchy.leaves.directOnly })}
+                        </Label>
+                        <span id="leaves-direct-only-hint" className="sr-only">
+                            {fm({ id: message.systemHierarchy.leaves.directOnlyTooltip })}
+                        </span>
                     </div>
                 </Tooltip>
                 <ColumnVisibilityDropdown table={table} excludeColumns={['icon']} />

--- a/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
+++ b/src/modules/systemHierarchy/components/leaves/LeavesToolbar.comp.tsx
@@ -5,6 +5,7 @@ import { useIntl } from 'react-intl'
 
 import { Tooltip } from '@/components/Tooltip'
 import { Button } from '@/components/ui/button'
+import { CheckboxWithLabel } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { useFormFilterState } from '@/hooks/form/useFormFilters'
 import { message } from '@/i18n/src/messages'
@@ -19,12 +20,16 @@ interface LeavesToolbarProps {
     tableId: string
     table: Table<SystemLeaf>
     enableQueryURL?: boolean
+    directOnly: boolean
+    onDirectOnlyChange: (next: boolean) => void
 }
 
 export const LeavesToolbar: FC<LeavesToolbarProps> = ({
     tableId,
     table,
     enableQueryURL = true,
+    directOnly,
+    onDirectOnlyChange,
 }) => {
     const { formatMessage: fm } = useIntl()
     const openFilterSheet = useLeavesFilterSheet()
@@ -80,6 +85,17 @@ export const LeavesToolbar: FC<LeavesToolbarProps> = ({
                         />
                     </div>
                 </div>
+                <Tooltip content={fm({ id: message.systemHierarchy.leaves.directOnlyTooltip })}>
+                    <div data-testid="leaves-toolbar-direct-only">
+                        <CheckboxWithLabel
+                            id="leaves-direct-only"
+                            label={fm({ id: message.systemHierarchy.leaves.directOnly })}
+                            checked={directOnly}
+                            onChange={onDirectOnlyChange}
+                            className="whitespace-nowrap"
+                        />
+                    </div>
+                </Tooltip>
                 <ColumnVisibilityDropdown table={table} excludeColumns={['icon']} />
             </div>
             {hasActiveFilters && <FilterBadges tableId={tableId} enableQueryURL={enableQueryURL} />}

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesEmptyState.spec.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesEmptyState.spec.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, screen } from '@testing-library/react'
+
+import { renderWithProviders as render } from '@/testutils/wrappers/renderWithProviders'
+
+import { LeavesEmptyState } from '../LeavesEmptyState.comp'
+
+let onShowAllLevels: jest.Mock
+let onClearFilters: jest.Mock
+
+const renderEmptyState = (props: Partial<React.ComponentProps<typeof LeavesEmptyState>> = {}) =>
+    render(
+        <LeavesEmptyState
+            directOnly={false}
+            hasNarrowedQuery={false}
+            onShowAllLevels={onShowAllLevels}
+            onClearFilters={onClearFilters}
+            {...props}
+        />,
+    )
+
+beforeEach(() => {
+    onShowAllLevels = jest.fn()
+    onClearFilters = jest.fn()
+})
+
+describe('LeavesEmptyState', () => {
+    it('blames the filters when only they are narrowing', () => {
+        renderEmptyState({ hasNarrowedQuery: true })
+
+        expect(screen.getByText('No subsystems found')).toBeInTheDocument()
+        expect(screen.getByTestId('leaves-clear-filters')).toBeInTheDocument()
+        expect(screen.queryByTestId('leaves-show-all-levels')).toBeNull()
+    })
+
+    it('blames the scope when only direct-only is on', () => {
+        renderEmptyState({ directOnly: true })
+
+        expect(
+            screen.getByText('No end systems directly under this system'),
+        ).toBeInTheDocument()
+        expect(screen.getByTestId('leaves-show-all-levels')).toBeInTheDocument()
+        expect(screen.queryByTestId('leaves-clear-filters')).toBeNull()
+    })
+
+    it('names both causes when both apply, instead of asserting something false', () => {
+        // The scope-only message would claim there are no direct end systems, which may
+        // well be untrue — the filter could be what excluded them.
+        renderEmptyState({ directOnly: true, hasNarrowedQuery: true })
+
+        expect(
+            screen.getByText(
+                'No end systems directly under this system match the current search and filters',
+            ),
+        ).toBeInTheDocument()
+    })
+
+    it('offers both escapes when both apply, so recovery is one click either way', () => {
+        renderEmptyState({ directOnly: true, hasNarrowedQuery: true })
+
+        fireEvent.click(screen.getByTestId('leaves-show-all-levels'))
+        expect(onShowAllLevels).toHaveBeenCalled()
+
+        fireEvent.click(screen.getByTestId('leaves-clear-filters'))
+        expect(onClearFilters).toHaveBeenCalled()
+    })
+})

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesPanelHeader.spec.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesPanelHeader.spec.tsx
@@ -68,6 +68,13 @@ describe('LeavesPanelHeader', () => {
         expect(screen.queryByText('(0)')).toBeNull()
     })
 
+    it('qualifies the count in direct-only mode', () => {
+        // The tree badge for the same node keeps showing the total, so an unqualified
+        // number here would put two conflicting figures on screen with no explanation.
+        renderWithProviders(<LeavesPanelHeader {...baseProps} totalCount={12} directOnly />)
+        expect(screen.getByText('(12 direct)')).toBeInTheDocument()
+    })
+
     it('parentSystemType falls back to default leaves title when null', () => {
         renderWithProviders(
             <LeavesPanelHeader {...baseProps} parentSystemType={null} />,

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.spec.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.spec.tsx
@@ -122,6 +122,21 @@ describe('LeavesToolbar', () => {
             expect(checkbox()).toBeEnabled()
         })
 
+        it('carries the explanation as a description, not only in the tooltip', () => {
+            // Radix puts its own aria-describedby on the tooltip trigger — the wrapper —
+            // so without this the control itself would have no description at all, and
+            // the help text would be reachable by pointer only.
+            renderToolbar()
+            expect(checkbox()).toHaveAccessibleDescription(
+                'Show only end systems directly under this system, instead of everything deeper in the tree.',
+            )
+        })
+
+        it('is labelled by the visible label', () => {
+            renderToolbar()
+            expect(checkbox()).toHaveAccessibleName('Direct only')
+        })
+
         it('leaves filter and search reachable so the mode can be exited', () => {
             renderToolbar({ directOnly: true })
             expect(screen.getByTestId('leaves-toolbar-filter-btn')).toBeEnabled()

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.spec.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.spec.tsx
@@ -38,10 +38,23 @@ const mockUseDebouncedSearchInput = useDebouncedSearchInput as jest.Mock
 const mockUseLeavesFilterSheet = useLeavesFilterSheet as unknown as jest.Mock
 
 let openFilterSheet: jest.Mock
+let onDirectOnlyChange: jest.Mock
+
+const renderToolbar = (props: Partial<React.ComponentProps<typeof LeavesToolbar>> = {}) =>
+    render(
+        <LeavesToolbar
+            tableId="t1"
+            table={{} as any}
+            directOnly={false}
+            onDirectOnlyChange={onDirectOnlyChange}
+            {...props}
+        />,
+    )
 
 beforeEach(() => {
     jest.clearAllMocks()
     openFilterSheet = jest.fn()
+    onDirectOnlyChange = jest.fn()
     mockUseLeavesFilterSheet.mockReturnValue(openFilterSheet)
     mockUseFormFilterState.mockReturnValue({ storeFilters: [] })
     mockUseDebouncedSearchInput.mockReturnValue({
@@ -53,39 +66,66 @@ beforeEach(() => {
 
 describe('LeavesToolbar', () => {
     it('renders filter btn + search + ColumnVisibility excluding icon', () => {
-        render(<LeavesToolbar tableId="t1" table={{} as any} />)
+        renderToolbar()
         expect(screen.getByTestId('leaves-toolbar-filter-btn')).toBeInTheDocument()
         expect(screen.getByTestId('leaves-toolbar-search')).toBeInTheDocument()
         expect(screen.getByTestId('col-vis').dataset.excludes).toBe('icon')
     })
 
     it('filter button click opens sheet', () => {
-        render(<LeavesToolbar tableId="t1" table={{} as any} />)
+        renderToolbar()
         fireEvent.click(screen.getByTestId('leaves-toolbar-filter-btn'))
         expect(openFilterSheet).toHaveBeenCalled()
     })
 
     it('hides FilterBadges when no active filters', () => {
-        render(<LeavesToolbar tableId="t1" table={{} as any} />)
+        renderToolbar()
         expect(screen.queryByTestId('filter-badges')).toBeNull()
     })
 
     it('shows FilterBadges when storeFilters non-empty', () => {
         mockUseFormFilterState.mockReturnValue({ storeFilters: [{ id: 'x', value: 'y' }] })
-        render(<LeavesToolbar tableId="t1" table={{} as any} />)
+        renderToolbar()
         expect(screen.getByTestId('filter-badges')).toBeInTheDocument()
     })
 
     it('filter icon gets fill-current when filters active', () => {
         mockUseFormFilterState.mockReturnValue({ storeFilters: [{ id: 'x', value: 'y' }] })
-        const { container } = render(<LeavesToolbar tableId="t1" table={{} as any} />)
+        const { container } = renderToolbar()
         expect(container.querySelector('svg.fill-current')).toBeInTheDocument()
     })
 
     it('passes enableQueryURL through to useDebouncedSearchInput', () => {
-        render(<LeavesToolbar tableId="t1" table={{} as any} enableQueryURL={false} />)
+        renderToolbar({ enableQueryURL: false })
         expect(mockUseDebouncedSearchInput).toHaveBeenCalledWith(
             expect.objectContaining({ enableQueryURL: false }),
         )
+    })
+
+    describe('direct-only checkbox', () => {
+        const checkbox = () => screen.getByRole('checkbox')
+
+        it('reflects the directOnly prop', () => {
+            renderToolbar({ directOnly: true })
+            expect(checkbox()).toBeChecked()
+        })
+
+        it('reports the toggle to the parent', () => {
+            renderToolbar()
+            expect(checkbox()).not.toBeChecked()
+            fireEvent.click(checkbox())
+            expect(onDirectOnlyChange).toHaveBeenCalledWith(true)
+        })
+
+        it('is never disabled — the flag it would key off is cached tree data', () => {
+            renderToolbar({ directOnly: true })
+            expect(checkbox()).toBeEnabled()
+        })
+
+        it('leaves filter and search reachable so the mode can be exited', () => {
+            renderToolbar({ directOnly: true })
+            expect(screen.getByTestId('leaves-toolbar-filter-btn')).toBeEnabled()
+            expect(screen.getByTestId('leaves-toolbar-search')).toBeEnabled()
+        })
     })
 })

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.test.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.test.tsx
@@ -61,75 +61,50 @@ const renderWithIntl = (ui: React.JSX.Element) =>
         </IntlProvider>,
     )
 
+const renderToolbar = (props: Partial<React.ComponentProps<typeof LeavesToolbar>> = {}) =>
+    renderWithIntl(
+        <LeavesToolbar
+            tableId={LEAVES_TABLE_ID}
+            table={createMockTable() as any}
+            directOnly={false}
+            onDirectOnlyChange={jest.fn()}
+            {...props}
+        />,
+    )
+
 describe('LeavesToolbar', () => {
     beforeEach(() => {
         jest.clearAllMocks()
     })
 
     it('renders search input', () => {
-        const table = createMockTable()
-        renderWithIntl(<LeavesToolbar
-                tableId={LEAVES_TABLE_ID}
-                table={table as any}
-                directOnly={false}
-                onDirectOnlyChange={jest.fn()}
-            />)
+        renderToolbar()
         expect(screen.getByTestId('leaves-toolbar-search')).toBeInTheDocument()
     })
 
     it('renders filter button', () => {
-        const table = createMockTable()
-        renderWithIntl(<LeavesToolbar
-                tableId={LEAVES_TABLE_ID}
-                table={table as any}
-                directOnly={false}
-                onDirectOnlyChange={jest.fn()}
-            />)
+        renderToolbar()
         expect(screen.getByTestId('leaves-toolbar-filter-btn')).toBeInTheDocument()
     })
 
     it('opens filter sheet on filter button click', () => {
-        const table = createMockTable()
-        renderWithIntl(<LeavesToolbar
-                tableId={LEAVES_TABLE_ID}
-                table={table as any}
-                directOnly={false}
-                onDirectOnlyChange={jest.fn()}
-            />)
+        renderToolbar()
         fireEvent.click(screen.getByTestId('leaves-toolbar-filter-btn'))
         expect(mockOpenFilterSheet).toHaveBeenCalled()
     })
 
     it('renders column visibility dropdown', () => {
-        const table = createMockTable()
-        renderWithIntl(<LeavesToolbar
-                tableId={LEAVES_TABLE_ID}
-                table={table as any}
-                directOnly={false}
-                onDirectOnlyChange={jest.fn()}
-            />)
+        renderToolbar()
         expect(screen.getByTestId('column-visibility-dropdown')).toBeInTheDocument()
     })
 
     it('renders toolbar container', () => {
-        const table = createMockTable()
-        renderWithIntl(<LeavesToolbar
-                tableId={LEAVES_TABLE_ID}
-                table={table as any}
-                directOnly={false}
-                onDirectOnlyChange={jest.fn()}
-            />)
+        renderToolbar()
         expect(screen.getByTestId('leaves-toolbar')).toBeInTheDocument()
     })
 
     it('updates local value on search input change', () => {
-        const table = createMockTable()
-        renderWithIntl(<LeavesToolbar
-                tableId={LEAVES_TABLE_ID}
-                table={table as any}
-                directOnly={false}
-                onDirectOnlyChange={jest.fn()}
-            />)
+        renderToolbar()
         const searchInput = screen.getByTestId('leaves-toolbar-search')
         fireEvent.change(searchInput, { target: { value: 'test search' } })
         expect(searchInput).toHaveValue('test search')

--- a/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.test.tsx
+++ b/src/modules/systemHierarchy/components/leaves/__tests__/LeavesToolbar.test.tsx
@@ -68,38 +68,68 @@ describe('LeavesToolbar', () => {
 
     it('renders search input', () => {
         const table = createMockTable()
-        renderWithIntl(<LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />)
+        renderWithIntl(<LeavesToolbar
+                tableId={LEAVES_TABLE_ID}
+                table={table as any}
+                directOnly={false}
+                onDirectOnlyChange={jest.fn()}
+            />)
         expect(screen.getByTestId('leaves-toolbar-search')).toBeInTheDocument()
     })
 
     it('renders filter button', () => {
         const table = createMockTable()
-        renderWithIntl(<LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />)
+        renderWithIntl(<LeavesToolbar
+                tableId={LEAVES_TABLE_ID}
+                table={table as any}
+                directOnly={false}
+                onDirectOnlyChange={jest.fn()}
+            />)
         expect(screen.getByTestId('leaves-toolbar-filter-btn')).toBeInTheDocument()
     })
 
     it('opens filter sheet on filter button click', () => {
         const table = createMockTable()
-        renderWithIntl(<LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />)
+        renderWithIntl(<LeavesToolbar
+                tableId={LEAVES_TABLE_ID}
+                table={table as any}
+                directOnly={false}
+                onDirectOnlyChange={jest.fn()}
+            />)
         fireEvent.click(screen.getByTestId('leaves-toolbar-filter-btn'))
         expect(mockOpenFilterSheet).toHaveBeenCalled()
     })
 
     it('renders column visibility dropdown', () => {
         const table = createMockTable()
-        renderWithIntl(<LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />)
+        renderWithIntl(<LeavesToolbar
+                tableId={LEAVES_TABLE_ID}
+                table={table as any}
+                directOnly={false}
+                onDirectOnlyChange={jest.fn()}
+            />)
         expect(screen.getByTestId('column-visibility-dropdown')).toBeInTheDocument()
     })
 
     it('renders toolbar container', () => {
         const table = createMockTable()
-        renderWithIntl(<LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />)
+        renderWithIntl(<LeavesToolbar
+                tableId={LEAVES_TABLE_ID}
+                table={table as any}
+                directOnly={false}
+                onDirectOnlyChange={jest.fn()}
+            />)
         expect(screen.getByTestId('leaves-toolbar')).toBeInTheDocument()
     })
 
     it('updates local value on search input change', () => {
         const table = createMockTable()
-        renderWithIntl(<LeavesToolbar tableId={LEAVES_TABLE_ID} table={table as any} />)
+        renderWithIntl(<LeavesToolbar
+                tableId={LEAVES_TABLE_ID}
+                table={table as any}
+                directOnly={false}
+                onDirectOnlyChange={jest.fn()}
+            />)
         const searchInput = screen.getByTestId('leaves-toolbar-search')
         fireEvent.change(searchInput, { target: { value: 'test search' } })
         expect(searchInput).toHaveValue('test search')

--- a/src/modules/systemHierarchy/components/tree/TreeNode.comp.tsx
+++ b/src/modules/systemHierarchy/components/tree/TreeNode.comp.tsx
@@ -107,7 +107,12 @@ export const TreeNode: FC<TreeNodeProps> = ({
                 indicator — the row already handles clicks. */}
             {node.hasLeafChildren && (
                 <Tooltip content={fm({ id: message.systemHierarchy.tree.hasDirectLeaves })}>
+                    {/* The tooltip is hover-only, so without an accessible name the marker
+                        would be invisible to screen readers — exactly the users who can
+                        least afford to miss the one cue that end systems are hiding here. */}
                     <span
+                        role="img"
+                        aria-label={fm({ id: message.systemHierarchy.tree.hasDirectLeaves })}
                         className="size-1.5 shrink-0 rounded-full bg-primary/60"
                         data-testid={`tree-node-direct-leaves-${node.uid}`}
                     />

--- a/src/modules/systemHierarchy/components/tree/TreeNode.comp.tsx
+++ b/src/modules/systemHierarchy/components/tree/TreeNode.comp.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import { useCallback } from 'react'
 import { useIntl } from 'react-intl'
 
+import { Tooltip } from '@/components/Tooltip'
 import {
     ContextMenu,
     ContextMenuContent,
@@ -101,6 +102,17 @@ export const TreeNode: FC<TreeNodeProps> = ({
             <span className="truncate flex-1">
                 {search ? highlightText(node.name, search) : node.name}
             </span>
+            {/* End systems never appear in the tree, so without this marker there is no
+                way to tell which node hides some directly beneath it. Purely an
+                indicator — the row already handles clicks. */}
+            {node.hasLeafChildren && (
+                <Tooltip content={fm({ id: message.systemHierarchy.tree.hasDirectLeaves })}>
+                    <span
+                        className="size-1.5 shrink-0 rounded-full bg-primary/60"
+                        data-testid={`tree-node-direct-leaves-${node.uid}`}
+                    />
+                </Tooltip>
+            )}
             <code className="text-[10px] text-muted-foreground shrink-0 rounded bg-muted px-1 py-0.5">
                 {isLeavesCountLoading ? '…' : count}
             </code>

--- a/src/modules/systemHierarchy/components/tree/__tests__/TreeNode.test.tsx
+++ b/src/modules/systemHierarchy/components/tree/__tests__/TreeNode.test.tsx
@@ -30,6 +30,7 @@ const messages = {
     'systemHierarchy.copy.pasteSystem': 'Paste System',
     'systemHierarchy.create.menuItem': 'Create System',
     'systemHierarchy.delete.menuItem': 'Delete System',
+    'systemHierarchy.tree.hasDirectLeaves': 'Has end systems directly under it',
 }
 
 const renderTreeNode = (props: Partial<React.ComponentProps<typeof TreeNode>> = {}) =>
@@ -85,6 +86,15 @@ describe('TreeNode', () => {
         it('marks a node that has end systems directly under it', () => {
             renderTreeNode()
             expect(screen.getByTestId('tree-node-direct-leaves-node-1')).toBeInTheDocument()
+        })
+
+        it('exposes the marker to assistive tech, not just to hover', () => {
+            // The tooltip is hover-only; without a name the one cue that end systems are
+            // hiding under this node is invisible to screen-reader users.
+            renderTreeNode()
+            expect(
+                screen.getByRole('img', { name: 'Has end systems directly under it' }),
+            ).toBeInTheDocument()
         })
 
         it('omits the marker when every end system sits deeper', () => {

--- a/src/modules/systemHierarchy/components/tree/__tests__/TreeNode.test.tsx
+++ b/src/modules/systemHierarchy/components/tree/__tests__/TreeNode.test.tsx
@@ -77,6 +77,28 @@ describe('TreeNode', () => {
         expect(screen.getByText('7')).toBeInTheDocument()
     })
 
+    describe('direct end-systems marker', () => {
+        beforeEach(() => {
+            mockUseSystemLeavesCount.mockReturnValue({ count: 7, isLoading: false, error: null })
+        })
+
+        it('marks a node that has end systems directly under it', () => {
+            renderTreeNode()
+            expect(screen.getByTestId('tree-node-direct-leaves-node-1')).toBeInTheDocument()
+        })
+
+        it('omits the marker when every end system sits deeper', () => {
+            renderTreeNode({ node: { ...baseNode, hasLeafChildren: false } })
+            expect(screen.queryByTestId('tree-node-direct-leaves-node-1')).toBeNull()
+        })
+
+        it('leaves the count badge untouched — it stays the total, not the direct one', () => {
+            renderTreeNode()
+            expect(screen.getByText('7')).toBeInTheDocument()
+            expect(mockUseSystemLeavesCount).toHaveBeenCalledWith('node-1')
+        })
+    })
+
     it('calls onToggle and does not trigger onSelect when chevron button is clicked', () => {
         mockUseSystemLeavesCount.mockReturnValue({
             count: 3,

--- a/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
+++ b/src/modules/systemHierarchy/hooks/__tests__/useHierarchyNavigation.spec.ts
@@ -81,4 +81,51 @@ describe('useHierarchyNavigation', () => {
         act(() => result.current.selectParent('B'))
         expect(lastPushedQuery()).toEqual({ parent: 'B', leaf: 'B' })
     })
+
+    describe('directOnly', () => {
+        it('reads the flag off the URL', () => {
+            mockQuery = { parent: 'A', direct: '1' }
+            const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+            expect(result.current.directOnly).toBe(true)
+        })
+
+        it('treats any other value as off', () => {
+            mockQuery = { parent: 'A', direct: 'true' }
+            const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+            expect(result.current.directOnly).toBe(false)
+        })
+
+        it('setDirectOnly(true) sets the flag and drops a stale page', () => {
+            mockQuery = { parent: 'A', page: '9' }
+            const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+            act(() => result.current.setDirectOnly(true))
+            expect(lastPushedQuery()).toEqual({ parent: 'A', direct: '1' })
+        })
+
+        it('setDirectOnly(false) removes the flag and the page alike', () => {
+            mockQuery = { parent: 'A', direct: '1', page: '4' }
+            const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+            act(() => result.current.setDirectOnly(false))
+            expect(lastPushedQuery()).toEqual({ parent: 'A' })
+        })
+
+        it('keeps filters and search — the mode narrows scope, it does not replace them', () => {
+            mockQuery = { parent: 'A', search: 'pump', filter: '[{"id":"zone"}]' }
+            const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+            act(() => result.current.setDirectOnly(true))
+            expect(lastPushedQuery()).toEqual({
+                parent: 'A',
+                search: 'pump',
+                filter: '[{"id":"zone"}]',
+                direct: '1',
+            })
+        })
+
+        it('survives switching to another tree node, unlike page', () => {
+            mockQuery = { parent: 'A', direct: '1', page: '3' }
+            const { result } = renderHook(() => useHierarchyNavigation(), { wrapper })
+            act(() => result.current.selectParent('B'))
+            expect(lastPushedQuery()).toEqual({ parent: 'B', direct: '1' })
+        })
+    })
 })

--- a/src/modules/systemHierarchy/hooks/queries/__tests__/useSystemLeaves.spec.ts
+++ b/src/modules/systemHierarchy/hooks/queries/__tests__/useSystemLeaves.spec.ts
@@ -11,7 +11,7 @@ jest.mock('@/utils/fetcher', () => ({
 
 jest.mock('@/hooks/useQueryManager', () => ({
     __esModule: true,
-    default: () => ({ query: {} }),
+    default: () => ({ query: { search: 'pump' } }),
 }))
 
 const mockQueryFetcher = queryFetcher as jest.Mock
@@ -53,6 +53,39 @@ describe('useSystemLeaves', () => {
         await waitFor(() => expect(result.current.isInitialLoad).toBe(false))
         expect(result.current.leaves).toHaveLength(1)
         expect(result.current.totalCount).toBe(1)
+    })
+
+    describe('directOnly', () => {
+        const queryOf = (result: { current: { queryKey: unknown[] } }) =>
+            (result.current.queryKey[1] as { query: Record<string, unknown> }).query
+
+        it('omits the param when off, so the endpoint keeps its current shape', () => {
+            mockQueryFetcher.mockReturnValue(jest.fn(() => new Promise<never>(() => {})))
+            const { result } = renderHook(() => useSystemLeaves('sys-1'), {
+                wrapper: QueryClientWrapper,
+            })
+            expect(queryOf(result)).not.toHaveProperty('directOnly')
+        })
+
+        it('adds the param alongside the existing query when on', () => {
+            mockQueryFetcher.mockReturnValue(jest.fn(() => new Promise<never>(() => {})))
+            const { result } = renderHook(() => useSystemLeaves('sys-1', true), {
+                wrapper: QueryClientWrapper,
+            })
+            // search must survive — the mode narrows the scope, it does not replace filtering
+            expect(queryOf(result)).toEqual({ search: 'pump', directOnly: true })
+        })
+
+        it('keys the two modes apart so neither serves the other cached rows', () => {
+            mockQueryFetcher.mockReturnValue(jest.fn(() => new Promise<never>(() => {})))
+            const { result: all } = renderHook(() => useSystemLeaves('sys-1'), {
+                wrapper: QueryClientWrapper,
+            })
+            const { result: direct } = renderHook(() => useSystemLeaves('sys-1', true), {
+                wrapper: QueryClientWrapper,
+            })
+            expect(all.current.queryKey).not.toEqual(direct.current.queryKey)
+        })
     })
 
     it('isInitialLoad false after a failed first fetch (no perpetual skeleton)', async () => {

--- a/src/modules/systemHierarchy/hooks/queries/useSystemLeaves.ts
+++ b/src/modules/systemHierarchy/hooks/queries/useSystemLeaves.ts
@@ -1,5 +1,5 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 
 import useQueryManager from '@/hooks/useQueryManager'
@@ -9,10 +9,22 @@ import { queryFetcher } from '@/utils/fetcher'
 import type { LeavesResponse } from '../../types'
 import { LEAVES_QUERY_KEY, LEAVES_TABLE_ID } from '../../types/constants'
 
-export const useSystemLeaves = (parentUid: string | null) => {
+/**
+ * @param directOnly Restrict the result to the parent's direct children instead of
+ * every descendant leaf. The server narrows the traversal depth; search, filters,
+ * sorting and pagination keep working on top of the narrowed set.
+ */
+export const useSystemLeaves = (parentUid: string | null, directOnly: boolean = false) => {
     const { query } = useQueryManager(LEAVES_TABLE_ID, undefined, true)
 
-    const queryKey: QueryFetcherKey = [LEAVES_QUERY_KEY, { uid: parentUid, query }]
+    // Only added when enabled — getEndpoints drops null/undefined/'' but would
+    // happily serialise `directOnly=false` and split the cache for no reason.
+    const effectiveQuery = useMemo(
+        () => (directOnly ? { ...query, directOnly: true } : query),
+        [query, directOnly],
+    )
+
+    const queryKey: QueryFetcherKey = [LEAVES_QUERY_KEY, { uid: parentUid, query: effectiveQuery }]
 
     const { data, isFetching, isError, error } = useQuery<
         LeavesResponse,

--- a/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
@@ -44,9 +44,7 @@ export const useHierarchyNavigation = () => {
             const parentChanged = (router.query.parent as string | undefined) !== uid
             const pageReset = parentChanged ? { page: undefined } : {}
             updateQuery(
-                inDetail
-                    ? { parent: uid, leaf: uid, ...pageReset }
-                    : { parent: uid, ...pageReset },
+                inDetail ? { parent: uid, leaf: uid, ...pageReset } : { parent: uid, ...pageReset },
             )
         },
         [queryClient, router, updateQuery],

--- a/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
+++ b/src/modules/systemHierarchy/hooks/useHierarchyNavigation.ts
@@ -14,6 +14,10 @@ export const useHierarchyNavigation = () => {
     const selectedParentUid = (router.query.parent as string) ?? null
     const selectedLeafUid = (router.query.leaf as string) ?? null
     const activeTab = ((router.query.tab as string) ?? HIERARCHY_TABS.DETAIL) as HierarchyTab
+    // Lives in the URL so it survives reload and deep links. Deliberately NOT reset by
+    // selectParent — walking the tree level by level with the mode on is the point,
+    // and ?filter/?search carry over the same way.
+    const directOnly = router.query.direct === '1'
 
     const updateQuery = useCallback(
         (updates: Record<string, string | undefined>, options?: { replace?: boolean }) => {
@@ -72,6 +76,15 @@ export const useHierarchyNavigation = () => {
         [updateQuery],
     )
 
+    // Page reset: the narrowed list is far shorter, so keeping ?page would land the
+    // user past its end (and vice versa when switching back).
+    const setDirectOnly = useCallback(
+        (next: boolean) => {
+            updateQuery({ direct: next ? '1' : undefined, page: undefined })
+        },
+        [updateQuery],
+    )
+
     const goBackToLeaves = useCallback(() => {
         updateQuery({ leaf: undefined, tab: undefined })
     }, [updateQuery])
@@ -85,10 +98,12 @@ export const useHierarchyNavigation = () => {
             selectedParentUid,
             selectedLeafUid,
             activeTab,
+            directOnly,
             selectParent,
             selectLeaf,
             resolveParentForLeaf,
             setActiveTab,
+            setDirectOnly,
             goBackToLeaves,
             clearSelection,
         }),
@@ -96,10 +111,12 @@ export const useHierarchyNavigation = () => {
             selectedParentUid,
             selectedLeafUid,
             activeTab,
+            directOnly,
             selectParent,
             selectLeaf,
             resolveParentForLeaf,
             setActiveTab,
+            setDirectOnly,
             goBackToLeaves,
             clearSelection,
         ],


### PR DESCRIPTION
## Proč

Strom v hierarchii (`/systems/hierarchy`) vrací **jen uzly, které mají potomky**, plus systémy bez rodiče. Koncové systémy v něm nejsou vidět nikdy — to je záměr, jsou v tabulce vedle.

Jenže tabulka (`/system/{uid}/leaves`) vrací **všechny koncové systémy do hloubky 1..50**. Uzel, který má 3 přímé listy a pod sebou podstrom s tisíci listů, ty 3 utopí. Uživatel nemá **žádnou optiku „co visí přímo pod tímhle uzlem"** — strom listy nezobrazuje, tabulka míchá všechny hloubky. Listy na vyšších patrech hierarchie jsou tak prakticky nedohledatelné.

## Co se mění

**Checkbox „Direct only"** vedle search baru v tabulce hierarchie. Zúží seznam na koncové systémy visící přímo pod vybraným uzlem.

Není to druhá datová cesta — `useSystemLeaves` jen přidá `directOnly: true` do query, kterou už staví `useQueryManager`. Filtry, search, řazení i stránkování proto fungují dál a **skládají se** s režimem. Backend: eli-eric/eli-panda-api#430.

**Tečka u uzlů stromu**, které mají přímé koncové systémy. API `hasLeafChildren` vrací už dneska, frontend ho ignoroval. Bez ní uživatel nemá jak poznat, u kterého uzlu má checkbox zaškrtnout — a discoverability je jádro celého problému.

## Rozhodnutí, která stojí za zmínku

- **Stav v URL (`?direct=1`)**, ne ve store — přežije reload i deep-link. `setDirectOnly` resetuje `?page`, protože zúžený seznam je kratší a stará stránka by byla za koncem.
- **Režim se drží přes přepnutí uzlu.** Konzistentní se `selectParent`, který resetuje jen `page` a `?filter`/`?search` přenáší. Procházet strom patro po patru se zapnutým režimem je cílový workflow.
- **Badge u uzlu ve stromu zůstává celkový.** Je to vlastnost uzlu, ne pohledu — a `useSystemLeavesCount` běží per vykreslený uzel, takže vazba na režim by při každém přepnutí vystřelila jeden request na každý uzel.
- **Tečka je jen indikátor, neklikací.** Malý cíl s jiným chováním než zbytek řádku, který sám reaguje na klik, by se trefoval omylem.
- **Checkbox není nikdy disabled.** Disablovat podle cachovaného `hasLeafChildren` by při změně z jiné session zamklo prvek bez vysvětlení; prázdný stav s tlačítkem „Show all levels" řekne totéž, ale až po skutečném dotazu.

## Zvažováno a zamítnuto

**`/system/{uid}/subsystems`** (endpoint přímých dětí, který už existuje) — neumí žádné parametry: holé pole, `LIMIT 1000`, žádný search/filter/sort/stránkování. Vedlo by to na druhou datovou cestu, klientské řazení, skrývání stránkování a na kompromis „checkbox a filtry se vylučují". Param na `/leaves` je proti tomu ~6 řádků cypheru.

**Column filter místo query paramu** — je to rozsah, ne filtr, má se s filtry skládat. Navíc by mizel při psaní do search (`useFormFilters.ts:106` čistí filtry při změně search).

**`custom` bag v `useTableStateStore`** — funguje, ale je to store navíc plus efekt URL→store, který při deep-linku způsobí jeden fetch bez parametru.

## Nasazení

FE nečeká na API. Dokud není eli-panda-api#430 venku, backend parametr ignoruje a checkbox vrací plný seznam — funkce je do té doby neúčinná, ne rozbitá.

## Ověření

`yarn test src/modules/systemHierarchy` → 84 suites / 557 testů zelených. `yarn lint` → 235 warnings, 0 errors (shodné s baseline před změnami).

Nové testy: `directOnly` v query key právě když je zapnuto a klíče obou režimů se liší (cache se nemíchá); `?direct` se čte i zapisuje, resetuje `page`, ale přežije `selectParent` a nesahá na filtry ani search; checkbox reflektuje propu, hlásí toggle a není disabled; tečka ve stromu podle `hasLeafChildren` a badge se nemění.

Součástí je i drobná ruční úprava od @jansmrcka — `outline` varianta tlačítka zpět v detailu.