### PR TITLE
fix(deploy): copy the lockfile into every runner stage, not just production

### DIFF
--- a/Dockerfile.azure-dev
+++ b/Dockerfile.azure-dev
@@ -84,8 +84,18 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Install sharp in the production image with the correct platform binaries
+# Install sharp in the production image with the correct platform binaries.
+#
+# The lockfile must come along. `yarn add` in a directory that has package.json but
+# no yarn.lock re-resolves the WHOLE dependency tree from the registry, and it writes
+# into /app/node_modules — the very directory the standalone output above put its
+# traced, build-pinned modules in. That is how a range like "next": "^16.3.0" ended up
+# installing a newer minor at runtime than the one `yarn build` compiled against, and
+# the standalone server.js carries a config serialized by the build: any field the
+# newer runtime expects but the older build never emitted reads as undefined and
+# crashes on boot (next 16.3.0 vs 16.2.9 → experimental.instantInsights.validationLevel).
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
 RUN yarn add sharp --ignore-scripts --prefer-offline
 
 USER nextjs

--- a/Dockerfile.devenv
+++ b/Dockerfile.devenv
@@ -73,8 +73,18 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Install sharp in the production image with the correct platform binaries
+# Install sharp in the production image with the correct platform binaries.
+#
+# The lockfile must come along. `yarn add` in a directory that has package.json but
+# no yarn.lock re-resolves the WHOLE dependency tree from the registry, and it writes
+# into /app/node_modules — the very directory the standalone output above put its
+# traced, build-pinned modules in. That is how a range like "next": "^16.3.0" ended up
+# installing a newer minor at runtime than the one `yarn build` compiled against, and
+# the standalone server.js carries a config serialized by the build: any field the
+# newer runtime expects but the older build never emitted reads as undefined and
+# crashes on boot (next 16.3.0 vs 16.2.9 → experimental.instantInsights.validationLevel).
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
 RUN yarn add sharp --ignore-scripts --prefer-offline
 
 USER nextjs

--- a/Dockerfile.devenv.czolap04
+++ b/Dockerfile.devenv.czolap04
@@ -73,8 +73,18 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Install sharp in the production image with the correct platform binaries
+# Install sharp in the production image with the correct platform binaries.
+#
+# The lockfile must come along. `yarn add` in a directory that has package.json but
+# no yarn.lock re-resolves the WHOLE dependency tree from the registry, and it writes
+# into /app/node_modules — the very directory the standalone output above put its
+# traced, build-pinned modules in. That is how a range like "next": "^16.3.0" ended up
+# installing a newer minor at runtime than the one `yarn build` compiled against, and
+# the standalone server.js carries a config serialized by the build: any field the
+# newer runtime expects but the older build never emitted reads as undefined and
+# crashes on boot (next 16.3.0 vs 16.2.9 → experimental.instantInsights.validationLevel).
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
 RUN yarn add sharp --ignore-scripts --prefer-offline
 
 USER nextjs

--- a/Dockerfile.testenv
+++ b/Dockerfile.testenv
@@ -74,8 +74,18 @@ COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
-# Install sharp in the production image with the correct platform binaries
+# Install sharp in the production image with the correct platform binaries.
+#
+# The lockfile must come along. `yarn add` in a directory that has package.json but
+# no yarn.lock re-resolves the WHOLE dependency tree from the registry, and it writes
+# into /app/node_modules — the very directory the standalone output above put its
+# traced, build-pinned modules in. That is how a range like "next": "^16.3.0" ended up
+# installing a newer minor at runtime than the one `yarn build` compiled against, and
+# the standalone server.js carries a config serialized by the build: any field the
+# newer runtime expects but the older build never emitted reads as undefined and
+# crashes on boot (next 16.3.0 vs 16.2.9 → experimental.instantInsights.validationLevel).
 COPY --from=builder /app/package.json ./package.json
+COPY --from=builder /app/yarn.lock ./yarn.lock
 RUN yarn add sharp --ignore-scripts --prefer-offline
 
 USER nextjs


### PR DESCRIPTION
Follow-up to #1144. That PR fixed `Dockerfile`, but **dev does not build from `Dockerfile`**.

## The gap

| Environment | Dockerfile | Fixed by #1144? |
|---|---|---|
| production | `Dockerfile` | ✅ |
| dev | `Dockerfile.devenv` | ❌ |
| test | `Dockerfile.testenv` | ❌ |
| dev (czolap04) | `Dockerfile.devenv.czolap04` | ❌ |
| azure dev | `Dockerfile.azure-dev` | ❌ |
| e2e | `Dockerfile.e2e` | n/a — no runtime install |

All four missing ones carry the identical runner-stage block: `COPY package.json` (no lockfile) followed by `yarn add sharp`, which re-resolves the whole dependency tree into the standalone output's `node_modules`.

## Why dev came back up anyway

Not because of the Dockerfile change — `Dockerfile.devenv` was untouched. What unblocked it was the version bump in #1144: with `package.json` at `^16.3.0` and 16.3.0 currently the newest matching release, the unlocked re-resolution happens to land on exactly the version `yarn build` used. Build and runtime agree by coincidence, not by construction.

That coincidence ends the day Next publishes **16.3.1**: the runner installs 16.3.1 while the lockfile keeps the build at 16.3.0. Whether that crashes depends on whether the patch reads a config field the older build never emitted — which is precisely the roll of the dice that produced the 502.

Production has not broken yet only because it has not been deployed since 16.3.0 was published. Its next deploy has the same exposure.

## Change

One line per file, before the sharp install:

```dockerfile
COPY --from=builder /app/yarn.lock ./yarn.lock
```

plus the explanatory comment already in `Dockerfile`, so all five read identically. No behavioral change beyond making resolution deterministic.

## Verification

- `docker build --check` passes on all five (the remaining warnings — `SecretsUsedInArgOrEnv` and friends — are pre-existing).
- Confirmed the builder stage has `COPY . .` in every file, so `/app/yarn.lock` exists to copy from.
- **Behavioural proof**, reproducing the runner stage locally with `package.json` + `yarn.lock`:

  ```
  $ NODE_ENV=production yarn add sharp --ignore-scripts --prefer-offline
  info All dependencies
  └─ sharp@0.35.3
  $ node -p "require('./node_modules/next/package.json').version"
  16.3.0        # the locked version, left alone
  ```

  With the lockfile present yarn installs sharp and nothing else. Without it, `^16.2.5` resolved to 16.3.0 — the original incident.

- `yarn test` → 715 suites / 3584 tests pass.

  One note: the first pre-push run reported `1 failed, 3583 passed` and a clean re-run passed all 3584. This branch only touches Dockerfiles, so it is a flaky test rather than a regression. I could not capture which one — worth watching, and I'd rather flag it than let it pass unmentioned.

## Still open

`yarn add sharp` in the runner remains a heavy way to obtain one native module: it reconciles the entire tree against the manifest on every image build, in five places. Both stages are `node:22-alpine`, so sharp installed in `deps` would already have the right binaries — moving it into `dependencies` and dropping the runtime install would delete this whole class of bug. Deliberately not doing that here; this PR is the low-risk containment.